### PR TITLE
AIR-1257 (Inst. and Public Collections Not Clearing Previously Applied Filters)

### DIFF
--- a/src/app/browse-page/browse-page.component.ts
+++ b/src/app/browse-page/browse-page.component.ts
@@ -6,6 +6,7 @@ import { Locker } from 'angular2-locker';
 import { TitleService } from '../shared/title.service';
 import { AssetService } from '../shared/assets.service';
 import { AuthService } from '../shared/auth.service';
+import { AssetFiltersService } from '../asset-filters/asset-filters.service';
 
 import { AppConfig } from '../app.service';
 
@@ -42,7 +43,8 @@ export class BrowsePage implements OnInit, OnDestroy {
       private _app: AppConfig,
       private route: ActivatedRoute,
       private router: Router,
-      private _title: TitleService
+      private _title: TitleService,
+      private _filters: AssetFiltersService
   ) {
       this._storage = locker.useDriver(Locker.DRIVERS.LOCAL);
       this.institution = this._storage.get('institution');
@@ -52,6 +54,9 @@ export class BrowsePage implements OnInit, OnDestroy {
   ngOnInit() {
     // Set page title
     this._title.setSubtitle("Browse")
+
+    // Clear previously applied filters on search
+    this._filters.clearApplied()
 
     this.subscriptions.push(
       this.route.firstChild.url


### PR DESCRIPTION
Clear previously applied filters while initializing browse page, so that the filters are not applied to search calls once you land on the collection pages from the browse page!