### PR TITLE
Air-1412: Group tags: Display and select tags

### DIFF
--- a/src/app/browse-page/browse-groups/groups.component.pug
+++ b/src/app/browse-page/browse-groups/groups.component.pug
@@ -15,9 +15,15 @@ nav.nav.nav-inline.browse-nav
     ang-general-search(*ngIf="route.snapshot.params.view == 'search'", [updateSearchTerm]="updateSearchTerm", [init]="searchTerm", (executeSearch)="addQueryParams({ term: $event }, false)")
     h3.pb-1.px-2 Groups     
       pagination([pageObj]="pagination", (goToPage)="goToPage($event)", [right]="true")
+    h3.pb-1.px-2(*ngIf="_tagFilters.selectedFilters.length>0") Tags:
+      .filter.filter--aboveGroup(*ngFor="let tag of _tagFilters.selectedFilters", (click)="tag.selected = !tag.selected", [class.active]="tag.selected")
+        span.notranslate {{ tag.key }} ({{ tag.doc_count }})
+        i.icon.icon-add
+        i.icon.icon-close
+      a#groupTagsClear.link--accent.small(*ngIf="_tagFilters.selectedFilters.length>1", tabindex="", style="margin:3px;", (click)="_tagFilters.clearFilters();") Clear All
     .group-list.has-icon-overlay.px-2
       .alert.alert-warning(*ngIf="errorObj[selectedBrowseLevel]", [innerHtml]="errorObj[selectedBrowseLevel]")
-      .alert.alert-info(*ngIf="showSearchPrompt && route.snapshot.params.view == 'search'") {{ 'BROWSE.ERRORS.SEARCH_PROMPT' | translate }}
+      .alert.alert-info(*ngIf="showSearchPrompt && route.snapshot.params.view == 'search'") {{ 'BROWSE.ERRORS.SEARCH_PROMPT' | translate }}    
       ng-container(*ngIf="showCardView")
         ang-card-view(*ngFor="let tag of tags; let i=index;", [tag]="tag", [group]="groups[i]", [browseLevel]="selectedBrowseLevel", link="true")
       ng-container(*ngIf="!showCardView")

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -138,6 +138,9 @@ export class BrowseGroupsComponent implements OnInit {
     this.subscriptions.push(
       this._router.events.filter(event=>event instanceof NavigationEnd)
       .subscribe(event => {
+        // Set showRemainTags to be false so that the choice of see all tags show up everytime browselevel is changed
+        this._tagFilters.showRemainTags = false
+
         let query = this.route.snapshot.queryParams;
         let params = this.route.snapshot.params;
 

--- a/src/app/browse-page/browse-groups/tag-filters.service.ts
+++ b/src/app/browse-page/browse-groups/tag-filters.service.ts
@@ -7,13 +7,14 @@ export class TagFiltersService {
 
   private _filters: TagFilter[] = []
   private _updateFilters: EventEmitter<any>
+  public showRemainTags: boolean = false
 
   public filterKeys: Subject<string[]> = new Subject()
 
   constructor(
     // don't put other services in here
     // data should be set from outside, and this service stores and curates it
-  ) {
+  ) { 
     this._updateFilters = new EventEmitter()
     // whenever a tag is updated, redistribute the tag filters string which is curated here
     this._updateFilters.subscribe((filter) => {

--- a/src/app/browse-page/browse-groups/tag-filters.service.ts
+++ b/src/app/browse-page/browse-groups/tag-filters.service.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs/Subject'
 export class TagFiltersService {
 
   private _filters: TagFilter[] = []
+  private _selectedFilters: TagFilter[] = []
   private _updateFilters: EventEmitter<any>
   public showRemainTags: boolean = false
 
@@ -24,6 +25,10 @@ export class TagFiltersService {
 
   get filters() {
     return this._filters
+  }
+
+  get selectedFilters() {
+    return this._selectedFilters
   }
 
   /**
@@ -63,6 +68,18 @@ export class TagFiltersService {
       newFilters.push(new TagFilter(filter, this._updateFilters, isSelected))
     })
     this._filters = newFilters
+
+    this._selectedFilters = []
+    for (let tag of this._filters) {
+      if (tag.selected) {
+        // Push the selected filters to the top of the filter list
+        this._filters.splice(this._filters.indexOf(tag), 1)
+        this._filters.unshift(tag)
+
+        // Construct selectedFilters to show them on top of the image groups
+        this._selectedFilters.push(tag)
+      }
+    }
   }
 
   /**

--- a/src/app/browse-page/browse-groups/tags-list.component.pug
+++ b/src/app/browse-page/browse-groups/tags-list.component.pug
@@ -2,7 +2,13 @@ h3 Tags
   = " "
   a.contextual-help(title="How do I use tags?", href="http://support.artstor.org/?article=tags", target="_blank") ?
   a#groupTagsClear.link--accent.small(tabindex="", style="float:right;", (click)="_tagFilters.clearFilters();") Clear All
-.filter.filter--tag(*ngFor="let tag of _tagFilters.filters", (click)="tag.selected = !tag.selected", [class.active]="tag.selected")
+.filter.filter--tag(*ngFor="let tag of _tagFilters.filters.slice(0, 15)", (click)="tag.selected = !tag.selected", [class.active]="tag.selected")
   span.notranslate {{ tag.key }} ({{ tag.doc_count }})
   i.icon.icon-add
   i.icon.icon-close
+.filter.filter--tag(*ngIf="!_tagFilters.showRemainTags && _tagFilters.filters.length>15", (click)="_tagFilters.showRemainTags=true") See all {{ _tagFilters.filters.length }} tags
+ng-container(*ngIf="_tagFilters.showRemainTags")
+  .filter.filter--tag(*ngFor="let tag of _tagFilters.filters.slice(15)", (click)="tag.selected = !tag.selected", [class.active]="tag.selected")
+    span.notranslate {{ tag.key }} ({{ tag.doc_count }})
+    i.icon.icon-add
+    i.icon.icon-close

--- a/src/app/browse-page/browse-page.component.scss
+++ b/src/app/browse-page/browse-page.component.scss
@@ -217,3 +217,9 @@
         }
     }
 }
+
+.filter--aboveGroup {
+	width: auto;
+	display: inline-block;
+	margin: 3px;
+}

--- a/src/sass/modules/_filters.scss
+++ b/src/sass/modules/_filters.scss
@@ -83,6 +83,8 @@ filter, .filter {
 		color: $activeFilterColor;
 		background: $filterHoverBg;
 		margin-bottom: 1px;
+		text-decoration: none;
+		font-weight: bold;
 	}
 
 	&:hover, &:active, &:focus{
@@ -203,7 +205,8 @@ button.filter--tag {
 }
 
 .filter--tag {
-	color:#8300e0;
+	color:#000;
+	text-decoration: underline;
 }
 
 filter.date-span-input {


### PR DESCRIPTION
 - Selected tags are pushed to the top once selected
 - Add selected tags above the image groups,  and once more than one tag is selected, there is clear all button showing up
 - Only show 15 tags by default and user has a chance to expend it
 - Change the style of the tags according to the design