### PR TITLE
AIR-1729 （ADL collection links on asset pages broken）

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1171,8 +1171,8 @@ export class AssetPage implements OnInit, OnDestroy {
     setCollectionLink(asset: Asset): any[] {
         let link = []
 
-        // 103 Collection Id routes to /category/<categoryId>
-        if (String(asset.collectionId) === '103') {
+        // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN, check the id in the collections array instead
+        if (String(asset.collectionId) === '103' || String(asset.collections[0].id) === '103') {
             return ['/category', String(asset.categoryId)]
         }
         else {


### PR DESCRIPTION
In setCollectionLink, we are now checking the collectionId, but some of the collections have collectionId of NaN. In this case, check the id in the collections array instead.