### PR TITLE
Air-1799

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -351,12 +351,12 @@ export class AssetGrid implements OnInit, OnDestroy {
           // Tie prevRouteParams array with previousRouteTS (time stamp) before sending to asset page
           this.prevRouteTS = Date.now().toString()
           let id: string = this.prevRouteTS
-          
+
           let prevRouteParams = this._session.get('prevRouteParams') || {}
           prevRouteParams[id] = this.route.snapshot.url
           this._session.set('prevRouteParams', prevRouteParams)
 
-          //Generate Facets
+          // Generate Facets
           if (allResults && allResults.collTypeFacets) {
               this._filters.generateColTypeFacets( allResults.collTypeFacets );
               // this._filters.generateGeoFilters( allResults.geographyFacets );
@@ -491,7 +491,7 @@ export class AssetGrid implements OnInit, OnDestroy {
    */
 
   private selectAsset(asset, event?): void {
-    if(this.editMode){
+    if (this.editMode){
       event && event.preventDefault()
       let index: number = this.isSelectedAsset(asset)
       if (index > -1){
@@ -715,7 +715,7 @@ export class AssetGrid implements OnInit, OnDestroy {
    * - Owner of Group only
    */
   private removeFromGroup(assetsToRemove: Thumbnail[], clearRestricted?: boolean): void {
-    for(let i = 0; i < assetsToRemove.length; i++) {
+    for (let i = 0; i < assetsToRemove.length; i++) {
       let assetId = assetsToRemove[i].objectId
       this.ig.items.splice(this.ig.items.indexOf(assetId), 1)
     }

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -348,13 +348,9 @@ export class AssetGrid implements OnInit, OnDestroy {
 
           this._session.set('totalAssets', this.totalAssets ? this.totalAssets : 1)
 
-          // Tie prevRouteParams array with requestId before sending to asset page
-          let id: string = this._search.latestSearchRequestId ? this._search.latestSearchRequestId.toString() : 'undefined'
-          // Incase of an image group save the prevRouteParams, with the timestamp as key, in sessionStorage
-          if(this.ig.id && id === 'undefined'){
-            this.prevRouteTS = Date.now().toString()
-            id = this.prevRouteTS
-          }
+          // Tie prevRouteParams array with previousRouteTS (time stamp) before sending to asset page
+          this.prevRouteTS = Date.now().toString()
+          let id: string = this.prevRouteTS
           
           let prevRouteParams = this._session.get('prevRouteParams') || {}
           prevRouteParams[id] = this.route.snapshot.url
@@ -513,15 +509,11 @@ export class AssetGrid implements OnInit, OnDestroy {
   private constructNavigationCommands (thumbnail: Thumbnail) {
     let assetId = thumbnail.objectId ? thumbnail.objectId : thumbnail.artstorid
     let params: any = {
-      requestId: this._search.latestSearchRequestId
+      requestId: this._search.latestSearchRequestId,
+      prevRouteTS: this.prevRouteTS // for fetching previous route params from session storage, on asset page
     }
     thumbnail.iap && (params.iap = 'true')
-    // this.ig && this.ig.id && (params.groupId = this.ig.id)
-
-    if(this.ig && this.ig.id){
-      params.groupId = this.ig.id
-      params.prevRouteTS = this.prevRouteTS
-    }
+    this.ig && this.ig.id && (params.groupId = this.ig.id)
 
     let url = ['/#/asset', assetId].join('/')
     for (let key in params) {

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -509,7 +509,6 @@ export class AssetGrid implements OnInit, OnDestroy {
   private constructNavigationCommands (thumbnail: Thumbnail) {
     let assetId = thumbnail.objectId ? thumbnail.objectId : thumbnail.artstorid
     let params: any = {
-      requestId: this._search.latestSearchRequestId,
       prevRouteTS: this.prevRouteTS // for fetching previous route params from session storage, on asset page
     }
     thumbnail.iap && (params.iap = 'true')

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -145,6 +145,9 @@ export class AssetGrid implements OnInit, OnDestroy {
   // Image group
   private ig: any = {};
 
+  // Used as a key to save the previous route params in session storage (incase of image group)
+  private prevRouteTS: string = ''
+
   private _storage;
   private _session;
 
@@ -347,6 +350,12 @@ export class AssetGrid implements OnInit, OnDestroy {
 
           // Tie prevRouteParams array with requestId before sending to asset page
           let id: string = this._search.latestSearchRequestId ? this._search.latestSearchRequestId.toString() : 'undefined'
+          // Incase of an image group save the prevRouteParams, with the timestamp as key, in sessionStorage
+          if(this.ig.id && id === 'undefined'){
+            this.prevRouteTS = Date.now().toString()
+            id = this.prevRouteTS
+          }
+          
           let prevRouteParams = this._session.get('prevRouteParams') || {}
           prevRouteParams[id] = this.route.snapshot.url
           this._session.set('prevRouteParams', prevRouteParams)
@@ -507,7 +516,12 @@ export class AssetGrid implements OnInit, OnDestroy {
       requestId: this._search.latestSearchRequestId
     }
     thumbnail.iap && (params.iap = 'true')
-    this.ig && this.ig.id && (params.groupId = this.ig.id)
+    // this.ig && this.ig.id && (params.groupId = this.ig.id)
+
+    if(this.ig && this.ig.id){
+      params.groupId = this.ig.id
+      params.prevRouteTS = this.prevRouteTS
+    }
 
     let url = ['/#/asset', assetId].join('/')
     for (let key in params) {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -319,13 +319,17 @@ export class AssetPage implements OnInit, OnDestroy {
                     // Set image share link
                     this.generateImgURL(this.assetIds[0])
                 }
+                
+                // Set requestId for logging purposes
+                if(routeParams['requestId']){
+                    this.requestId = routeParams['requestId']
+                }
 
-                // For "Go Back to Results" and pagination, for asset that is not from image group look for requestId to set prevRouteParams
-                if (routeParams['requestId'] || routeParams['groupId'] || routeParams['prevRouteTS']) {
+                // For "Back to Results" link and pagination, look for prevRouteTS to set prevRouteParams
+                if (routeParams['prevRouteTS']) {
                     // For "Go Back to Results"
                     // Get map of previous search params
                     let prevRoutesMap = this._session.get('prevRouteParams')
-                    this.requestId = routeParams['requestId']
 
                     // Reference previous search params for the prevRouteTS
                     let prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -326,8 +326,15 @@ export class AssetPage implements OnInit, OnDestroy {
                     // Get map of previous search params
                     let prevRoutesMap = this._session.get('prevRouteParams')
                     this.requestId = routeParams['requestId']
-                    // Reference previous search params for the current request id
-                    let prevRouteParams = prevRoutesMap[this.requestId]
+                    
+                    let prevRouteParams: any[] = []
+                    // For image groups use the prevRouteTS to fetch the search params from session storage
+                    if(routeParams['groupId']) {
+                        prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]
+                    } else { // Reference previous search params for the current request id
+                        prevRouteParams = prevRoutesMap[this.requestId]
+                    }
+
                     // Set previous route params if available, showing "Back to Results" link
                     if (prevRoutesMap && prevRouteParams && (prevRouteParams.length > 0)) {
                         this.prevRouteParams = prevRouteParams

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -128,8 +128,6 @@ export class AssetPage implements OnInit, OnDestroy {
     private showDeletePCModal: boolean = false
     private downloadLoading: boolean = false
 
-    private requestId: string = ''
-
     private uiMessages: {
         deleteFailure?: boolean
     } = {}
@@ -248,8 +246,6 @@ export class AssetPage implements OnInit, OnDestroy {
                             if (this.assetGroupId) {
                                 queryParams['groupId'] = this.assetGroupId
                             }
-                            // Maintain the requestId route parameter for next page
-                            queryParams['requestId'] = this.requestId
                             this._router.navigate(['/asset', this.prevAssetResults.thumbnails[0][this.assetIdProperty], queryParams]);
                         }
                     }
@@ -267,8 +263,6 @@ export class AssetPage implements OnInit, OnDestroy {
                             if (this.assetGroupId) {
                                 queryParams['groupId'] = this.assetGroupId
                             }
-                            // Maintain the requestId route parameter for previous page
-                            queryParams['requestId'] = this.requestId
                             this._router.navigate(['/asset', this.prevAssetResults.thumbnails[this.prevAssetResults.thumbnails.length - 1][this.assetIdProperty], queryParams]);
                         }
                     }
@@ -318,11 +312,6 @@ export class AssetPage implements OnInit, OnDestroy {
 
                     // Set image share link
                     this.generateImgURL(this.assetIds[0])
-                }
-                
-                // Set requestId for logging purposes
-                if(routeParams['requestId']){
-                    this.requestId = routeParams['requestId']
                 }
 
                 // For "Back to Results" link and pagination, look for prevRouteTS to set prevRouteParams
@@ -571,9 +560,6 @@ export class AssetPage implements OnInit, OnDestroy {
                     queryParams['groupId'] = this.assetGroupId
                 }
 
-                // Maintain the requestId route parameter for previous page
-                queryParams['requestId'] = this.requestId
-
                 this._router.navigate(['/asset', this.prevAssetResults.thumbnails[prevAssetIndex][this.assetIdProperty], queryParams]);
             }
             else if (this.assetIndex == 0) {
@@ -594,9 +580,6 @@ export class AssetPage implements OnInit, OnDestroy {
                 if (this.assetGroupId) {
                     queryParams['groupId'] = this.assetGroupId
                 }
-
-                // Maintain the requestId route parameter for next page
-                queryParams['requestId'] = this.requestId
 
                 this._router.navigate(['/asset', this.prevAssetResults.thumbnails[nextAssetIndex][this.assetIdProperty], queryParams]);
             }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -321,19 +321,14 @@ export class AssetPage implements OnInit, OnDestroy {
                 }
 
                 // For "Go Back to Results" and pagination, for asset that is not from image group look for requestId to set prevRouteParams
-                if (routeParams['requestId'] || routeParams['groupId']) {
+                if (routeParams['requestId'] || routeParams['groupId'] || routeParams['prevRouteTS']) {
                     // For "Go Back to Results"
                     // Get map of previous search params
                     let prevRoutesMap = this._session.get('prevRouteParams')
                     this.requestId = routeParams['requestId']
                     
-                    let prevRouteParams: any[] = []
-                    // For image groups use the prevRouteTS to fetch the search params from session storage
-                    if(routeParams['groupId']) {
-                        prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]
-                    } else { // Reference previous search params for the current request id
-                        prevRouteParams = prevRoutesMap[this.requestId]
-                    }
+                    // Reference previous search params for the prevRouteTS
+                    let prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]
 
                     // Set previous route params if available, showing "Back to Results" link
                     if (prevRoutesMap && prevRouteParams && (prevRouteParams.length > 0)) {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -326,7 +326,7 @@ export class AssetPage implements OnInit, OnDestroy {
                     // Get map of previous search params
                     let prevRoutesMap = this._session.get('prevRouteParams')
                     this.requestId = routeParams['requestId']
-                    
+
                     // Reference previous search params for the prevRouteTS
                     let prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]
 


### PR DESCRIPTION
Fix `Back to Results` link for image group assets. Using `prevRouteTS` to save the previous route params in session storage.