### PR TITLE
AIR-1707 (PPT/zip download error message)

### DIFF
--- a/src/app/image-group-page/ig-download-modal/ig-download-modal.component.pug
+++ b/src/app/image-group-page/ig-download-modal/ig-download-modal.component.pug
@@ -2,19 +2,13 @@
   .modal-dialog(role="document")
     .modal-content
       .modal-header
-        h4.modal-title Export/Download Guidelines
+        h4.modal-title {{ 'IMAGE_GROUP_PAGE.IG_DOWNLOAD_MODAL.TITLE' | translate }}
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
-        p All logged in users may export/download up to
-          b  2000
-          |  images in a
-          b  120
-          |  day period. Multimedia files are not exported.
-        p Also note that, by accepting this download, you are agreeing to the
-          = " "
-          a.link(href="http://www.artstor.org/terms", name="Terms and conditions of use", target="_blank") terms and conditions of use.
-        p Would you like to proceed?
+        div([innerHtml]="'IMAGE_GROUP_PAGE.IG_DOWNLOAD_MODAL.TEXT' | translate")
+        .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total>100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.IG_DOWNLOAD_MODAL.DOWNLOAD_ERROR_BIG' | translate")
+        .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total<=100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.IG_DOWNLOAD_MODAL.DOWNLOAD_ERROR_SMALL' | translate")
       .modal-footer
         button.btn.btn-secondary(type="button", (click)="closeModal.emit()") Cancel
         a#generatePowerpointLink.btn.btn-primary(*ngIf="!downloadLink  && !isLoading", tabindex="1", (click)="getPPT()") Request PPT

--- a/src/app/image-group-page/ig-download-modal/ig-download-modal.component.ts
+++ b/src/app/image-group-page/ig-download-modal/ig-download-modal.component.ts
@@ -27,7 +27,7 @@ export class PptModalComponent implements OnInit {
   private zipDownloadLink: string = '';
   private downloadTitle: string = 'Image Group';
   private allowedDownloads: number = 0;
-  private imgCount: number = 0;
+  private error: boolean = false;
 
   private header = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
   private defaultOptions = { withCredentials: true};
@@ -41,7 +41,6 @@ export class PptModalComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-
   }
 
   private getPPT() {
@@ -58,7 +57,8 @@ export class PptModalComponent implements OnInit {
     })
     .catch((err) => {
       console.error(err)
-       this.isLoading = false
+      this.error = true
+      this.isLoading = false
     })
   }
 
@@ -76,6 +76,7 @@ export class PptModalComponent implements OnInit {
     })
     .catch((err) => {
       console.error(err)
+      this.error = true
       this.zipLoading = false
     })
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -162,6 +162,12 @@
     }
   },
   "IMAGE_GROUP_PAGE": {
+    "IG_DOWNLOAD_MODAL": {
+      "TITLE": "Export/Download Guidelines",
+      "TEXT": "<p>All logged in users may export/download up to <b>2000</b> images in a <b>120</b> day period. Multimedia files are not exported.</p><p>Also note that, by accepting this download, you are agreeing to the <a href=\"http://www.artstor.org/terms\" class=\"link\" name=\"Terms and conditions of use\" target=\"_blank\">terms and conditions of use.</a></p><p>Would you like to proceed?</p>",
+      "DOWNLOAD_ERROR_BIG": "We're sorry, we were unable to generate your file. The recommended group size is under 100 images.",
+      "DOWNLOAD_ERROR_SMALL": "We're sorry, we were unable to generate your file. Please try again. If the problem persists, contact us at <a href=\"mailto:support@artstor.org\" class=\"link\" target=\"_blank\">support@artstor.org</a>"
+    },
     "DOWNLOAD_LIMIT_MODAL": {
       "TITLE": "Download Limit Reached",
       "CLOSE_BUTTON": "Ok",


### PR DESCRIPTION
 - Show error message when failure according to image group size
 - Move the long sentences to en.json

P.S. If logged in as air01, can use "ppt download" private image group to test, which is a big image group.