### PR TITLE
Air 1761: Allow group owner to remove deleted assets

### DIFF
--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -75,12 +75,11 @@
       //- Error Row
       div
         //- Restricted assets warning message
-        .alert.alert-warning(*ngIf="rstd_imgs")
+        .alert.alert-warning(*ngIf="restricted_results && restricted_results.length > 0")
           | {{ "BROWSE.WARNINGS.RSTD_IMGS" | translate }}
-          br
-          br
-          div.mt-2 As the <b>Owner</b> of this group, would you like to remove the deleted images?
-          a.mt-1.btn.btn-secondary.btn-sm.float-right(tabindex="0") Remove deleted images
+          ng-container(*ngIf="ig.owner_id == user.baseProfileId")
+            div.mt-4 As the <b>Owner</b> of this group, would you like to remove the deleted images?
+            a.mt-2.btn.btn-secondary.btn-sm(tabindex="0", (click)="removeFromGroup(restricted_results)") Remove deleted images
         .alert.alert-warning(*ngIf="!isLoading && (totalAssets == '0') && (!results || results.length < 1) && (searchError.length < 1) && !searchLimitError")
           b Unable to find any assets
           br

--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -77,6 +77,10 @@
         //- Restricted assets warning message
         .alert.alert-warning(*ngIf="rstd_imgs")
           | {{ "BROWSE.WARNINGS.RSTD_IMGS" | translate }}
+          br
+          br
+          div.mt-2 As the <b>Owner</b> of this group, would you like to remove the deleted images?
+          a.mt-1.btn.btn-secondary.btn-sm.float-right(tabindex="0") Remove deleted images
         .alert.alert-warning(*ngIf="!isLoading && (totalAssets == '0') && (!results || results.length < 1) && (searchError.length < 1) && !searchLimitError")
           b Unable to find any assets
           br

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -64,7 +64,7 @@ export class AssetGrid implements OnInit, OnDestroy {
   private isPartialPage: boolean = false;
 
   // Flag to check if the results have any restricted images.
-  private rstd_imgs: boolean = false;
+  private restricted_results: any[] = [];
 
   private excludedAssetsCount: number = 0;
   private sortByDateTotal: number = 0;
@@ -323,7 +323,7 @@ export class AssetGrid implements OnInit, OnDestroy {
             this.itemIds = allResults.items
             this.ig = allResults
           }
-          this.rstd_imgs = allResults.rstd_imgs_count && (allResults.rstd_imgs_count > 0) ? true : false
+          this.restricted_results = allResults.restricted_thumbnails
 
           if (this.results && this.results.length > 0) {
             this.isLoading = false;
@@ -701,4 +701,24 @@ export class AssetGrid implements OnInit, OnDestroy {
     this._renderer.setElementClass(event.target.parentElement, 'show-box', false);
   }
 
+  /**
+   * Remove Assets from a Group
+   * - Owner of Group only
+   */
+  private removeFromGroup(assetsToRemove: Thumbnail[], clearRestricted?: boolean): void {
+    for(let i = 0; i < assetsToRemove.length; i++) {
+      let assetId = assetsToRemove[i].objectId
+      this.ig.items.splice(this.ig.items.indexOf(assetId), 1)
+    }
+    // Save removal to Group
+    this._groups.update(this.ig)
+      .take(1)
+      .subscribe(
+        data => {
+          // Reload group after removing assets
+          window.location.reload()
+        }, error => {
+          console.error(error);
+        });
+  }
 }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -233,7 +233,7 @@ export class AssetPage implements OnInit, OnDestroy {
                     this.assetIdProperty = (allResults.thumbnails[0] && allResults.thumbnails[0].objectId) ? 'objectId' : 'artstorid'
 
                     this.prevAssetResults.thumbnails = allResults.thumbnails
-                    this.restrictedAssetsCount = allResults.rstd_imgs_count && (allResults.rstd_imgs_count > 0) ? allResults.rstd_imgs_count : 0
+                    this.restrictedAssetsCount = allResults.restricted_thumbnails.length
                     if (this.loadArrayFirstAsset) {
                         this.loadArrayFirstAsset = false;
                         if ((this.prevAssetResults) && (this.prevAssetResults.thumbnails.length > 0)) {

--- a/src/app/shared/assets.service.ts
+++ b/src/app/shared/assets.service.ts
@@ -174,17 +174,19 @@ export class AssetService {
         this.paginationSource.next(paginationValue);
 
         /**
-         * Include only availble assets to the resultsObj thumbnails array, Also keep the count for the restricted assets
+         * Include only availble assets to the resultsObj thumbnails array, set aside restricted assets
          */
         if (resultObj.thumbnails){
-            let thumbnailsOrignalLength: number = resultObj.thumbnails.length
+            // let thumbnailsOrignalLength: number = resultObj.thumbnails.length
+            resultObj['restricted_thumbnails'] = []
             resultObj.thumbnails = resultObj.thumbnails.filter( thumbnail => {
-                let assetAvailable: boolean = thumbnail.status === 'not-available' ? false : true
-                return assetAvailable
+                if (thumbnail.status === 'not-available') {
+                    resultObj['restricted_thumbnails'].push(thumbnail)
+                    return false
+                } else {
+                    return true
+                }
             })
-            if (thumbnailsOrignalLength > resultObj.thumbnails.length){
-                resultObj['rstd_imgs_count'] = thumbnailsOrignalLength - resultObj.thumbnails.length
-            }
         }
         // Update results thumbnail array
         this.allResultsValue = resultObj;


### PR DESCRIPTION
To recreate:
- Upload PC assets
- Add PC assets to your own group
- Delete one of the PC assets
- Open group, and see restricted images message
- You can now "Remove" deleted assets, and clear the alert