### PR TITLE
fix for non-search asset selection

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -334,20 +334,15 @@ export class AssetGrid implements OnInit, OnDestroy {
    * @param asset object to be selected / deselected
    */
   private selectAsset(asset: any): void{
-    console.log('asset', asset)
     if(this.editMode){
-      console.log('in edit mode')
       let index: number = this.isSelectedAsset(asset);
-      console.log('index', index)
       if(index > -1){
         this.selectedAssets.splice(index, 1);
-        console.log(this.selectedAssets)
         this._assets.setSelectedAssets(this.selectedAssets);
       }
       else{
         this.selectedAssets.push(asset);
         this._assets.setSelectedAssets(this.selectedAssets);
-        console.log(this.selectedAssets)
       }
     }
     else{


### PR DESCRIPTION
Just added a check at the beginning of `isSelectedAsset` in order to determine whether to use `objectId` or `artstorid`

Note: if you log something within `isSelectedAsset`, you can see that the function is being run many times. I think it might be used in the template, which was causing some lag in selecting assets, because for every template binding it will be looping through the entire assets array and evaluating things every time. I tried to provide a short optimization here, but I'll add a SAD story too