### PR TITLE
increase limit on Browse Public Collections search query to 600, and …

### DIFF
--- a/src/app/shared/assets.service.ts
+++ b/src/app/shared/assets.service.ts
@@ -784,12 +784,11 @@ export class AssetService {
             // base facet field
             "name" : "", // ex: collectiontypes
             "mincount" : 1,
-            "limit" : 100
+            "limit" : 600
         }
         facetField.name = facetName
-        facetField.limit = 500
-        // Ignore junk data, collections with only one asset aren't collections we care about
-        facetField.mincount = 5
+        facetField.limit = 600
+        facetField.mincount = 1
         query.facet_fields = [facetField]
       }
 


### PR DESCRIPTION
- Resolves missing Public Collections at browse/commons

Note: Two other Dartmouth collections are not returned in data results at all,
but are referenced in Forum/Binder issues for these individual collections.

Sample collections now included are :
```
YES
{"collectionid":"87731073","collectionname":"Dartmouth: Chinese Graphic Novels","collectionType":5,"collectionDisplayType":5}
,
YES
{"collectionid":"87731004","collectionname":"Dartmouth: Remix the Manuscript","collectionType":5,"collectionDisplayType":5}

Sample collections still not included are :

NO
{"collectionid":"87731881","collectionname":"Dartmouth: Portuguese-language Film Collection","collectionType":5,"collectionDisplayType":5}
,

NO
{"collectionid":"87731864","collectionname":"Dartmouth: Book Arts Prize","collectionType":5,"collectionDisplayType":5}
,
```