### PR TITLE
AIR-1772 (Handle cases when owner name and owner id for image groups doesn't exist)

### DIFF
--- a/src/app/browse-page/card-view/card-view.component.pug
+++ b/src/app/browse-page/card-view/card-view.component.pug
@@ -15,10 +15,10 @@
             a(id="tagItem{{ tag.tagId }}Open", [ngClass]="{ 'no-link' : linkRoute.length < 1 || !tag.canOpen }", [routerLink]="[ linkRoute, tag.tagId, { 'browseType': browseType } ]")
               span.font-weight-bold.notranslate {{ tag.title }}
           .value.mobile--hide#description([innerHtml]="description")
-          //p.mobile--hide This is the description that I don't have.
           .row.mobile--show#information-row
               span.font-weight-bold Creator:&nbsp;
-              span {{ group.owner_name }}
+              span.link(*ngIf="group.owner_name", (click)="searchOwner(group)") {{  group.owner_name }}
+              span(*ngIf="!group.owner_name") -
         .col-sm-4.mobile--hide#no-padding-left
           .row#information-row
             .col-sm-6
@@ -30,7 +30,8 @@
             .col-sm-6
               p.font-weight-bold Creator:
             .col-sm-6
-              p.link((click)="searchOwner(group)") {{ group.owner_name }}
+              p.link(*ngIf="group.owner_name", (click)="searchOwner(group)") {{  group.owner_name }}
+              p(*ngIf="!group.owner_name") -
           .row#information-row
             .col-sm-6
               p.font-weight-bold Type:
@@ -41,5 +42,4 @@
           ul.list-inline
             li.list-inline-item(*ngFor="let tag of group.tags")
               a.tag-link.font-weight-bold((click)="selectTag(tag)") {{ tag }}
-              //span(style="background-color:white;") &nbsp;
 

--- a/src/app/browse-page/card-view/card-view.component.ts
+++ b/src/app/browse-page/card-view/card-view.component.ts
@@ -54,7 +54,9 @@ export class CardViewComponent implements OnInit {
         this.groupType = 'Artstor Curated'
       }
       // If I am the owner of the image group, group_type 100 means I make it to be private, group_type 200 means I make it to be institutional
-      else if (this.group.owner_id === this._auth.getUser().baseProfileId.toString()) {
+      // Some of the groups have multiple owners, so there is possibility that the owner_id is not equal to baseProfileId but it is still my group.
+      // To prevent it to be showed as "Shared with Me", as long as on created level, show either "Private" or "Shared"
+      else if (this.browseLevel === 'created' || this.group.owner_id === this._auth.getUser().baseProfileId.toString()) {
         if (this.group.group_type && this.group.group_type === 100) {
           this.groupType = 'Private'
         }


### PR DESCRIPTION
 - When there is no group owner name, show '-' as creator and make it not linkable
 - On level=created, don't rely on if the owner_id=profileId to check group type. Since on level=created, everything returned by the group call will be my group, I only need to check group_type of 100 or 200. I I add this logic to the code so that the group type will be correct even if I don't have owner id.
 - Did some clear up, and made creator clickable on mobile.