### PR TITLE
Query search for cluster, rename param "clusterid"

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -43,7 +43,7 @@ export const ROUTES: Routes = [
   { path: 'category', component: CategoryPage, canActivate:[AuthService] },
   { path: 'group/:igId', component: ImageGroupPage, canActivate:[AuthService] },
   { path: 'group', component: ImageGroupPage, canActivate:[AuthService] },
-  { path: 'cluster/:objectId', component: ClusterPage, canActivate:[AuthService] },
+  { path: 'cluster/:clusterId', component: ClusterPage, canActivate:[AuthService] },
   { path: 'cluster', component: ClusterPage, canActivate:[AuthService] },
   { path: 'browse', component: BrowsePage, canActivate:[AuthService], children: BrowseRoutes },
   { path: 'associated/:objectId/:colId', component: AssociatedPage, canActivate:[AuthService] },

--- a/src/app/cluster-page/cluster-page.component.ts
+++ b/src/app/cluster-page/cluster-page.component.ts
@@ -16,7 +16,7 @@ export class ClusterPage implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
   // Cluster Asset Title
   private clusterObjTitle: string;
-  private objectId: string;
+  private clusterId: string;
 
   // TypeScript public modifiers
   constructor(
@@ -30,13 +30,13 @@ export class ClusterPage implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.route.params
         .subscribe((routeParams: Params) => {
-          this.objectId = routeParams["objectId"];
+          this.clusterId = routeParams["clusterId"];
           let params = Object.assign({}, routeParams);
           // If a page number isn't set, reset to page 1!
           if (!params['page']){
             params['page'] = 1;
           }
-          if (this.objectId) {
+          if (this.clusterId) {
             this._assets.queryAll(params);
           }
           if(routeParams['objTitle']) {
@@ -44,7 +44,7 @@ export class ClusterPage implements OnInit, OnDestroy {
           }
         })
     );
-    this._analytics.setPageValues('cluster', this.objectId)
+    this._analytics.setPageValues('cluster', this.clusterId)
   } // OnInit
 
   ngOnDestroy() {

--- a/src/app/shared/assets.service.ts
+++ b/src/app/shared/assets.service.ts
@@ -407,12 +407,18 @@ export class AssetService {
                 if (params.hasOwnProperty("objectId") && params["objectId"] !== "" && params.hasOwnProperty("colId") && params["colId"] !== "") {
                     //gets associated images thumbnails
                     this.loadAssociatedAssets(params.objectId, params.colId);
+                    /**
+                     * Future solr implementation
+                     * searchTerm = "frequentlygroupedwith:(" + params["objectId"] + ")"
+                     * this.loadSearch(searchTerm)
+                     */
                 } else if (params.hasOwnProperty("igId") && params["igId"] !== "") {
-                    //get image group thumbnails
+                    // Load IG via Groups service
                     this.loadIgAssets(params.igId);
-                } else if (params.hasOwnProperty("objectId") && params["objectId"] !== "") {
-                    //get clustered images thumbnails
-                    this.loadCluster(params.objectId);
+                } else if (params.hasOwnProperty("clusterId") && params["clusterId"] !== "") {
+                    // Filter by clusterid
+                    searchTerm = "clusterid:(" + params["clusterId"] + ")"
+                    this.loadSearch(searchTerm)
                 } else if (params.hasOwnProperty("pcolId") && params["pcolId"] !== "") {
                     //get personal collection thumbnails via SOLR
                     this.loadSearch(searchTerm)
@@ -701,32 +707,6 @@ export class AssetService {
             }
             loadBatch(0);
         });
-    }
-
-    private loadCluster(objectId: string){
-
-        let options = { withCredentials: true };
-        let startIndex = ((this.urlParams.page - 1) * this.urlParams.size) + 1;
-
-        let requestString = [this._auth.getUrl(), "cluster", objectId, "thumbnails", startIndex, this.urlParams.size].join("/");
-
-        this.http
-            .get(requestString, options)
-            .toPromise()
-            .then((res) => {
-                if (res['thumbnails']) {
-                    //The asset grid component expects the total number of assets in 'total'
-                    res['total'] = res['count']
-                    // Set the allResults object
-                    this.updateLocalResults(res);
-                } else {
-                    throw new Error("There are no thumbnails. Server responsed with status " + res['status']);
-                }
-            })
-            .catch((err) => {
-                console.log(err)
-                this.allResultsSource.error(err)
-            });
     }
 
     // Used by Browse page


### PR DESCRIPTION
Example cluster:
/cluster/SCALA_ARCHIVES_1039779789;objTitle=David

- /cluster route loads results via Solr
- Route param is now "clusterId" to differentiate from /associated