### PR TITLE
Air-1742 (Error message for empty search query)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,7 +22,7 @@ import { ScriptService, FlagService } from './shared';
   template: `
     <ang-sky-banner *ngIf="showSkyBanner" [textValue]="skyBannerCopy" (closeBanner)="showSkyBanner = false"></ang-sky-banner>
     <div id="skip" tabindex="-1" aria-activedescendant="button">
-      <button id="button" (click)="findMainContent()" (keydown.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
+      <button id="button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
     </div>
     <nav-bar tabindex="-1"></nav-bar>
 
@@ -141,20 +141,23 @@ export class App {
   }
 
   private findMainContent(): void {
-    let htmlelement: HTMLElement = document.getElementById('mainContent');
-    let element: Element;
-    // On log in page, go to log in box
-    if (htmlelement.querySelector('form div input')){
-      element = htmlelement.querySelector('form div input');
-    }
-    // On any page that has search bar, go to search box
-    else if (htmlelement.querySelector('div input')){
-      element = htmlelement.querySelector('div input');
-    }
-    // On asset page, go to the container that contains the item details
-    else {
-      element = htmlelement;
-    }
-    (<HTMLElement>element).focus();
+    window.setTimeout(function ()
+    {
+      let htmlelement: HTMLElement = document.getElementById('mainContent');
+      let element: Element;
+      // On log in page, go to log in box
+      if (htmlelement.querySelector('form div input')){
+        element = htmlelement.querySelector('form div input');
+      }
+      // On any page that has search bar, go to search box
+      else if (htmlelement.querySelector('div input')){
+        element = htmlelement.querySelector('div input');
+      }
+      // On asset page, go to the container that contains the item details
+      else {
+        element = htmlelement;
+      }
+      (<HTMLElement>element).focus();
+    }, 100);
   }
 }

--- a/src/app/browse-page/browse-groups/general-search.component.pug
+++ b/src/app/browse-page/browse-groups/general-search.component.pug
@@ -1,6 +1,7 @@
 .form-group
   .input-group
     //- the .driver-find-inputbox class is important for the tour to find it, be careful when removing or changing it
-    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup.enter)="executeSearch.emit(term)", aria-describedby="search-label", type="text", placeholder="Search for groups by title...", data-sc="search: simple keyword")
+    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup)="startSearch=false;", (keyup.enter)="startSearch=true; executeSearch.emit(term); setFocus();", aria-describedby="search-label", type="text", placeholder="Search for groups by title...", data-sc="search: simple keyword")
     i#iconClearSearch.icon.icon-close.form-control__icon(*ngIf="term && !loadingGrps", (click)="term=''; clearGrpSearch.emit()", placement="bottom", ngbTooltip="clear search")
-    i#iconSearchSubmit.icon.icon-search.form-control__icon(*ngIf="!term", (click)="executeSearch.emit(term)")
+    i#iconSearchSubmit.icon.icon-search.form-control__icon(*ngIf="!term", (click)="startSearch=true; executeSearch.emit(term); setFocus();")
+  .alert.alert-info#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).

--- a/src/app/browse-page/browse-groups/general-search.component.pug
+++ b/src/app/browse-page/browse-groups/general-search.component.pug
@@ -4,4 +4,4 @@
     input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup)="startSearch=false;", (keyup.enter)="startSearch=true; executeSearch.emit(term); setFocus();", aria-describedby="search-label", type="text", placeholder="Search for groups by title...", data-sc="search: simple keyword")
     i#iconClearSearch.icon.icon-close.form-control__icon(*ngIf="term && !loadingGrps", (click)="term=''; clearGrpSearch.emit()", placement="bottom", ngbTooltip="clear search")
     i#iconSearchSubmit.icon.icon-search.form-control__icon(*ngIf="!term", (click)="startSearch=true; executeSearch.emit(term); setFocus();")
-  .alert.alert-info#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).
+  .alert.alert-warning#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).

--- a/src/app/browse-page/browse-groups/general-search.component.pug
+++ b/src/app/browse-page/browse-groups/general-search.component.pug
@@ -1,6 +1,6 @@
 .form-group
   .input-group
     //- the .driver-find-inputbox class is important for the tour to find it, be careful when removing or changing it
-    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup.enter)="executeSearch.emit(term)", aria-describedby="search-label", type="text", placeholder="Search", data-sc="search: simple keyword")
+    input#inputSearchTerm.form-control.has-icon.driver-find-inputbox([(ngModel)]="term", (keyup.enter)="executeSearch.emit(term)", aria-describedby="search-label", type="text", placeholder="Search for groups by title...", data-sc="search: simple keyword")
     i#iconClearSearch.icon.icon-close.form-control__icon(*ngIf="term && !loadingGrps", (click)="term=''; clearGrpSearch.emit()", placement="bottom", ngbTooltip="clear search")
     i#iconSearchSubmit.icon.icon-search.form-control__icon(*ngIf="!term", (click)="executeSearch.emit(term)")

--- a/src/app/browse-page/browse-groups/general-search.component.ts
+++ b/src/app/browse-page/browse-groups/general-search.component.ts
@@ -18,6 +18,7 @@ export class GeneralSearchComponent implements OnInit {
 
   // the term that will be searched for
   private term: string = ''
+  private startSearch: boolean = false
 
   constructor() { }
 
@@ -31,6 +32,14 @@ export class GeneralSearchComponent implements OnInit {
         })
       )
     }
+  }
+
+  private setFocus() : void {
+    window.setTimeout(function () {
+      if (document.getElementById('empty-search-alert')){
+        document.getElementById('empty-search-alert').focus()
+      }    
+    }, 110);  
   }
 
 }

--- a/src/app/browse-page/browse-page.component.pug
+++ b/src/app/browse-page/browse-page.component.pug
@@ -1,5 +1,6 @@
-nav-menu
-#mainContent.container.main-content(tabindex="-1")
-  nav.nav.nav-inline.coll-nav
-    a.nav-link(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)") {{ colOpt.label }}
-  router-outlet
+.voiceover-fix-wrap
+  nav-menu
+  #mainContent.container.main-content(tabindex="-1")
+    nav.nav.nav-inline.coll-nav
+      a.nav-link(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)") {{ colOpt.label }}
+    router-outlet

--- a/src/app/shared/search/search.component.pug
+++ b/src/app/shared/search/search.component.pug
@@ -8,6 +8,6 @@
       input#searchInResChkBx(type="checkbox", [(ngModel)]="searchInResults",  (ngModelChange)="onSearchWithinChange($event)")
       = " "
       label(for="searchInResChkBx") Search within {{ nestedSrchLbl }}
-    .alert.alert-info#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).
+    .alert.alert-warning#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).
 a.link.small.open-modal((click)="showSearchModal = true", tabindex="0") {{ 'HOME.LINKS.ADVNC_SRCH' | translate}}
 ang-search-modal(*ngIf="showSearchModal", (closeModal)="showSearchModal = false")

--- a/src/app/shared/search/search.component.pug
+++ b/src/app/shared/search/search.component.pug
@@ -8,6 +8,6 @@
       input#searchInResChkBx(type="checkbox", [(ngModel)]="searchInResults",  (ngModelChange)="onSearchWithinChange($event)")
       = " "
       label(for="searchInResChkBx") Search within {{ nestedSrchLbl }}
-    .alert.alert-warning#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).
+    .alert.alert-warning#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert", style="width:100%;") Please enter search term(s).
 a.link.small.open-modal((click)="showSearchModal = true", tabindex="0") {{ 'HOME.LINKS.ADVNC_SRCH' | translate}}
 ang-search-modal(*ngIf="showSearchModal", (closeModal)="showSearchModal = false")

--- a/src/app/shared/search/search.component.pug
+++ b/src/app/shared/search/search.component.pug
@@ -1,12 +1,13 @@
 .search-wrap
   .form-group.row
     .input-group([ngClass]="{'col-md-7': allowSearchInRes}")
-      input#inputSearchTerm.form-control.has-icon(*ngIf="!UserNotLoggedIn", [(ngModel)]="term", (keyup.enter)="updateSearchTerm(term)", aria-describedby="search-label", type="text", placeholder="Search", data-sc="search: simple keyword")
-      input#inputSearchTerm.form-control.has-icon(*ngIf="UserNotLoggedIn", [(ngModel)]="term", (keyup.enter)="updateSearchTerm(term)", aria-describedby="search-label", type="text", placeholder="Search Public Collections", data-sc="search: simple keyword")
-      i#iconSearchSubmit.icon.icon-search.form-control__icon((click)="updateSearchTerm(term)")
+      input#inputSearchTerm.form-control.has-icon(*ngIf="!UserNotLoggedIn", [(ngModel)]="term", (keyup)="startSearch=false;", (keyup.enter)="startSearch=true; updateSearchTerm(term); setFocus();", aria-describedby="search-label", type="text", placeholder="Search", data-sc="search: simple keyword")
+      input#inputSearchTerm.form-control.has-icon(*ngIf="UserNotLoggedIn", [(ngModel)]="term", (keyup)="startSearch=false;", (keyup.enter)="startSearch=true; updateSearchTerm(term); setFocus();", aria-describedby="search-label", type="text", placeholder="Search Public Collections", data-sc="search: simple keyword")
+      i#iconSearchSubmit.icon.icon-search.form-control__icon((click)="startSearch=true; updateSearchTerm(term); setFocus();")
     .search-in-results.col-md-5.hidden-sm-down(*ngIf="allowSearchInRes")
       input#searchInResChkBx(type="checkbox", [(ngModel)]="searchInResults",  (ngModelChange)="onSearchWithinChange($event)")
       = " "
       label(for="searchInResChkBx") Search within {{ nestedSrchLbl }}
+    .alert.alert-info#empty-search-alert([class.hidden]="term || !startSearch", tabindex="0", role="alert", aria-label="no search term alert") Please enter search term(s).
 a.link.small.open-modal((click)="showSearchModal = true", tabindex="0") {{ 'HOME.LINKS.ADVNC_SRCH' | translate}}
 ang-search-modal(*ngIf="showSearchModal", (closeModal)="showSearchModal = false")

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -20,6 +20,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 
   private showSearchModal: boolean = false;
   private term: string;
+  private startSearch: boolean = false
 
   private size: number = 24;
 
@@ -181,5 +182,13 @@ export class SearchComponent implements OnInit, OnDestroy {
    */
   private onSearchWithinChange(value: boolean): void{
     this._filters.searchWithin = value
+  }
+
+  private setFocus() : void {
+    window.setTimeout(function () {
+      if (document.getElementById('empty-search-alert')){
+        document.getElementById('empty-search-alert').focus()
+      }    
+    }, 110);  
   }
 }

--- a/src/sass/modules/_alerts.scss
+++ b/src/sass/modules/_alerts.scss
@@ -1,6 +1,13 @@
 
 $infoColor: $blue;
 
+/**
+ * @atom Alert Warning
+ * @section Alerts
+ * @markup
+ *  <div aria-label="no search term alert" class="alert alert-warning" id="empty-search-alert" role="alert" tabindex="0">Please enter search term(s).</div>
+ */
+
 .alert {
     @extend %SansRegular;
     font-size: 12px;
@@ -21,6 +28,13 @@ $infoColor: $blue;
     }
 }
 
+
+/**
+ * @atom Alert Info
+ * @section Alerts
+ * @markup
+ *  <div aria-label="no search term alert" class="alert alert-info" id="empty-search-alert" role="alert" tabindex="0">Please enter search term(s).</div>
+ */
 .alert-info {
     border-color: $infoColor;
     color: $infoColor;

--- a/src/sass/modules/_styleguide.scss
+++ b/src/sass/modules/_styleguide.scss
@@ -186,5 +186,3 @@ $navBarPad: 0.5rem;
         margin-bottom: 13px;
     }
 }
-
-


### PR DESCRIPTION
 - Show error message for image group page, search page, home page
 - Set focus on the error message whenever there is error message
 - Set aria label to the error message

Note: Current the Voiceover is not read anything below the nav bar, so it is not reading the error message.