### PR TITLE
AIR-605

### DIFF
--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -501,7 +501,7 @@ export class AuthService implements CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     let options = { headers: this.userInfoHeader, withCredentials: true }
 
-    if (this.isPublicOnly() && state.url === '/register') { // For unaffiliated users, trying to access /register route
+    if (this.isPublicOnly() && state.url.includes('/register')) { // For unaffiliated users, trying to access /register route
       return new Observable(observer => {
         observer.next(false)
       })


### PR DESCRIPTION
- More robust fix for restricting `/register` route to unaffiliated users.
- Handles the case were user directly (using URL) tries to access the `/register;featureFlag=unaffiliated` route.