### PR TITLE
AIR-1725

### DIFF
--- a/src/app/browse-page/browse-groups/groups.component.pug
+++ b/src/app/browse-page/browse-groups/groups.component.pug
@@ -12,7 +12,7 @@ nav.nav.nav-inline.browse-nav
           | {{ filter.label }}
     ang-tags-list([browseLevel]="selectedBrowseLevel")
   .col-md-9
-    ang-general-search(*ngIf="route.snapshot.params.view == 'search'", [updateSearchTerm]="updateSearchTerm", [init]="searchTerm", (executeSearch)="addQueryParams({ term: $event }, false)")
+    ang-general-search(*ngIf="route.snapshot.params.view == 'search'", [updateSearchTerm]="updateSearchTerm", [init]="searchTerm", (executeSearch)="addQueryParams({ term: $event }, false, true)")
     h3.pb-1.px-2 Groups     
       pagination([pageObj]="pagination", (goToPage)="goToPage($event)", [right]="true")
     h3.pb-1.px-2(*ngIf="_tagFilters.selectedFilters.length>0") Tags:

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -353,7 +353,8 @@ export class BrowseGroupsComponent implements OnInit {
     } else {
       baseParams = Object.assign({}, this.route.snapshot.queryParams)
     }
-    if(searchWithTerm && baseParams['id']){
+    if (searchWithTerm && baseParams['id']) {
+      delete baseParams['tags']
       delete baseParams['id']
     }
     let queryParams = Object.assign(baseParams, params)

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -115,7 +115,7 @@ export class BrowseGroupsComponent implements OnInit {
       .subscribe((params: Params) => {
         // Find feature flags
         if(params && params['featureFlag'] && params['featureFlag'] === 'cardview'){
-              this.showCardView = true;
+          this.showCardView = true;
         }
       })
     )
@@ -166,7 +166,7 @@ export class BrowseGroupsComponent implements OnInit {
 
         let requestedPage = Number(query.page) || 1
         if (requestedPage < 1 || tagAdded) {
-          this.addQueryParams({page: 1}, false, query)
+          this.addQueryParams({page: 1}, false, false, query)
         } // STOP THEM if they're trying to enter a negative number
         // if (tagAdded) { requestedPage = 1 } // if they're adding a tag, we want to nav them back to page 1
         let requestedLevel = this.selectedBrowseLevel !== 'search' ? this.selectedBrowseLevel : query.level;
@@ -344,7 +344,7 @@ export class BrowseGroupsComponent implements OnInit {
    * @param params the parameters to add to the url (if duplicate parameters already in url, this will overwrite them)
    * @param reset allows resetting of queryParams to empty object plus whatever params you pass, instead of keeping old params
    */
-  private addQueryParams(params: { [key: string]: any }, reset?: boolean, currentParams?: any) {
+  private addQueryParams(params: { [key: string]: any }, reset?: boolean, searchWithTerm?: boolean, currentParams?: any) {
     let baseParams
     if (reset) {
       baseParams = {}
@@ -353,7 +353,7 @@ export class BrowseGroupsComponent implements OnInit {
     } else {
       baseParams = Object.assign({}, this.route.snapshot.queryParams)
     }
-    if(baseParams['id']){
+    if(searchWithTerm && baseParams['id']){
       delete baseParams['id']
     }
     let queryParams = Object.assign(baseParams, params)

--- a/src/app/browse-page/card-view/card-view.component.ts
+++ b/src/app/browse-page/card-view/card-view.component.ts
@@ -106,7 +106,7 @@ export class CardViewComponent implements OnInit {
   private updateUrl(tag: string): void {
     let queryParams: any = Object.assign({}, this.route.snapshot.queryParams)
     delete queryParams['tags']
-    queryParams = Object.assign({}, {'tags': tag})
+    queryParams = Object.assign(queryParams, {'tags': tag})
 
     this._router.navigate(['/browse','groups', this.browseLevel], { queryParams: queryParams })
   }


### PR DESCRIPTION
 - Keep image group id in route param when applying filters, so that when we clear the filters we still land on the original search page
 - Clear existing tags when we make a new search with search term