### PR TITLE
Air 1755

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,8 @@
           (initPath.indexOf('/library/ExternalIV.jsp') > -1
           || initPath.indexOf('/library/secure/ViewImages') > -1
           || initPath.indexOf('.org/library/collection') > -1
-          || initPath.indexOf('.org/library/welcome.html') > -1
+          // || initPath.indexOf('.org/library/welcome.html') > -1
+          || initPath.indexOf('/library/welcome.html') > -1 // To cater for legacy links via both proxy and without proxy
           || initPath.indexOf('.org/library/#') > -1
           || initPath.indexOf('/asset/') > -1
           || initPath.indexOf('/assetprint/') > -1


### PR DESCRIPTION
Redirect issue on artstor.org curriculum guides - Check proxy URL pattern as well while evaluating `initPath`.