### PR TITLE
AIR-1178 : Create tag on ‘Enter Press’!

### DIFF
--- a/src/app/modals/new-ig-modal/new-ig-modal.component.pug
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.pug
@@ -39,6 +39,8 @@
               [formControl]="newIgForm.controls['tags']",
               placeholder="Add a tag...",
               [addOnBlur]="true",
+              [addOnEnter]="true",
+              [autocompleteSelectFirstItem]="false",
               [autocomplete]="true",
               [autocompleteItems]="tagSuggestions",
               [autocompleteMustMatch]="false",


### PR DESCRIPTION
1. Select/Create a tag suggestion on 'Enter' press only once its highlighted.
2. By default, the first tag suggestion should not be highlighted. 
3. If no tag suggestion is highlighted, on 'Enter' press, create a tag with the text in tag input field.