### PR TITLE
AIR-1657

### DIFF
--- a/src/app/modals/new-ig-modal/new-ig.ts
+++ b/src/app/modals/new-ig-modal/new-ig.ts
@@ -82,6 +82,11 @@ export class IgFormUtil {
       })
     }
 
+    // Make sure to trim/remove the leading and trailing space from each tag
+    for(let tag of group.tags){
+      tag = tag.trim()
+    }
+
     return group
   }
 }


### PR DESCRIPTION
Trim leading / trailing spaces from image group tags when preparing group for save / edit.