### PR TITLE
Fallback to smaller thumbnail sizes

### DIFF
--- a/src/app/asset-page/asset-viewer/asset-viewer.component.pug
+++ b/src/app/asset-page/asset-viewer/asset-viewer.component.pug
@@ -14,7 +14,7 @@
       | {{ 'audio_error' }}
   // Large thumbnail fallback
   #fallbackViewer(*ngIf="mediaLoadingFailed")
-    img.item.item--thumbnail(alt="{{ asset.title }}", [attr.src]="_assets.makeThumbUrl(asset.imgURL, 2)")
+    img.item.item--thumbnail(alt="{{ asset.title }}", [attr.src]="_assets.makeThumbUrl(asset.imgURL, thumbnailSize)", (error)="thumbnailError($event)")
   .button-group.asset-viewer__buttons(id="imageButtons-{{ asset.id + '-' + index }}")
     button.btn.btn--icon([class.hidden]="!isOpenSeaDragonAsset || mediaLoadingFailed", id="zoomIn-{{ asset.id + '-' + index}}", title="Zoom In")
       i.icon.icon-zoom-in

--- a/src/app/asset-page/asset-viewer/asset-viewer.component.ts
+++ b/src/app/asset-page/asset-viewer/asset-viewer.component.ts
@@ -55,6 +55,8 @@ export class AssetViewerComponent implements OnInit, OnDestroy, AfterViewInit {
     private fallbackFailed: boolean = false
     private tileSource: string
     private lastZoomValue: number
+    // Thumbanil Size is decremented if load fails (see thumbnailError)
+    private thumbnailSize: number = 2
     // private showCaption: boolean = true
 
     private kalturaUrl: string
@@ -352,6 +354,15 @@ export class AssetViewerComponent implements OnInit, OnDestroy, AfterViewInit {
      */
     private disableContextMenu(event): boolean{
         return false;
+    }
+
+    /**
+     * When thumbnail fails to load, try to load a different size
+     * - Decrements the thumbnail size
+     * - Workaround for missing sizes of particular thumbnails
+     */
+    private thumbnailError(event) : void {
+        this.thumbnailSize--
     }
 
 }


### PR DESCRIPTION
To test:
- Block the IIIF requests (tsstage.artstor.... just right click the 'info.json' call in the network plan, and "block" in Chrome)
- Open this asset: /asset/AIC_990026
- It's fallback thumbnail was not loading before