### PR TITLE
AIR-1702: [yarn install] Viewer @1.1.6, web crawler support

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "angular2-moment": "^1.2.0",
         "angular2-tag-autocomplete": "^1.2.10",
         "angulartics2": "^4.2.0",
-        "artstor-viewer": "1.1.5",
+        "artstor-viewer": "1.1.6",
         "assets-webpack-plugin": "^3.5.1",
         "blob-polyfill": "^2.0.20171115",
         "codelyzer": "^2.0.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,9 +643,9 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-artstor-viewer@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/artstor-viewer/-/artstor-viewer-1.1.5.tgz#f1e876fae1b8da21bee45d7c0cec3e3ffc5d64c0"
+artstor-viewer@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/artstor-viewer/-/artstor-viewer-1.1.6.tgz#90248db8e90802a3acf5c9c9db50a3d6e855e82a"
   dependencies:
     "@angular/http" "^5.2.0"
     npm "^5.7.1"


### PR DESCRIPTION
- Viewer update makes it so the thumbnail is always loaded on the page, and other viewers stack on top
- Adds a background to other viewers to cover the thumbnail
- Having the thumbnail always available makes it accessible to the Googlebot