### PR TITLE
handle Download View in FF and Safari to also work with the Agree Modal

### DIFF
--- a/src/app/asset-page/agree-modal/agree-modal.component.pug
+++ b/src/app/asset-page/agree-modal/agree-modal.component.pug
@@ -14,4 +14,4 @@
           a.link(href="http://support.artstor.org/?article=embedded-metadata", name="Embedded metadata viewing help", target="_blank") click here.
       .modal-footer
         button.btn.btn-secondary(type="button", (click)="closeModal.emit()") I reject
-        a.btn.btn-primary((click)="agree()", [href]="assetUrl", download target="_blank") I accept
+        a.btn.btn-primary((click)="agree()", [href]="assetUrl", [download]="downloadName", target="_self") I accept

--- a/src/app/asset-page/agree-modal/agree-modal.component.ts
+++ b/src/app/asset-page/agree-modal/agree-modal.component.ts
@@ -9,6 +9,7 @@ import { Asset } from './../asset';
   styleUrls: [ './agree-modal.component.scss' ]
 })
 export class AgreeModalComponent implements OnInit {
+
   /** Causes modal to be hidden */
   @Output()
   closeModal = new EventEmitter();
@@ -17,6 +18,9 @@ export class AgreeModalComponent implements OnInit {
   downloadAsset = new EventEmitter();
   @Input()
   assetUrl: string;
+  /** The value of the download attribute for Download View **/
+  @Input()
+  downloadName : string;
 
   constructor(private _auth: AuthService) { }
 
@@ -26,7 +30,7 @@ export class AgreeModalComponent implements OnInit {
    * Authorizes download and closes modal
    */
   private agree(): void {
-    this._auth.authorizeDownload();
-    this.closeModal.emit();
+    this._auth.authorizeDownload()
+    this.closeModal.emit()
   }
 }

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -214,7 +214,7 @@
         ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{'selected' : asset.selected || (assets[0].id == asset[assetIdProperty]), 'disabled': (asset.selected && assets.length === 1) }", (click)="toggleAsset(asset)")
         .text-center.pt-2
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
-ang-agree-modal(*ngIf="showAgreeModal", (closeModal)="showAgreeModal = false", [assetUrl]="downloadUrl")
+ang-agree-modal(*ngIf="showAgreeModal", (closeModal)="showAgreeModal = false", [assetUrl]="downloadUrl", [downloadName]="downloadName")
 ang-login-req-modal(*ngIf="showLoginModal", (closeModal)="showLoginModal = false")
 ang-add-to-group(*ngIf="showAddModal", [selectedAssets]="[ assets[0] ]", [showCreateGroup]="true", [copySelectionStr]=" 'ADD_TO_GROUP_MODAL.FROM_ASSET' ", (createGroup)="showCreateGroupModal = true; showAddModal = false;", (closeModal)="showAddModal = false")
 ang-new-ig-modal(*ngIf="showCreateGroupModal", [selectedAssets]="[ assets[0] ]", [showAddToGroup]="true", (addToGroup)="showAddModal = true; showCreateGroupModal = false;", (closeModal)="showCreateGroupModal = false")

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -69,6 +69,7 @@ export class AssetPage implements OnInit, OnDestroy {
     private generatedFullURL: string = ''
     // Used for agree modal input, changes based on selection
     private downloadUrl: any
+    private downloadName: string
     // Used for generated view blob url
     private blobURL: string = '' 
     private prevRouteParams: any = []
@@ -643,8 +644,10 @@ export class AssetPage implements OnInit, OnDestroy {
         }
     }
 
-    private genDownloadViewLink() : void {
-
+    /** Calls downloadViewBlob in AssetSearch service to retrieve blob file,
+        and then sets generatedViewUrl to this local reference. **/
+        
+    private genDownloadViewLink() :  void {
         let asset = this.assets[0]
 
         // Revoke the browser reference to a previously generated view download blob URL
@@ -736,6 +739,7 @@ export class AssetPage implements OnInit, OnDestroy {
     setDownloadImage() : void {
         this.downloadUrl = this.generatedFullURL;
         this.showAgreeModal = true;
+        this.downloadName = 'download'
     }
 
     /**
@@ -744,9 +748,8 @@ export class AssetPage implements OnInit, OnDestroy {
      */
     setDownloadView() : void {
         this.downloadUrl = this.generatedViewURL;
-        this.showAgreeModal = true;
-
-
+        this.showAgreeModal = true
+        this.downloadName = 'download.jpg'
     }
 
     trackDownloadImage() : void {

--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -52,9 +52,6 @@ export class AssetSearchService {
     return this.http.get(url, { 
         responseType: 'blob'
     })
-    .map(blob => {
-        return blob
-    })
   }
 
   /**


### PR DESCRIPTION
This corrects failing QA tests for AIR-1380. Previous PR #341 did not handle downloading a view
when users had not agreed to terms and conditions yet. The 'Accept' button on the Agree Modal now links correctly to the generated view url.