### PR TITLE
Apply institution filter for Sahara

### DIFF
--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -127,10 +127,8 @@ export class AssetSearchService {
      * - WLVs filter by contributing institution id
      */
     let institutionFilters: number[] = this._app.getWLVConfig().contributingInstFilters
-    if (institutionFilters) {
-      for (let i = 0; i < institutionFilters.length; i++) {
-        filterArray.push("contributinginstitutionid:" + institutionFilters[i])
-      }
+    for (let i = 0; i < institutionFilters.length; i++) {
+      filterArray.push("contributinginstitutionid:" + institutionFilters[i])
     }
 
     let pageSize = urlParams.size

--- a/src/app/white-label-config.ts
+++ b/src/app/white-label-config.ts
@@ -8,6 +8,7 @@
 export const WLV_ARTSTOR = {
     pageTitle: "Artstor",
     logoUrl: "/assets/img/logo-v1-1.png",
+    "contributingInstFilters" : [],
     footerLinks: [
         "ABOUT",
         "GETTING_STARTED",


### PR DESCRIPTION
Please double check:
- You can only see Sahara content as lib@artstor.org
- You can still see ADL collections as air01@artstor.org