### PR TITLE
pcEnabled preserved in more robust fashion

### DIFF
--- a/src/app/browse-page/my-collections.component.ts
+++ b/src/app/browse-page/my-collections.component.ts
@@ -79,7 +79,7 @@ export class MyCollectionsComponent implements OnInit {
     this.subscriptions.push(
       this._auth.currentUser.subscribe(
         (userObj) => {
-          this.pcEnabled = userObj.pcEnabled
+            this.pcEnabled = userObj.pcEnabled
         },
         (err) => { console.error(err) }
       )

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -397,7 +397,9 @@ export class AuthService implements CanActivate {
    */
   public saveUser(user: any) {
     // Preserve added pcEnabled, determined by _assets.pccollection() call
-    if (user.isLoggedIn && this.getUser().pcEnabled) {
+    //  since pcEnabled needs its own call, we're preserving it in local storage
+    let pcEnabled: boolean = this._storage.get('pcEnabled')
+    if (user.isLoggedIn && pcEnabled == true) {
       user.pcEnabled = true
     }
     // Should have session timeout, username, baseProfileId, typeId
@@ -427,9 +429,7 @@ export class AuthService implements CanActivate {
    * Sets pcEnabled in local storage
    */
   public setpcEnabled(pcEnabled: boolean): void {
-    let user = this.getUser()
-    user.pcEnabled = pcEnabled
-    this.saveUser(user)
+    this._storage.set('pcEnabled', pcEnabled)
   }
 
   /** Stores an object in local storage for you - your welcome */


### PR DESCRIPTION
`pcEnabled` used to be saved directly on the user object, but occasionally there's a /userinfo call that comes back as an empty object and resets the user, which overwrites the `pcEnabled` property (and the call to /api/pccollection is not re-made to reset the property). By saving it in local storage by itself, it will be preserved until the user logs out, and we'll reset it on the local user object every time we execute `saveUser()`