### PR TITLE
Fix share-ig-link url containing special chars

### DIFF
--- a/src/app/modals/share-ig-link/share-ig-link.component.ts
+++ b/src/app/modals/share-ig-link/share-ig-link.component.ts
@@ -66,7 +66,7 @@ export class ShareIgLinkModal implements OnInit {
         .subscribe((res) => {
           this.serviceStatus.isLoading = false
           if (res.success && res.token) {
-            this.shareLink = [protocol, document.location.host, groupPath, ig.id, "?token=", res.token].join("")
+            this.shareLink = [protocol, document.location.host, groupPath, ig.id, "?token=", encodeURIComponent(res.token)].join("")
           } else {
             this.serviceStatus.tokenError = true
           }


### PR DESCRIPTION
We need to url encode image group share tokens so that browsers don't encode them when pasted into the address bar - which was causing the tokens not to match when passed to the redeem endpoint