### PR TITLE
Air 1794

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -793,34 +793,34 @@ export class AssetPage implements OnInit, OnDestroy {
         if (retryCount <= 2) {
             // Download generated jpg as local blob file
             let blob = this._search.downloadViewBlob(dlink)
-                .take(1)
-                .subscribe((blob) => {
-                    // Call recursively two more times if Promise blob.size < 7.5kb
-                    if (blob.size < 7500) {
-                        result = false
-                        retryCount += 1
-                        this.runDownloadView(dlink, retryCount)
+              .take(1)
+              .subscribe((blob) => {
+                // Call recursively two more times if Promise blob.size < 7.5kb
+                if (blob.size < 7500) {
+                    result = false
+                    retryCount += 1
+                    this.runDownloadView(dlink, retryCount)
+                }
+                else {
+                    if (this.isMSAgent) {
+                        this.downloadLoading = false
+                        console.log('MSAgent Blob: ', blob)
+                        this.navigator.msSaveBlob(blob, 'download.jpg')
+
                     }
                     else {
-                        if (this.isMSAgent) {
-                            this.downloadLoading = false
-                            console.log('MSAgent Blob: ', blob)
-                            this.navigator.msSaveBlob(blob, 'download.jpg')
-
-                        }
-                        else {
-                            this.blobURL = this.URL.createObjectURL(blob)
-                            this.generatedViewURL = this._sanitizer.bypassSecurityTrustUrl(this.blobURL)
-                        }
-                        this.downloadLoading = false
-                        result = true
+                        this.blobURL = this.URL.createObjectURL(blob)
+                        this.generatedViewURL = this._sanitizer.bypassSecurityTrustUrl(this.blobURL)
                     }
-                }, (err) => {
-                    console.error('Error returning generated download view', err)
-                    result = false
                     this.downloadLoading = false
-                    this.showServerErrorModal = true
-                })
+                    result = true
+                }
+            }, (err) => {
+                console.error('Error returning generated download view', err)
+                result = false
+                this.downloadLoading = false
+                this.showServerErrorModal = true
+            })
         }
 
         return result
@@ -842,8 +842,8 @@ export class AssetPage implements OnInit, OnDestroy {
         // Revoke the browser reference to a previously generated view download blob URL
         if (this.blobURL.length) {
             this.URL.revokeObjectURL(this.blobURL)
-            this.blobURL = ''
-            this.generatedViewURL = ''
+            //this.blobURL = ''
+            //this.generatedViewURL = ''
         }
 
         if (asset.typeName === 'image' && asset.viewportDimensions.contentSize) {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -832,8 +832,6 @@ export class AssetPage implements OnInit, OnDestroy {
         // Revoke the browser reference to a previously generated view download blob URL
         if (this.blobURL.length) {
             this.URL.revokeObjectURL(this.blobURL)
-            //this.blobURL = ''
-            //this.generatedViewURL = ''
         }
 
         if (asset.typeName === 'image' && asset.viewportDimensions.contentSize) {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -787,43 +787,33 @@ export class AssetPage implements OnInit, OnDestroy {
      * @param dlink String from generateDownloadView
      * @param retryCount Number, tracks recursive calls of this function for download tries
      */
-    private runDownloadView(dlink: string, retryCount: number): boolean {
-        let result: boolean = false
+    private runDownloadView(dlink: string): boolean {
+      let result: boolean = false
 
-        if (retryCount <= 2) {
-            // Download generated jpg as local blob file
-            let blob = this._search.downloadViewBlob(dlink)
-              .take(1)
-              .subscribe((blob) => {
-                // Call recursively two more times if Promise blob.size < 7.5kb
-                if (blob.size < 7500) {
-                    result = false
-                    retryCount += 1
-                    this.runDownloadView(dlink, retryCount)
-                }
-                else {
-                    if (this.isMSAgent) {
-                        this.downloadLoading = false
-                        console.log('MSAgent Blob: ', blob)
-                        this.navigator.msSaveBlob(blob, 'download.jpg')
+      // Download generated jpg as local blob file
+      let blob = this._search.downloadViewBlob(dlink)
+        .take(1)
+        .subscribe((blob) => {
 
-                    }
-                    else {
-                        this.blobURL = this.URL.createObjectURL(blob)
-                        this.generatedViewURL = this._sanitizer.bypassSecurityTrustUrl(this.blobURL)
-                    }
-                    this.downloadLoading = false
-                    result = true
-                }
-            }, (err) => {
-                console.error('Error returning generated download view', err)
-                result = false
-                this.downloadLoading = false
-                this.showServerErrorModal = true
-            })
-        }
+          if (blob && blob.size)
+              if (this.isMSAgent) {
+                  this.downloadLoading = false
+                  this.navigator.msSaveBlob(blob, 'download.jpg')
+              }
+              else {
+                  this.blobURL = this.URL.createObjectURL(blob)
+                  this.generatedViewURL = this._sanitizer.bypassSecurityTrustUrl(this.blobURL)
+              }
+              this.downloadLoading = false
+              result = true
+          },
+          (err) => {
+            result = false
+            this.downloadLoading = false
+            this.showServerErrorModal = true
+          })
 
-        return result
+      return result
     }
 
     /** Calls downloadViewBlob in AssetSearch service to retrieve blob file,
@@ -873,7 +863,7 @@ export class AssetPage implements OnInit, OnDestroy {
             let downloadLink: string = asset.tileSource.replace('info.json', '') + xOffset + ',' + yOffset + ',' + zoomX + ',' + zoomY + '/' + viewX + ',' + viewY + '/0/native.jpg'
 
             // Call runDownloadView and check for success, tries 3 times.
-            this.runDownloadView(downloadLink, 0)
+            this.runDownloadView(downloadLink)
         }
     }
 

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -860,7 +860,7 @@ export class AssetPage implements OnInit, OnDestroy {
             // Generate the view url from tilemap service
             let downloadLink: string = asset.tileSource.replace('info.json', '') + xOffset + ',' + yOffset + ',' + zoomX + ',' + zoomY + '/' + viewX + ',' + viewY + '/0/native.jpg'
 
-            // Call runDownloadView and check for success, tries 3 times.
+            // Call runDownloadView, downloads local view image blob file to browser
             this.runDownloadView(downloadLink)
         }
     }

--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -11,8 +11,6 @@ import {
 import { AuthService } from './'
 import { AppConfig } from '../app.service'
 import { Observable } from 'rxjs/Observable'
-import { error } from 'util';
-
 @Injectable()
 export class AssetSearchService {
 

--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -53,13 +53,10 @@ export class AssetSearchService {
   public downloadViewBlob(url: string): Observable<any> {
 
     let res: Observable<Blob>
-    if (url.includes('blob')) {
       res = this.http.get(url, {
         responseType: 'blob'
       })
-    // } else {
-    //   return 'failed'
-    }
+
     return res
   }
 

--- a/src/app/shared/asset-search.service.ts
+++ b/src/app/shared/asset-search.service.ts
@@ -11,6 +11,7 @@ import {
 import { AuthService } from './'
 import { AppConfig } from '../app.service'
 import { Observable } from 'rxjs/Observable'
+import { error } from 'util';
 
 @Injectable()
 export class AssetSearchService {
@@ -50,9 +51,16 @@ export class AssetSearchService {
   * @param url - Generated tilemap view url
   */
   public downloadViewBlob(url: string): Observable<any> {
-    return this.http.get(url, {
-      responseType: 'blob'
-    })
+
+    let res: Observable<Blob>
+    if (url.includes('blob')) {
+      res = this.http.get(url, {
+        responseType: 'blob'
+      })
+    // } else {
+    //   return 'failed'
+    }
+    return res
   }
 
   private initQuery(keyword: string, pageSize, startIndex) {


### PR DESCRIPTION
The main change here is removing the retry logic, and not setting downloadLink and generated urls to an empty string.

This work is a small patch to slightly improve reliability of download views, but also in prep for refactoring of how download views is implemented.