### PR TITLE
AIR-1749

### DIFF
--- a/src/app/browse-page/browse-groups/general-search.component.pug
+++ b/src/app/browse-page/browse-groups/general-search.component.pug
@@ -1,6 +1,6 @@
 .form-group
   .input-group
     //- the .driver-find-inputbox class is important for the tour to find it, be careful when removing or changing it
-    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup.enter)="executeSearch.emit(term)", aria-describedby="search-label", type="text", placeholder="Search", data-sc="search: simple keyword")
+    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup.enter)="executeSearch.emit(term)", aria-describedby="search-label", type="text", placeholder="Search for groups by title...", data-sc="search: simple keyword")
     i#iconClearSearch.icon.icon-close.form-control__icon(*ngIf="term && !loadingGrps", (click)="term=''; clearGrpSearch.emit()", placement="bottom", ngbTooltip="clear search")
     i#iconSearchSubmit.icon.icon-search.form-control__icon(*ngIf="!term", (click)="executeSearch.emit(term)")


### PR DESCRIPTION
 - Update ang-general-search placeholder
 - The component ang-general-search is only used for image group search so I just change the placeholder directly instead of passing an input from the group page