### PR TITLE
AIR-1190

### DIFF
--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -116,7 +116,7 @@ export class NewIgModal implements OnInit {
   private tagDebouncing: boolean = false
 
   private getTagSuggestions(event: any) : void  {
-    this.tagSuggestTerm = event.srcElement.value
+    this.tagSuggestTerm = event.target.value
 
     if (!this.tagDebouncing) {
       this.tagDebouncing = true


### PR DESCRIPTION
- Using ‘event.target’ instead of ‘event.srcElement’ to support Firefox. 'event.target' is supported in  Chrome, firefox & safari.