### PR TITLE
Attach pcEnabled to user observable

### DIFF
--- a/src/app/browse-page/browse-page.component.ts
+++ b/src/app/browse-page/browse-page.component.ts
@@ -47,7 +47,6 @@ export class BrowsePage implements OnInit, OnDestroy {
       this._storage = locker.useDriver(Locker.DRIVERS.LOCAL);
       this.institution = this._storage.get('institution');
       this.browseOpts = this._app.config.browseOptions;
-      this.pcEnabled = this._auth.getpcEnabled();
   }
 
   ngOnInit() {
@@ -61,7 +60,15 @@ export class BrowsePage implements OnInit, OnDestroy {
       })
     );
 
-
+    // Subscribe to User object updates
+    this.subscriptions.push(
+      this._auth.currentUser.subscribe(
+        (userObj) => {
+          this.pcEnabled = userObj.pcEnabled
+        },
+        (err) => { console.error(err) }
+      )
+    )
 
     if( this.browseOpts.artstorCol ){
         this.colMenuArray.push( { label: 'Artstor Digital Library', id: '1', link: 'library' } );

--- a/src/app/browse-page/my-collections.component.ts
+++ b/src/app/browse-page/my-collections.component.ts
@@ -29,7 +29,7 @@ export class MyCollectionsComponent implements OnInit {
     private _analytics: AnalyticsService,
     private _title: TitleService
   ) { 
-    this.pcEnabled = this._auth.getpcEnabled();
+      
    }
 
   private subscriptions: Subscription[] = [];
@@ -76,7 +76,17 @@ export class MyCollectionsComponent implements OnInit {
         }
 
       })
-    );
+    )
+
+    // Subscribe to User object updates
+    this.subscriptions.push(
+      this._auth.currentUser.subscribe(
+        (userObj) => {
+          this.pcEnabled = userObj.pcEnabled
+        },
+        (err) => { console.error(err) }
+      )
+    )
 
     if(this.pcEnabled){ // If user has personal collections get data for user's personal collections
       this.getUserPCol();

--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -77,11 +77,20 @@ export class NavMenu implements OnInit, OnDestroy {
     private _analytics: AnalyticsService
   ) {
     this.browseOpts = this._app.config.browseOptions
-    this.pcEnabled = this._auth.getpcEnabled()
   }
 
   ngOnInit() {
-    this.user = this._auth.getUser()
+    // Subscribe to User object updates
+    this.subscriptions.push(
+      this._auth.currentUser.subscribe(
+        (userObj) => {
+          this.user = userObj
+          this.pcEnabled = this.user.pcEnabled
+        },
+        (err) => { console.error(err) }
+      )
+    );
+    
     this.subscriptions.push(
       this._assets.selection.subscribe(
         selectedAssets => {

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -388,7 +388,11 @@ export class AuthService implements CanActivate {
    * @param user The user should be an object to store in sessionstorage
    */
   public saveUser(user: any) {
-    //should have session timeout, username, baseProfileId, typeId
+    // Preserve added pcEnabled, determined by _assets.pccollection() call
+    if (user.isLoggedIn && this.getUser().pcEnabled) {
+      user.pcEnabled = true
+    }
+    // Should have session timeout, username, baseProfileId, typeId
     this._storage.set('user', user);
     // Update observable
     this.userSource.next(user)
@@ -404,19 +408,14 @@ export class AuthService implements CanActivate {
   public getUser() : any {
       return this._storage.get('user') ? this._storage.get('user') : {};
   }
-  
-  /**
-   * Gets pcEnabled from local storage
-   */
-  public getpcEnabled(): boolean {
-      return this._storage.get('pcEnabled') ? this._storage.get('pcEnabled') : false;
-  }
 
   /**
    * Sets pcEnabled in local storage
    */
   public setpcEnabled(pcEnabled: boolean): void {
-    this._storage.set('pcEnabled', pcEnabled);
+    let user = this.getUser()
+    user.pcEnabled = pcEnabled
+    this.saveUser(user)
   }
 
   /** Stores an object in local storage for you - your welcome */


### PR DESCRIPTION
air01 and shshtestuser@artstor.org / artstor1 should see their Personal Collections, and air02 should not be able to browse to the page (even after a hard refresh)