### PR TITLE
AIR-1525

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,7 +76,7 @@ export class App {
         let zendeskElements = document.querySelectorAll('.zopim')
 
         // On navigation end, load the zendesk chat widget if user lands on login page else hide the widget
-        if(this.showChatWidget(event.url)) {
+        if(this.showChatWidget(window.location.href)) {
           this._script.loadScript('zendesk')
             .then( data => {
               if(data['status'] === 'loaded'){


### PR DESCRIPTION
When click ADL / Public collections etc and then click Groups -> Artstor Curated, the event.url is: /browse/groups, but the current url is actually: /browse/groups/public.

I use window.location.href instead of event.url to get the right path, since we are checking whether the url contains "/browse/groups/public".

But it may be a problem as event.url is showing "/browse/groups" while the actual link is "/browse/groups/public". I didn't fix that, if I should, please let me know.