### PR TITLE
Air 1696: Ensure asset loads after user access has loaded this session

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -13,27 +13,28 @@
         span#assetPageCount {{ totalAssetCount - restrictedAssetsCount }}
     //- Asset Viewer Row
     .asset-col([ngClass]="[ isFullscreen ? 'fullscreen-container' : 'col-md-8', showAssetDrawer && isFullscreen ? 'drawer' : '' ]")
-      artstor-viewer(*ngFor="let assetId of (isFullscreen ? assetIds : [assetIds[0]]); let i = index",
-        [testEnv]="_auth.getEnv() === 'test'",
-        [assetId]="assetId",
-        [encrypted]="encryptedAccess",
-        [groupId]="assetGroupId",
-        (assetMetadata)="handleLoadedMetadata($event, i)",
-        [ngClass]="[ 'asset-viewer-' + assetIds.length ]",
-        (fullscreenChange)="updateFullscreenVar($event)",
-        [index]="i",
-        [assetCompareCount]="assets.length",
-        [assetNumber]="assetNumber",
-        [assetGroupCount]="totalAssetCount - restrictedAssetsCount",
-        [assets]="assets",
-        [isFullscreen]="isFullscreen",
-        [showCaption]="showAssetCaption",
-        [quizMode]="quizMode",
-        [prevAssetResults]="prevAssetResults",
-        (removeAsset)="toggleAsset($event)",
-        (nextPage)="showNextAsset()",
-        (prevPage)="showPrevAsset()",
-        (assetDrawer)="toggleAssetDrawer(!showAssetDrawer)")
+      ng-container(*ngIf="userSessionFresh")
+        artstor-viewer(*ngFor="let assetId of (isFullscreen ? assetIds : [assetIds[0]]); let i = index",
+          [testEnv]="_auth.getEnv() === 'test'",
+          [assetId]="assetId",
+          [encrypted]="encryptedAccess",
+          [groupId]="assetGroupId",
+          (assetMetadata)="handleLoadedMetadata($event, i)",
+          [ngClass]="[ 'asset-viewer-' + assetIds.length ]",
+          (fullscreenChange)="updateFullscreenVar($event)",
+          [index]="i",
+          [assetCompareCount]="assets.length",
+          [assetNumber]="assetNumber",
+          [assetGroupCount]="totalAssetCount - restrictedAssetsCount",
+          [assets]="assets",
+          [isFullscreen]="isFullscreen",
+          [showCaption]="showAssetCaption",
+          [quizMode]="quizMode",
+          [prevAssetResults]="prevAssetResults",
+          (removeAsset)="toggleAsset($event)",
+          (nextPage)="showNextAsset()",
+          (prevPage)="showPrevAsset()",
+          (assetDrawer)="toggleAssetDrawer(!showAssetDrawer)")
       //- Related results from JSTOR
       .pl-3(*ngIf="jstorResults.length > 0 && relatedResFlag")
         .row-hdr.pt-3 Related Results from JSTOR

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -36,7 +36,8 @@ export class AssetPage implements OnInit, OnDestroy {
 
     @ViewChild(ArtstorViewer) assetViewer: any
 
-    private user: any
+    public user: any
+    public userSessionFresh: boolean = false
     private encryptedAccess: boolean = false
     private document = document
     private URL = URL
@@ -169,6 +170,13 @@ export class AssetPage implements OnInit, OnDestroy {
 
         // sets up subscription to allResults, which is the service providing thumbnails
         this.subscriptions.push(
+            this._auth.currentUser.subscribe((user) => {
+                this.user = user
+                // userSessionFresh: Do not attempt to load asset until we know user object is fresh
+                if (!this.userSessionFresh && this._auth.userSessionFresh) {
+                    this.userSessionFresh = true
+                }
+            }),
             this._assets.allResults.subscribe((allResults) => {
                 if (allResults.thumbnails) {
                     // Set asset id property to reference
@@ -361,6 +369,10 @@ export class AssetPage implements OnInit, OnDestroy {
 
 
     handleLoadedMetadata(asset: Asset, assetIndex: number) {
+        // Reset modals if new data comes in
+        this.showAccessDeniedModal = false
+        this.showServerErrorModal = false
+
         if (asset && asset['error']) {
             let err = asset['error']
             if (err.status === 403 || err.message == "Unable to load metadata!") {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -117,7 +117,7 @@ export class Login implements OnInit, OnDestroy {
       });
 
     // this handles showing the register link for only ip auth'd users
-    this._auth.getIpAuth()
+    this._auth.getUserInfo()
       .take(1)
       .subscribe((res) => {
         if (res.remoteaccess === false && res.user) {

--- a/src/app/shared/nav/nav.component.ts
+++ b/src/app/shared/nav/nav.component.ts
@@ -73,7 +73,7 @@ export class Nav implements OnInit, OnDestroy {
     );
 
     // this handles showing the register link for only ip auth'd users
-    this._auth.getIpAuth()
+    this._auth.getUserInfo()
       .take(1)
       .subscribe((res) => {
         if (res.remoteaccess === false && res.user) {


### PR DESCRIPTION
Steps to recreate problem:
1. Be Ip auth'd
2. Search "ornamental initials" on Jstor
3. Explore result image in Artstor
4. While in Artstor, delete all library.artstor.org cookies
5. Close Artstor tab
6. Leave VPN, lose ip auth
7. Explore result image in Artstor again, no modal will show