### PR TITLE
AIR-1213

### DIFF
--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -228,10 +228,8 @@ export class AssetSearchService {
         }
       } else {
         for (let j = 0; j < filters[i].filterValue.length; j++) {
-          let filterValueArray = filters[i].filterValue[j].toString().trim().split(',')
-          for(let filter of filterValueArray){ // Push each filter value seperately in the filterArray (for multiple filter selection within the same filterGroup)
-            filterArray.push(filters[i].filterGroup + ':\"' + filter + '\"')
-          }
+          let filterValue = filters[i].filterValue[j]
+          filterArray.push(filters[i].filterGroup + ':\"' + filterValue + '\"')
         }
       }
     }


### PR DESCRIPTION
Pushed a fix for AIR-1213.

- No need to split filterValue on ‘,’ - causes no results in search. Multiple filter values (from the same filter group) are pushed individually to the applied filters array.