### PR TITLE
Refactor AssetSearchService.search

### DIFF
--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -17,7 +17,7 @@ export class AssetSearchService {
 
   showCollectionType: boolean = false
 
-   public filterFields: { name: string, value: string, description?: string }[] = [
+  public filterFields: { name: string, value: string, description?: string }[] = [
     { name: "In any field", value: "", description: "ADVANCED_SEARCH_MODAL.FIELDS.ANY" },
     { name: "Creator", value: "artcreator", description: "ADVANCED_SEARCH_MODAL.FIELDS.CREATOR" },
     { name: "Title", value: "arttitle", description: "ADVANCED_SEARCH_MODAL.FIELDS.TITLE" },
@@ -31,7 +31,7 @@ export class AssetSearchService {
     { name: "Technique", value: "arttechnique", description: "ADVANCED_SEARCH_MODAL.FIELDS.TECHNIQUE" },
     { name: "Number", value: "artidnumber", description: "ADVANCED_SEARCH_MODAL.FIELDS.NUMBER" },
     { name: "SSID", value: "ssid", description: "ADVANCED_SEARCH_MODAL.FIELDS.SSID" },
-    { name: "Repository ID", value: "artcurrentrepositoryidnumber", description: "ADVANCED_SEARCH_MODAL.FIELDS.REPO_ID"}
+    { name: "Repository ID", value: "artcurrentrepositoryidnumber", description: "ADVANCED_SEARCH_MODAL.FIELDS.REPO_ID" }
   ]
 
   public latestSearchRequestId: string
@@ -51,8 +51,155 @@ export class AssetSearchService {
   */
   public downloadViewBlob(url: string): Observable<any> {
     return this.http.get(url, {
-        responseType: 'blob'
+      responseType: 'blob'
     })
+  }
+
+  private initQuery(keyword: string, pageSize, startIndex) {
+
+    return {
+      "limit": pageSize,
+      "start": startIndex,
+      "content_types": [
+        "art"
+      ],
+      // "startdate" : earliestDate,
+      // "enddate" : latestDate,
+      //   "facet_fields": [
+      //       "artclassification"
+      //   ],
+      // "ms_facet_fields": [
+      //     {
+      //     "field": "artclassification",
+      //     "efq": []
+      //     }
+      // ],
+      // Add fuzzy operator
+      "query": keyword,
+      filter_query: [],
+      "hier_facet_fields2": [
+        {
+          "field": "hierarchies",
+          "hierarchy": "artstor-geography",
+          "look_ahead": 2,
+          "look_behind": -10,
+          "d_look_ahead": 1
+        }
+      ],
+      "facet_fields":
+        [
+          // Limited to 16 classifications (based on the fact that Artstor has 16 classifications)
+          // + 1 to allow for empty string values crowding out the top 16
+          {
+            "name": "artclassification_str",
+            "mincount": 1,
+            "limit": 17
+          }
+          // ,
+          // {
+          //   "name" : "artcollectiontitle_str",
+          //   "mincount" : 1,
+          //   "limit" : 15
+          // }
+        ],
+    };
+  }
+
+  /**
+   * applyFilters
+   * Wraps logic for applying filters to search requests.
+   * @params are locally scoped to the search method
+   */
+  public applyFilters(query, institutionalTypeFilter, options, sortIndex, filterOptions) {
+    // Loop through applied filters
+    for (var i = 0; i < filterOptions.filters.length; i++) {
+      let currentFilter = filterOptions.filters[i]
+
+      // for these values, do nothing
+      if (['collTypes', 'page', 'size', 'sort', 'startDate', 'endDate'].indexOf(currentFilter.filterGroup) > -1) {
+
+      } else if (currentFilter.filterGroup == 'geography') {
+        for (let j = 0; j < currentFilter.filterValue.length; j++) {
+          if (!query['hier_facet_fields2'][0]['efq']) {
+            query['hier_facet_fields2'][0]['efq'] = [currentFilter.filterValue[j]]
+          } else {
+            query['hier_facet_fields2'][0]['efq'].push(currentFilter.filterValue[j])
+          }
+        }
+      } else {
+        for (let j = 0; j < currentFilter.filterValue.length; j++) {
+          let filterValue = currentFilter.filterValue[j]
+          /**
+           * In case of Inst. colType filter, also use the contributing inst. ID to filter
+           */
+          if ((currentFilter.filterGroup === 'collectiontypes') && (filterValue === 2 || filterValue === 4)) {
+            institutionalTypeFilter = true
+            filterOptions.filterArray.push('contributinginstitutionid:\"' + this._auth.getUser().institutionId.toString() + '\"')
+          }
+
+          // Push filter queries into the array
+          let filterValueArray = filterValue.toString().trim().split('|')
+          for (let filterVal of filterValueArray) {
+            filterOptions.filterArray.push(currentFilter.filterGroup + ':\"' + filterVal + '\"')
+          }
+        }
+      }
+    }
+
+    if (options.colId || options['coll'] || options.pcolId) {
+      let colId = ''
+      if (options['coll']) {
+        colId = options['coll']
+      }
+      else if (options.colId) {
+        colId = options.colId
+      }
+      else if (options.pcolId) {
+        // Loading Personal OR Private Collection
+        colId = options.pcolId
+      }
+
+      filterOptions.filterArray.push("collections:\"" + colId + "\"");
+    }
+
+    if (options.collections) {
+      let colsArray = options.collections.toString().trim().split(',');
+      for (let col of colsArray) { // Push each collection id seperately in the filterArray
+        filterOptions.filterArray.push("collections:\"" + col + "\"");
+      }
+    }
+
+    query.filter_query = filterOptions.filterArray
+
+    if (filterOptions.dateFacet.modified) {
+      filterOptions.earliestDate = filterOptions.dateFacet.earliest.date;
+      filterOptions.earliestDate = (filterOptions.dateFacet.earliest.era == 'BCE') ? (parseInt(filterOptions.earliestDate) * -1).toString() : filterOptions.earliestDate.toString();
+
+      filterOptions.latestDate = filterOptions.dateFacet.latest.date;
+      filterOptions.latestDate = (filterOptions.dateFacet.latest.era == 'BCE') ? (parseInt(filterOptions.latestDate) * -1).toString() : filterOptions.latestDate.toString();
+
+      query["filter_query"].push("year:[" + filterOptions.earliestDate + " TO " + filterOptions.latestDate + "]")
+    }
+
+    if (sortIndex) {
+      // Set the sort order to descending for sort by 'Recently Added' else ascending
+      if (sortIndex == '4') {
+        query["sortorder"] = "desc"
+      } else {
+        query["sortorder"] = "asc"
+      }
+
+      if (sortIndex == '1') {
+        query["sort"] = 'name_str'
+      } else if (sortIndex == '2') {
+        query["sort"] = 'agent_str'
+      } else if (sortIndex == '3') {
+        query["filter_query"].push('year:[* TO *]', '-year:((0) OR (9999))', 'yearend:[* TO *]', '-yearend:((0) OR (9999))')
+        query["sort"] = 'yearend'
+      } else if (sortIndex == '4') {
+        query["sort"] = 'updatedon_str'
+      }
+    }
   }
 
   /**
@@ -68,29 +215,29 @@ export class AssetSearchService {
       ],
       // "query": "*",
       "hier_facet_fields2": [
-      {
-        "field": "hierarchies",
-        "hierarchy": "artstor-geography",
-        "look_ahead": 2,
-        "look_behind": -10,
-        "d_look_ahead": 1
-      }
-    ],
-      "facet_fields" :
-      [
-        // Limited to 16 classifications (based on the fact that Artstor has 16 classifications)
-        // + 1 to allow for empty string values crowding out the top 16
         {
-          "name" : "artclassification_str",
-          "mincount" : 1,
-          "limit" : 17
+          "field": "hierarchies",
+          "hierarchy": "artstor-geography",
+          "look_ahead": 2,
+          "look_behind": -10,
+          "d_look_ahead": 1
         }
-        // {
-        //   "name" : "artcollectiontitle_str",
-        //   "mincount" : 1,
-        //   "limit" : 100
-        // }
       ],
+      "facet_fields":
+        [
+          // Limited to 16 classifications (based on the fact that Artstor has 16 classifications)
+          // + 1 to allow for empty string values crowding out the top 16
+          {
+            "name": "artclassification_str",
+            "mincount": 1,
+            "limit": 17
+          }
+          // {
+          //   "name" : "artcollectiontitle_str",
+          //   "mincount" : 1,
+          //   "limit" : 100
+          // }
+        ],
     };
 
     let filterArray = []
@@ -98,9 +245,9 @@ export class AssetSearchService {
     // if not sahara push this facet
     if (this.showCollectionType) {
       query.facet_fields.push({
-        "name" : "collectiontypes",
-        "mincount" : 1,
-        "limit" : 10
+        "name": "collectiontypes",
+        "mincount": 1,
+        "limit": 10
       })
     }
 
@@ -127,7 +274,7 @@ export class AssetSearchService {
    * @returns       Returns an object with the properties: thumbnails, count, altKey, classificationFacets, geographyFacets, minDate, maxDate, collTypeFacets, dateFacets
    */
   public search(options: SearchOptions, keyword: string, sortIndex): Observable<SearchResponse> {
-    let startIndex = ((options.page - 1) * options.size) + 1;
+
     let thumbSize = 0;
     let type = 6;
     let colTypeIds = '';
@@ -136,13 +283,15 @@ export class AssetSearchService {
     let geographyIds = '';
     let institutionalTypeFilter: boolean = false
 
-    let earliestDate = '';
-    let latestDate = '';
-
-    let filters = this._filters.getApplied();
-    // To-do: break dateObj out of available filters
-    let dateFacet = this._filters.getAvailable()['dateObj'];
-    let filterArray = []
+    // Shared Variables passed to applyFilters
+    let filterOptions = {
+      filters: this._filters.getApplied(),
+      // To-do: break dateObj out of available filters
+      dateFacet: this._filters.getAvailable()['dateObj'],
+      filterArray: [],
+      earliestDate: '',
+      latestDate: '',
+    }
 
     /**
      * Check for WLVs Institution filter
@@ -150,7 +299,7 @@ export class AssetSearchService {
      */
     let institutionFilters: number[] = this._app.config.contributingInstFilters
     for (let i = 0; i < institutionFilters.length; i++) {
-      filterArray.push("contributinginstitutionid:" + institutionFilters[i])
+      filterOptions.filterArray.push("contributinginstitutionid:" + institutionFilters[i])
     }
 
     let pageSize: number = options.size
@@ -166,203 +315,68 @@ export class AssetSearchService {
       }
     }
 
-    let query: any = { // haven't added the SearchRequest type yet because I don't know how to deal with the TS error I'm getting - can't even see the whole thing
-      "limit": pageSize,
-      "start": START_INDEX,
-      "content_types": [
-        "art"
-      ],
-      // "startdate" : earliestDate,
-      // "enddate" : latestDate,
-    //   "facet_fields": [
-    //       "artclassification"
-    //   ],
-        // "ms_facet_fields": [
-        //     {
-        //     "field": "artclassification",
-        //     "efq": []
-        //     }
-        // ],
-      // Add fuzzy operator
-      "query": keyword,
-      // Fuzzy searches are expensive, avoid by request of Archie
-      // + "~0.8",
-      "hier_facet_fields2": [
-      {
-        "field": "hierarchies",
-        "hierarchy": "artstor-geography",
-        "look_ahead": 2,
-        "look_behind": -10,
-        "d_look_ahead": 1
-      }
-    ],
-      "facet_fields" :
-      [
-        // Limited to 16 classifications (based on the fact that Artstor has 16 classifications)
-        // + 1 to allow for empty string values crowding out the top 16
-        {
-          "name" : "artclassification_str",
-          "mincount" : 1,
-          "limit" : 17
-        }
-        // ,
-        // {
-        //   "name" : "artcollectiontitle_str",
-        //   "mincount" : 1,
-        //   "limit" : 15
-        // }
-      ],
-    };
+    let query = this.initQuery(keyword, pageSize, sortIndex)
 
     if (this.showCollectionType) {
       query.facet_fields.push({
-        "name" : "collectiontypes",
-        "mincount" : 1,
-        "limit" : 15
+        "name": "collectiontypes",
+        "mincount": 1,
+        "limit": 15
       })
     }
 
-    // Loop through applied filters
-    for (var i = 0; i < filters.length; i++) {
-      let currentFilter = filters[i]
-
-      // for these values, do nothing
-      if ( ['collTypes', 'page', 'size', 'sort', 'startDate', 'endDate'].indexOf(currentFilter.filterGroup) > -1) {
-
-      } else if (currentFilter.filterGroup == 'geography') {
-        for (let j = 0; j < currentFilter.filterValue.length; j++) {
-          if (!query['hier_facet_fields2'][0]['efq']) {
-            query['hier_facet_fields2'][0]['efq'] = [currentFilter.filterValue[j]]
-          } else {
-            query['hier_facet_fields2'][0]['efq'].push(currentFilter.filterValue[j])
-          }
-        }
-      } else {
-        for (let j = 0; j < currentFilter.filterValue.length; j++) {
-          let filterValue = currentFilter.filterValue[j]
-          /**
-           * In case of Inst. colType filter, also use the contributing inst. ID to filter
-           */
-          if( (currentFilter.filterGroup === 'collectiontypes') && (filterValue === 2 || filterValue === 4) ){
-            institutionalTypeFilter = true
-            filterArray.push('contributinginstitutionid:\"' + this._auth.getUser().institutionId.toString() + '\"')
-          }
-
-          // Push filter queries into the array
-          let filterValueArray = filterValue.toString().trim().split('|')
-          for( let filterVal of filterValueArray){
-            filterArray.push(currentFilter.filterGroup + ':\"' + filterVal + '\"')
-          }
-        }
-      }
-    }
-
-    if(options.colId || options['coll'] || options.pcolId){
-      let colId = ''
-      if(options['coll']){
-        colId = options['coll']
-      }
-      else if(options.colId){
-        colId = options.colId
-      }
-      else if(options.pcolId){
-        // Loading Personal OR Private Collection
-        colId = options.pcolId
-      }
-
-      filterArray.push("collections:\"" + colId + "\"");
-    }
-
-    if(options.collections){
-      let colsArray = options.collections.toString().trim().split(',');
-      for(let col of colsArray){ // Push each collection id seperately in the filterArray
-        filterArray.push("collections:\"" + col + "\"");
-      }
-    }
-
-    query.filter_query = filterArray
-
-    if (dateFacet.modified) {
-      earliestDate = dateFacet.earliest.date;
-      earliestDate = (dateFacet.earliest.era == 'BCE') ? (parseInt(earliestDate) * -1).toString() : earliestDate.toString();
-
-      latestDate = dateFacet.latest.date;
-      latestDate = (dateFacet.latest.era == 'BCE') ? (parseInt(latestDate) * -1).toString() : latestDate.toString();
-
-      query["filter_query"].push( "year:[" + earliestDate + " TO " + latestDate + "]")
-    }
-
-    if (sortIndex) {
-      // Set the sort order to descending for sort by 'Recently Added' else ascending
-      if (sortIndex == '4'){
-        query["sortorder"] = "desc"
-      } else{
-        query["sortorder"] = "asc"
-      }
-
-      if (sortIndex == '1') {
-        query["sort"] = 'name_str'
-      } else if(sortIndex == '2') {
-        query["sort"] = 'agent_str'
-      } else if(sortIndex == '3') {
-        query["filter_query"].push('year:[* TO *]', '-year:((0) OR (9999))', 'yearend:[* TO *]', '-yearend:((0) OR (9999))')
-        query["sort"] = 'yearend'
-      } else if(sortIndex == '4') {
-        query["sort"] = 'updatedon_str'
-      }
-    }
-
+    this.applyFilters(query, institutionalTypeFilter, options, sortIndex, filterOptions)
 
     return this.http.post<RawSearchResponse>(
       this._auth.getSearchUrl(),
       query,
       { withCredentials: true }
     )
-    .map((res) => {
-      if (institutionalTypeFilter && res.facets) {
-        for (let i = 0; i < res.facets.length; i++) {
-          if (res.facets[i].name == 'collectiontypes') {
-            // Push the fake Institutional collection type facet only if its not already returned in the response
-            if (res.facets[i].values.filter(e => e.name === "2").length === 0) {
-              res.facets[i].values.push({
-                name: "2",
-                fq: "collectiontypes:(\"2\")",
-                count: null,
-                efq: null
-              })
+      .map((res) => {
+        if (institutionalTypeFilter && res.facets) {
+          for (let i = 0; i < res.facets.length; i++) {
+            if (res.facets[i].name == 'collectiontypes') {
+              // Push the fake Institutional collection type facet only if its not already returned in the response
+              if (res.facets[i].values.filter(e => e.name === "2").length === 0) {
+                res.facets[i].values.push({
+                  name: "2",
+                  fq: "collectiontypes:(\"2\")",
+                  count: null,
+                  efq: null
+                })
+              }
             }
           }
         }
-      }
 
-      // media comes as a json string, so we'll parse it into an object for each result
-      let cleanedResults: SearchAsset[] = res.results.map((item) => {
-        let cleanedSSID: string = item.doi.substr(item.doi.lastIndexOf(".") + 1) // split the ssid off the doi
-        let cleanedMedia: MediaObject
-        if (item.media && typeof item.media == 'string') { cleanedMedia = JSON.parse(item.media) }
-        let cleanedAsset: SearchAsset = Object.assign(
-          {}, // assigning it to a new object
-          item, // base is the raw item returned from search
-          { // this object contains all of the new properties which exist on a cleaned asset
-            media: cleanedMedia, // assign a media object instead of a string
-            ssid: cleanedSSID, // assign the ssid, which is taken off the doi
-            thumbnailUrls: [] // this is only the array init - we add the urls later
+        // media comes as a json string, so we'll parse it into an object for each result
+        let cleanedResults: SearchAsset[] = res.results.map((item) => {
+          let cleanedSSID: string = item.doi.substr(item.doi.lastIndexOf(".") + 1) // split the ssid off the doi
+          let cleanedMedia: MediaObject
+          if (item.media && typeof item.media == 'string') { cleanedMedia = JSON.parse(item.media) }
+          let cleanedAsset: SearchAsset = Object.assign(
+            {}, // assigning it to a new object
+            item, // base is the raw item returned from search
+            { // this object contains all of the new properties which exist on a cleaned asset
+              media: cleanedMedia, // assign a media object instead of a string
+              ssid: cleanedSSID, // assign the ssid, which is taken off the doi
+              thumbnailUrls: [] // this is only the array init - we add the urls later
+            }
+          )
+          // make the thumbnail urls and add them to the array
+          for (let i = 0; i < 5; i++) {
+            cleanedAsset.thumbnailUrls.push(this.makeThumbUrl(cleanedAsset.media.thumbnailSizeOnePath, i))
           }
-        )
-        // make the thumbnail urls and add them to the array
-        for (let i = 0; i < 5; i++) {
-          cleanedAsset.thumbnailUrls.push(this.makeThumbUrl(cleanedAsset.media.thumbnailSizeOnePath, i))
-        }
 
-        return cleanedAsset
+          return cleanedAsset
+        })
+
+        // create the cleaned response to pass to caller
+        let searchResponse: SearchResponse = Object.assign({}, res, { results: cleanedResults })
+
+        this.latestSearchRequestId = res.requestId
+        return searchResponse
       })
-
-      // create the cleaned response to pass to caller
-      let searchResponse: SearchResponse = Object.assign({}, res, { results: cleanedResults })
-
-      this.latestSearchRequestId = res.requestId
-      return searchResponse
-    })
   }
 
   /**
@@ -374,7 +388,7 @@ export class AssetSearchService {
 
     let query = {
       "content_types": [],
-      "additional_fields": ["rectype","raw_type","htopic_st"],
+      "additional_fields": ["rectype", "raw_type", "htopic_st"],
       "hier_facet_fields": [
         {
           "maxdepth": 10,
@@ -420,18 +434,18 @@ export class AssetSearchService {
       assetQuery,
       { withCredentials: true }
     )
-    .map((res) => {
-      // search through results and make sure the id's match
-      let desiredAsset: SearchAsset = res.results.find((asset) => {
-        return asset.artstorid === assetId
-      })
+      .map((res) => {
+        // search through results and make sure the id's match
+        let desiredAsset: SearchAsset = res.results.find((asset) => {
+          return asset.artstorid === assetId
+        })
 
-      if (desiredAsset) {
-        return desiredAsset
-      } else {
-        throw new Error('No results found for the requested id')
-      }
-    })
+        if (desiredAsset) {
+          return desiredAsset
+        } else {
+          throw new Error('No results found for the requested id')
+        }
+      })
   }
 
   /**
@@ -500,7 +514,7 @@ export interface RawSearchResponse {
 }
 
 // the data returned from search in the results array
-interface RawSearchAsset {
+export interface RawSearchAsset {
   agent: string // creator of the piece
   artstorid: string // the correct id to reference when searching for artstor assets
   clusterid: string // id of the cluser the asset exists in, if any
@@ -552,7 +566,7 @@ export interface SearchAsset {
   yearend: number // end of date range the asset is thought to have been created in
 }
 
-interface HierarchicalFilter {
+export interface HierarchicalFilter {
   [key: string]: {
     children: HierarchicalFilter
     element: {
@@ -565,7 +579,7 @@ interface HierarchicalFilter {
   }
 }
 
-interface MediaObject {
+export interface MediaObject {
   format: string
   thumbnailSizeOnePath: string
   width: number
@@ -582,7 +596,7 @@ interface MediaObject {
   height: number
 }
 
-interface SearchRequest {
+export interface SearchRequest {
   limit?: number
   start?: number
   content_types: string[]
@@ -604,7 +618,7 @@ interface SearchRequest {
   sort?: string
 }
 
-interface SearchOptions {
+export interface SearchOptions {
   page?: number
   size?: number
   colId?: string

--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -315,7 +315,7 @@ export class AssetSearchService {
       }
     }
 
-    let query = this.initQuery(keyword, pageSize, sortIndex)
+    let query = this.initQuery(keyword, pageSize, START_INDEX)
 
     if (this.showCollectionType) {
       query.facet_fields.push({


### PR DESCRIPTION
Refactors, wraps some of the logic asset-search.service in order to isolate some of the search method logic.

-defines a filterOptions object in the search method.
-defines applyFilters function that wraps a large chunk of logic currently in search
-defines initQuery that wraps logic currently in search

-In AssetSearchService.search, we defined `let startIndex = ((options.page - 1) * options.size) + 1;`
and that value is never used - so it has been removed.