### PR TITLE
Move search logging logic upstream

### DIFF
--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -7,7 +7,7 @@ import { Angulartics2 } from 'angulartics2';
 import { SearchQueryUtil } from './search-query';
 import { AnalyticsService } from '../../analytics.service';
 import { AssetFiltersService } from './../../asset-filters/asset-filters.service';
-import { AuthService, AssetService, AssetSearchService, LogService } from "app/shared";
+import { AuthService, AssetService, AssetSearchService } from "app/shared";
 import { AppConfig } from '../../app.service';
 
 @Component({
@@ -92,8 +92,7 @@ export class SearchModal implements OnInit {
         private angulartics: Angulartics2,
         private _auth: AuthService,
         // Solr Search service
-        private _assetFilters: AssetFiltersService,
-        private _captainsLog: LogService
+        private _assetFilters: AssetFiltersService
       ) {
 
     // Setup two query fields
@@ -501,15 +500,6 @@ export class SearchModal implements OnInit {
     // Track in Adobe Analytics
     this._analytics.directCall('advanced_search');
     this.angulartics.eventTrack.next({ action: "advSearch", properties: { category: "search", label: advQuery } })
-
-    // Post search info to Captain's Log
-    this._captainsLog.log({
-      eventType: "artstor_search",
-      additional_fields: { 
-        "searchTerm": advQuery,
-        "searchFilters": filterParams
-      }
-    })
 
     // Maintain feature flags
     if (currentParams['featureFlag']) {

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router'
 import { Subscription }   from 'rxjs/Subscription';
 
 import { AssetService } from './../shared/assets.service';
-import { AuthService } from '../shared';
+import { AuthService, LogService } from '../shared';
 import { AssetFiltersService } from '../asset-filters/asset-filters.service';
 import { AnalyticsService } from '../analytics.service';
 import { AssetGrid } from './../asset-grid/asset-grid.component';
@@ -38,7 +38,8 @@ export class SearchPage implements OnInit, OnDestroy {
         private _router: Router,
         private _analytics: AnalyticsService,
         private _title: TitleService,
-        private _auth: AuthService
+        private _auth: AuthService,
+        private _captainsLog: LogService
       ) {
     this.siteID = this._appConfig.config.siteID;
     // this makes the window always render scrolled to the top
@@ -85,6 +86,19 @@ export class SearchPage implements OnInit, OnDestroy {
 
         // Make a search call if there is a search term or any selected filter
         if (params["term"] || params["classification"] || params["geography"] || params["collectiontypes"]  || params["collTypes"] || params["startDate"] || params["endDate"]) {
+          // Build *reporting* search filters object
+          let logFilters = Object.assign({}, params)
+          // Remove search term value
+          delete logFilters["term"]
+          // Post search info to Captain's Log
+          this._captainsLog.log({
+            eventType: "artstor_search",
+            additional_fields: { 
+              "searchTerm": params["term"],
+              "searchFilters": logFilters
+            }
+          })
+
           this._title.setSubtitle( '"'+ params["term"] + '"' )
           this._assets.queryAll(params);
         } else {

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -9,7 +9,6 @@ import { AnalyticsService } from '../../analytics.service';
 import { AssetFiltersService } from '../../asset-filters/asset-filters.service';
 import { Params } from '@angular/router/src/shared';
 import { PACKAGE_ROOT_URL } from '@angular/core/src/application_tokens';
-import { LogService } from '../log.service';
 
 @Component({
   selector: 'ang-search',
@@ -41,8 +40,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     private _router: Router,
     private route: ActivatedRoute,
     private angulartics: Angulartics2,
-    private _filters: AssetFiltersService,
-    private _captainsLog: LogService
+    private _filters: AssetFiltersService
   ) {
 
   }
@@ -99,13 +97,6 @@ export class SearchComponent implements OnInit, OnDestroy {
 
     this._analytics.directCall('search')
     this.angulartics.eventTrack.next({ action: "simpleSearch", properties: { category: "search", label: this.term }})
-
-    this._captainsLog.log({
-      eventType: "artstor_search",
-      additional_fields: { 
-        "searchTerm:": this.term
-      }
-    })
 
     let routeParams = this.route.snapshot.params;
     let params: Params = {


### PR DESCRIPTION
Search events should now fire when:
- Adv search is made
- Search term is updated
- Filter applied
But not when:
- Search page is loaded with terms or filters