### PR TITLE
AIR-1031 - removed institutional/open collection filter for search facets

### DIFF
--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -237,11 +237,6 @@ export class AssetSearchService {
       } else {
         for (let j = 0; j < filters[i].filterValue.length; j++) {
           filterArray.push(filters[i].filterGroup + ':\"' + filters[i].filterValue[j] + '\"')
-
-          if (filters[i].filterGroup == 'collectiontypes' && filters[i].filterValue[j] == 2) {
-            // Institutional filter should eliminate open assets
-            filterArray.push("-collectiontypes:5")
-          }
         }
       }
     }


### PR DESCRIPTION
there's no way to selectively exclude assets from a search facet in a list. need to not exclude open collection assets from institutional assets when filtering