### PR TITLE
Get users groups with level=created

### DIFF
--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -65,7 +65,7 @@ export class BrowseGroupsComponent implements OnInit {
     if (isLoggedIn) {
       this.groupFilterArray.push({
         label: 'My Groups',
-        level: 'private',
+        level: 'created',
         selected: true
       })
     }
@@ -195,7 +195,7 @@ export class BrowseGroupsComponent implements OnInit {
    * @param level The level param you want to search groups with
    */
   private setSearchLevel(level: string, navigate?: boolean): void {
-    if (!level) { level = 'private' }
+    if (!level) { level = 'created' }
     this.groupFilterArray.forEach((filter) => {
       if (filter.level !== level) {
         filter.selected = false


### PR DESCRIPTION
Binder made an api update to change the functionality of the search api. level=created is now the way to get the user's groups. These changes alter how we call the endpoint, which will provide for accessing a user's private groups with `level=private` in the future