### PR TITLE
AIR-1615

### DIFF
--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -488,7 +488,7 @@ export class AuthService implements CanActivate {
       .map(
         (data)  => {
           let user = this.decorateValidUser(data)
-          var onSahara: boolean = this.getHostname().toString().includes('sahara')
+          let onSahara: boolean = this.getHostname().toString().includes('sahara')
           if (user && (!onSahara || user.status)) {
             // Clear expired session modal
             this.showUserInactiveModal.next(false)


### PR DESCRIPTION
The problem is caused because:

In decorateValidUser() function, unaffiliated user is decorated to be not empty, but in canActivate function, we only check if(user) to decide whether redirect user to the login page.

Therefore, the problem is not limited in SAHARA, actually I see same behavior on library behind feature flag.

I add a check of user status in canActivate so that even if user object is decorated to be not empty, the redirection still works.