### PR TITLE
Air 601 - Making collection field hyperlink on asset page.

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -93,7 +93,7 @@
         .meta-block(*ngFor="let metadataObj of assets[0].formattedMetaArray")
           .label([attr.id]="cleanId(metadataObj.fieldName)") {{ metadataObj.fieldName }}
           div(*ngFor="let value of metadataObj.fieldValue")
-            .value([innerHTML]="cleanFieldValue(value, metadataObj.fieldName) | linkify")
+            .value([innerHTML]="formatFieldValue(value, metadataObj.fieldName) | linkify")
         .row-hdr.pt-1(*ngIf="assets[0].filePropertiesArray.length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.FILE_PROPS' | translate}}
         //- Loop through File Properties Array
         .meta-block(*ngFor="let filePropObj of assets[0].filePropertiesArray")

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -330,12 +330,13 @@ export class AssetPage implements OnInit, OnDestroy {
     /**
      * Some html tags are ruining things:
      * - <wbr> word break opportunities break our link detection
+     * - Apply collection links
      */
-    private cleanFieldValue(value: string, field: string): string {
+    private formatFieldValue(value: string, field: string): string {
         if (typeof(value) == 'string') {
             let resValue = value.replace(/\<wbr\>/g, '').replace(/\<wbr\/\>/g, '')
             // Make collection field a hyperlink to the collection page itself
-            if(field === 'Collection'){
+            if(field === 'Collection' && value.indexOf('http') < 0){
                 resValue = '<a href="/#/search/artcollectiontitle:' + resValue + '">' + resValue + '</a>'
             }
             return resValue


### PR DESCRIPTION
Pushing changes for AIR-601.

Note: As per discussion with Cody, Until Earth adds category ids for ADL images, we are gonna route the collection hyperlink on asset page, to search page and search on 'artcollectiontitle'. This is the closest we can get until we have changes from Earth!