### PR TITLE
Webpack: Attach cache query param to js files

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -63,8 +63,13 @@ module.exports = function(env) {
        * IMPORTANT: You must not specify an absolute path here!
        *
        * See: http://webpack.github.io/docs/configuration.html#output-filename
+       * 
+       * "response-cache-control" query param is attached to tell S3 to a attach a Cache-Control header
+       * S3 Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
+       * This header is then picked up by Fastly, so it knows to cache our js files
+       * Fastly Docs: https://docs.fastly.com/guides/tutorials/cache-control-tutorial.html
        */
-      filename: '[name].[chunkhash].bundle.js',
+      filename: '[name].[chunkhash].bundle.js?response-cache-control=' + encodeURIComponent('s-maxage=31536000'),
 
       /**
        * The filename of the SourceMaps for the JavaScript files.


### PR DESCRIPTION
"response-cache-control" query param is attached to the bundled JS files to tell S3 to return a cache control header which will then be picked up by Fastly