### PR TITLE
AIR-1593

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -347,7 +347,12 @@ export class AssetPage implements OnInit, OnDestroy {
                 let currentAssetId: string = this.assets[0].id || this.assets[0]['objectId'] // couldn't trust the 'this.assetIdProperty' variable
                 // Search returns a 401 if /userinfo has not yet set cookies
                 if (Object.keys(this._auth.getUser()).length !== 0) {
-                    this.collectionType = CollectionTypeHandler.getCollectionType([asset.collectionType], asset.contributinginstitutionid)
+                    // pass collectiontypeIds from asset.collections to getCollectionType function as an array of number
+                    let collectiontypeIds: number[] = []
+                    asset.collections.forEach((collection) => {
+                        collectiontypeIds.push(Number(collection.type))
+                    })
+                    this.collectionType = CollectionTypeHandler.getCollectionType(collectiontypeIds, asset.contributinginstitutionid)
                 }
                 this.generateImgURL()
 


### PR DESCRIPTION
- Originally on asset page, we are passing [asset.collectionType] as an array of single number to CollectionTypeHandler.
- In order for the CollectionTypeHandler to choose the type with highest priority, we need to pass all the types id as an array to it.

(I don't know if I need to change the "asset.collectionType" to be the type id with the highest priority. Currently it is not. If I need to fix that, please let me know.)