### PR TITLE
AIR-669: Fix link and icon events firing at the same time

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.html
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.html
@@ -3,8 +3,8 @@
         <img [class.disablePointerEvents]="reorderMode" [attr.src]="_assets.makeThumbUrl(thumbnail.thumbnailImgUrl, 1)" [attr.alt]="thumbnail.thumbnail1 ? 'Thumbnail of ' + thumbnail.thumbnail1 : 'No title available'">
     </div>
     <div class="card-icon-group" (click)="$event.stopPropagation(); $event.preventDefault();" [ngClass]="{ 'disablePointerEvents': editMode }" >
-        <i *ngIf="thumbnail.cfObjectId && thumbnail.cfObjectId.length > 0" [id]="thumbnail.objectId + '_associated_images'" class="icon icon-collab" [routerLink]="['/associated', thumbnail.cfObjectId, thumbnail.collectionId]" title="Others are also interested in..."></i>
-        <i *ngIf="thumbnail.clustered == 1" [id]="thumbnail.objectId + '_clustered_images'" class="icon icon-cluster" [routerLink]="['/cluster', thumbnail.objectId, { objTitle :  thumbnail.thumbnail1 }]" title="View related media"></i>
+        <i *ngIf="thumbnail.cfObjectId && thumbnail.cfObjectId.length > 0" [id]="thumbnail.objectId + '_associated_images'" class="icon icon-collab" (click)="openLink($event,['/associated', thumbnail.cfObjectId, thumbnail.collectionId])" title="Others are also interested in..."></i>
+        <i *ngIf="thumbnail.clustered == 1" [id]="thumbnail.objectId + '_clustered_images'" class="icon icon-cluster" (click)="openLink($event,['/cluster', thumbnail.objectId, { objTitle :  thumbnail.thumbnail1 }])" title="View related media"></i>
         <i *ngIf="thumbnail.objectTypeId && thumbnail.objectTypeId != 10" class="icon icon-{{thumbnail.objectTypeId | typeIdPipe}}"></i>
         <i class="icon icon-{{collectionTypeMap[thumbnail.collectionType] && collectionTypeMap[thumbnail.collectionType].name}} icon-collection-type" [attr.title]="collectionTypeMap[thumbnail.collectionType] && collectionTypeMap[thumbnail.collectionType].alt"></i>
     </div>

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -1,3 +1,4 @@
+import { Router } from '@angular/router';
 import { Component, OnInit, Input } from '@angular/core';
 
 import { Thumbnail } from './../../shared'
@@ -35,10 +36,19 @@ export class ThumbnailComponent implements OnInit {
   }
 
   constructor(
-    private _assets: AssetService
+    private _assets: AssetService,
+    private router: Router
   ) {
    }
 
   ngOnInit() { 
+  }
+
+  openLink(event: Event, urlParams: any[]) {
+    // Prevent the parent anchor tag from firing
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.router.navigate(urlParams)
   }
 }


### PR DESCRIPTION
- Cluster and Associated icons should open their appropriate pages