### PR TITLE
Fix citation slash mistake

### DIFF
--- a/src/app/modals/generate-citation/generate-citation.component.ts
+++ b/src/app/modals/generate-citation/generate-citation.component.ts
@@ -49,9 +49,9 @@ export class GenerateCitation implements OnInit {
 
     let assetPath
     if (window.location.host.indexOf('localhost:') > -1) {
-      assetPath = '/#/asset/'
+      assetPath = '#/asset/'
     } else {
-      assetPath = '/asset/'
+      assetPath = 'asset/'
     }
 
     // Note: The request protocol is added to ADA, and Chicago citations, but not MLA


### PR DESCRIPTION
The previous changes to to citation.component would output citation urls like:
library.artstor.org//asset/MMA_IAP_1039652085

This fixes the double `//`