### PR TITLE
Air-1757 (Display number of search results for image group search)

### DIFF
--- a/src/app/browse-page/browse-groups/groups.component.pug
+++ b/src/app/browse-page/browse-groups/groups.component.pug
@@ -15,7 +15,7 @@
     ang-tags-list(*ngIf="selectedFilter")
   .col-md-9
     ang-general-search([updateSearchTerm]="updateSearchTerm", [init]="searchTerm", (executeSearch)="addQueryParams({ term: $event }, false, true)")
-    h3.pb-1.px-2 {{ selectedFilter.label }}
+    h3.pb-1.px-2 {{ isSearch ? numResultMsg : selectedFilter.label }}
       pagination([pageObj]="pagination", (goToPage)="goToPage($event)", [right]="true")
     h3.pb-1.px-2(*ngIf="_tagFilters.selectedFilters.length>0") Tags:
       .filter.filter--aboveGroup(*ngFor="let tag of _tagFilters.selectedFilters", (click)="tag.selected = !tag.selected", [class.active]="tag.selected")

--- a/src/app/browse-page/browse-groups/groups.component.pug
+++ b/src/app/browse-page/browse-groups/groups.component.pug
@@ -32,7 +32,7 @@
 .row.has-icon-overlay(*ngIf="loading")
   i.icon-lg.icon-overlay--top.icon-loading-large
 // Don't show this if there is a filters list, if it's loading, or if the user hasn't searched for anything yet
-.alert.alert-info(*ngIf="tags.length < 1 && !loading")
+.alert.alert-info(*ngIf="!isSearch && tags.length < 1 && !loading")
   h3 {{ 'BROWSE.ERRORS.NO_GROUPS_COLLECTIONS_HEADING' | translate }}
   br
   div(*ngIf="selectedFilter && selectedFilter.level === 'created'", [innerHtml]="'BROWSE.ERRORS.NO_PRIVATE_GROUPS_COLLECTIONS_PROMPT' | translate")

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -25,6 +25,8 @@ export class BrowseGroupsComponent implements OnInit {
   private loading: boolean = true
   private showCardView: boolean = false
   private showAccessDeniedModal: boolean = false
+  private isSearch: boolean = false
+  private numResultMsg: string = ''
 
   private pagination: {
     totalPages: number,
@@ -149,10 +151,12 @@ export class BrowseGroupsComponent implements OnInit {
 
       // set the term every time there is one in the url
       if (query.term) {
+        this.isSearch = true
         this.searchTerm = query.term
         groupQuery.term = query.term
         this.updateSearchTerm.emit(query.term) // sets the term in the search box
       } else {
+        this.isSearch = false
         this.updateSearchTerm.emit('')
       }
 
@@ -294,6 +298,18 @@ export class BrowseGroupsComponent implements OnInit {
     .take(1)
     .subscribe(
       (data)  => {
+        if (data.total !== 0){
+          if (this.pagination.size < data.total) {
+            this.numResultMsg = 'Showing ' + this.pagination.size + ' of ' + data.total + ' results for \"' + this.searchTerm + '\"'
+          }
+          else {
+            this.numResultMsg = 'Showing ' + data.total + ' of ' + data.total + ' results for \"' + this.searchTerm + '\"'
+          }
+        }
+        else {
+          this.numResultMsg = '0 results to show for \"' + this.searchTerm + '\"'
+        }
+        
         this.pagination.page = groupQuery.page
         this.pagination.totalPages = Math.ceil(data.total/this.pagination.size) // update pagination, which is injected into pagination component
         if (this.pagination.page > this.pagination.totalPages && data.total > 0) {

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -312,6 +312,8 @@ export class BrowseGroupsComponent implements OnInit {
         
         this.pagination.page = groupQuery.page
         this.pagination.totalPages = Math.ceil(data.total/this.pagination.size) // update pagination, which is injected into pagination component
+        if (this.pagination.totalPages === 0) // The pagination should at least have one page even if there is no results, so that we don't show '1 of 0' on the pagination
+          this.pagination.totalPages = 1 
         if (this.pagination.page > this.pagination.totalPages && data.total > 0) {
           return this.goToPage(this.pagination.totalPages) // go to the last results page if they try to navigate to a page that is more than results
         }


### PR DESCRIPTION
 - Display number of search results when we search
 - Remove the alert saying the user doesn't have image group when search
 - Fix pagination so that we don't show "1 of 0" when there is no search result