### PR TITLE
Air 1799

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -145,6 +145,9 @@ export class AssetGrid implements OnInit, OnDestroy {
   // Image group
   private ig: any = {};
 
+  // Used as a key to save the previous route params in session storage (incase of image group)
+  private prevRouteTS: string = ''
+
   private _storage;
   private _session;
 
@@ -345,8 +348,10 @@ export class AssetGrid implements OnInit, OnDestroy {
 
           this._session.set('totalAssets', this.totalAssets ? this.totalAssets : 1)
 
-          // Tie prevRouteParams array with requestId before sending to asset page
-          let id: string = this._search.latestSearchRequestId ? this._search.latestSearchRequestId.toString() : 'undefined'
+          // Tie prevRouteParams array with previousRouteTS (time stamp) before sending to asset page
+          this.prevRouteTS = Date.now().toString()
+          let id: string = this.prevRouteTS
+          
           let prevRouteParams = this._session.get('prevRouteParams') || {}
           prevRouteParams[id] = this.route.snapshot.url
           this._session.set('prevRouteParams', prevRouteParams)
@@ -504,7 +509,7 @@ export class AssetGrid implements OnInit, OnDestroy {
   private constructNavigationCommands (thumbnail: Thumbnail) {
     let assetId = thumbnail.objectId ? thumbnail.objectId : thumbnail.artstorid
     let params: any = {
-      requestId: this._search.latestSearchRequestId
+      prevRouteTS: this.prevRouteTS // for fetching previous route params from session storage, on asset page
     }
     thumbnail.iap && (params.iap = 'true')
     this.ig && this.ig.id && (params.groupId = this.ig.id)

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -246,6 +246,9 @@ export class AssetPage implements OnInit, OnDestroy {
                             this.assetNumber = this._assets.currentLoadedParams.page ? this.assetIndex + 1 + ((this._assets.currentLoadedParams.page - 1) * this._assets.currentLoadedParams.size) : this.assetIndex + 1;
 
                             let queryParams = {}
+                            if (this.prevRouteTS) {
+                                queryParams['prevRouteTS'] = this.prevRouteTS
+                            }
                             if (this.assetGroupId) {
                                 queryParams['groupId'] = this.assetGroupId
                             }
@@ -263,6 +266,9 @@ export class AssetPage implements OnInit, OnDestroy {
                             this.assetNumber = this._assets.currentLoadedParams.page ? this.assetIndex + 1 + ((this._assets.currentLoadedParams.page - 1) * this._assets.currentLoadedParams.size) : this.assetIndex + 1;
 
                             let queryParams = {}
+                            if (this.prevRouteTS) {
+                                queryParams['prevRouteTS'] = this.prevRouteTS
+                            }
                             if (this.assetGroupId) {
                                 queryParams['groupId'] = this.assetGroupId
                             }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -129,6 +129,8 @@ export class AssetPage implements OnInit, OnDestroy {
     private showDeletePCModal: boolean = false
     private downloadLoading: boolean = false
 
+    private prevRouteTS: string = '' // Used to track the (Timestamp) key for previous route params in session storage
+
     private uiMessages: {
         deleteFailure?: boolean
     } = {}
@@ -317,12 +319,13 @@ export class AssetPage implements OnInit, OnDestroy {
 
                 // For "Back to Results" link and pagination, look for prevRouteTS to set prevRouteParams
                 if (routeParams['prevRouteTS']) {
+                    this.prevRouteTS = routeParams['prevRouteTS']
                     // For "Go Back to Results"
                     // Get map of previous search params
                     let prevRoutesMap = this._session.get('prevRouteParams')
 
                     // Reference previous search params for the prevRouteTS
-                    let prevRouteParams = prevRoutesMap[routeParams['prevRouteTS']]
+                    let prevRouteParams = prevRoutesMap[this.prevRouteTS]
 
                     // Set previous route params if available, showing "Back to Results" link
                     if (prevRoutesMap && prevRouteParams && (prevRouteParams.length > 0)) {
@@ -557,6 +560,9 @@ export class AssetPage implements OnInit, OnDestroy {
             if ((this.assetIndex > 0)) {
                 let prevAssetIndex = this.quizShuffle ? Math.floor(Math.random() * this.prevAssetResults.thumbnails.length) + 0 : this.assetIndex - 1; // Assign random thumbnail index if quiz shuffle is true
                 let queryParams = {}
+                if (this.prevRouteTS) {
+                    queryParams['prevRouteTS'] = this.prevRouteTS
+                }
                 if (this.assetGroupId) {
                     queryParams['groupId'] = this.assetGroupId
                 }
@@ -578,6 +584,9 @@ export class AssetPage implements OnInit, OnDestroy {
             if ((this.prevAssetResults.thumbnails) && (this.assetIndex < (this.prevAssetResults.thumbnails.length - 1))) {
                 let nextAssetIndex = this.quizShuffle ? Math.floor(Math.random() * this.prevAssetResults.thumbnails.length) + 0 : this.assetIndex + 1; // Assign random thumbnail index if quiz shuffle is true
                 let queryParams = {}
+                if (this.prevRouteTS) {
+                    queryParams['prevRouteTS'] = this.prevRouteTS
+                }
                 if (this.assetGroupId) {
                     queryParams['groupId'] = this.assetGroupId
                 }


### PR DESCRIPTION
Pagination fix for asset page. `prevRouteTS` should be passed with next/prev asset URLs.