### PR TITLE
AIR-1648

### DIFF
--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -205,18 +205,9 @@ export class NewIgModal implements OnInit {
       if(this.copyIG) {
         // Copying old group
         this._angulartics.eventTrack.next({ action:"copyGroup", properties: { category: "group", label: group.id }});
-
-        // Log copy group event into Captain's Log
-        this._log.log({
-          eventType: "artstor_copy_group",
-          additional_fields: {
-            "source_group_id": this.ig.id
-          }
-        })
       } else {
         // Create New Group
         this._angulartics.eventTrack.next({ action:"newGroup", properties: { category: "group" }});
-   
       }
 
       // create the group using the group service
@@ -233,13 +224,25 @@ export class NewIgModal implements OnInit {
               this.changeGlobalSetting(this.newGroup, formValue.artstorPermissions == "global")
             }
             
-            // Log create group event into Captain's Log
-            this._log.log({
-              eventType: "artstor_create_group",
-              additional_fields: {
-                "source_group_id": this.newGroup.id
-              }
-            })
+            if(this.copyIG) {
+              // Log copy group event into Captain's Log
+              this._log.log({
+                eventType: "artstor_copy_group",
+                additional_fields: {
+                  "source_group_id": this.ig.id,
+                  "group_id": this.newGroup.id
+                }
+              })
+            }
+            else {
+              // Log create group event into Captain's Log
+              this._log.log({
+                eventType: "artstor_create_group",
+                additional_fields: {
+                  "group_id": this.newGroup.id
+                }
+              })
+            }  
           },
           error => {
             console.error(error);


### PR DESCRIPTION
According to Eric, we need to change the field name of "source_group_id" to "group_id" for artstor_create_group event. And we need an additional "group_id" that represents the newly created group's id.