### PR TITLE
AIR-1273

### DIFF
--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -18,7 +18,7 @@ export class AssetSearchService {
   showCollectionType: boolean = false
 
    public filterFields: { name: string, value: string }[] = [
-    {name: "In any field", value: "*"},
+    {name: "In any field", value: ""},
     {name: "Creator", value: "artcreator" },
     {name: "Title", value: "arttitle" },
     {name: "Location", value: "artlocation" },


### PR DESCRIPTION
Cleaning the advance search query to remove preceding ‘*’ and ‘:’ if searching ‘In Any Field’.