### PR TITLE
Air 1794

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -104,7 +104,7 @@
                 [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedViewURL : (isMSAgent ? '#' : null)",
                 (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
                 (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
-                [class.disabled]="assets[0].disableDownload || assets[0].typeName !== 'image'",
+                [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_self",
                 tabindex="8")
                 i.icon.icon-download-black

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -98,7 +98,7 @@
                 target="_blank",
                 tabindex="8")
                 i.icon.icon-download-black
-                | Download File
+                | &nbsp;Download File
               a#downloadViewLink.dropdown-item(download="download.jpg",
                 type="image/jpeg",
                 [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedViewURL : (isMSAgent ? '#' : null)",
@@ -108,7 +108,7 @@
                 target="_self",
                 tabindex="8")
                 i.icon.icon-download-black
-                | Download View
+                | &nbsp;Download View
           //- False door button if user is not logged in
           button#assetpage-btn.btn.btn-secondary(tabindex="9", *ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true")
             | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -79,6 +79,7 @@ export class AssetPage implements OnInit, OnDestroy {
     private generatedImgURL: string = ''
     private generatedViewURL: SafeUrl | string = ''
     private generatedFullURL: string = ''
+    public downloadViewReady: boolean = false
     // Used for agree modal input, changes based on selection
     private downloadUrl: any
     private downloadName: string
@@ -782,18 +783,6 @@ export class AssetPage implements OnInit, OnDestroy {
     }
 
     /**
-     * Set state of downloadViewButton on or off
-     * @param on 1 for enabled, 0 for class .disabled
-     */
-    private setDownloadViewButton(on: Number) {
-      if (on)
-        document.getElementById('downloadViewLink').classList.remove('disabled')
-      else
-        document.getElementById('downloadViewLink').classList.add('disabled')
-    }
-
-
-    /**
      * runDownloadView handles the DownloadView results from AssetSearch.downloadViewBlob
      * @param dlink String from generateDownloadView
      */
@@ -812,11 +801,11 @@ export class AssetPage implements OnInit, OnDestroy {
                   this.generatedViewURL = this._sanitizer.bypassSecurityTrustUrl(this.blobURL)
               }
               this.downloadLoading = false
-              this.setDownloadViewButton(1)
+              this.downloadViewReady = true
           }},
           (err) => {
             this.downloadLoading = false
-            this.setDownloadViewButton(1)
+            this.downloadViewReady = false
             this.showServerErrorModal = true
 
           })
@@ -868,7 +857,7 @@ export class AssetPage implements OnInit, OnDestroy {
             let downloadLink: string = asset.tileSource.replace('info.json', '') + xOffset + ',' + yOffset + ',' + zoomX + ',' + zoomY + '/' + viewX + ',' + viewY + '/0/native.jpg'
 
             // Disable download view link button until file is ready
-            this.setDownloadViewButton(0)
+            this.downloadViewReady = false
 
             // Call runDownloadView after 1 sec, downloads local view image blob file to browser
             setTimeout(() => {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -785,7 +785,6 @@ export class AssetPage implements OnInit, OnDestroy {
     /**
      * runDownloadView handles the DownloadView results from AssetSearch.downloadViewBlob
      * @param dlink String from generateDownloadView
-     * @param retryCount Number, tracks recursive calls of this function for download tries
      */
     private runDownloadView(dlink: string): boolean {
       let result: boolean = false


### PR DESCRIPTION
- Further debugging and refactoring for download view Blob responses
- Adds UI update on the download view button for disabling / enabling the button until the view is ready

-Corrects return type of `runDownloadView` to a Subscription from an `Observable<any>` or a successful response of an `Observable<Blob>`

- Throws away and simplifies prior work on improving this feature. 