### PR TITLE
AIR 1059 Advanced Search not returning all results

### DIFF
--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -118,7 +118,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       }
       else if(routeParams['term']){
         let updatedTermValue = '';
-        updatedTermValue = ':"' + routeParams['term'] + '" AND :"' + term + '"';
+        updatedTermValue = routeParams['term'] + ' AND ' + term;
         term = updatedTermValue;
 
         if(routeParams['classification']){


### PR DESCRIPTION
Terms being passed as this now:
artcreator:(Oskar Kokoschka) AND cardinal

additional queries being passed as:
artcreator:(Oskar Kokoschka) AND artworktype:(painting)

Based off solution discussed in the issue comments