### PR TITLE
Air 1823: Better messaging when editing an asset

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -203,6 +203,8 @@
                 input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false", tabindex="6")
               .form-group.has-danger(*ngIf="uiMessages.deleteFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_ERROR' | translate }}
+              .form-group.has-danger(*ngIf="uiMessages.saveFailure")
+                .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_ERROR' | translate }}
               .form-group
                 button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
                 = " "

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -130,9 +130,15 @@
           .form-group.pt-1([class.hidden]="!showCopyUrl")
             //- label {{ 'ASSET_PAGE.HEADER_LABELS.SHR_LNK' | translate}}
             .alert.alert-info(*ngIf="copyURLStatusMsg") {{ copyURLStatusMsg }}
-        //- div(*ngIf="!showEditDetails")
+        //-------------------
+        //- Metadata Display
+        //-------------------
         div#mainContent([class.d-none]="showEditDetails", tabindex="0")
           .row-hdr.pt-3(*ngIf="(assets[0].formattedMetadata | keys).length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.OBJ_DETAILS' | translate}}
+          //- Alert: Metdata Processing
+          .alert.alert-info(*ngIf="showMetadataPending")
+            b Metadata Updates Processing&nbsp;
+            | Changes to metadata will not yet be available in search results or to other users
           .meta-block.collection-type-display(*ngIf="collectionType")
             ang-collection-badge([collectionType]="collectionType")
           //- Old metadata loop

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -72,6 +72,7 @@ export class AssetPage implements OnInit, OnDestroy {
     private showAccessDeniedModal: boolean = false
     private showServerErrorModal: boolean = false
     private showGenerateCitation: boolean = false
+    private showMetadataPending: boolean = false
 
     private copyURLStatusMsg: string = ''
     private showCopyUrl: boolean = false
@@ -1147,12 +1148,20 @@ export class AssetPage implements OnInit, OnDestroy {
 
     private updateMetadataFromLocal(localData: LocalPCAsset): void {
         if (!localData) { return } // if we don't have metadata for that asset, we won't run any of the update code
-
+        // Track whether or not server has propagated changes yet
+        this.showMetadataPending = false
         for (let key in localData.asset_metadata) {
             let metadataLabel: string = this.mapLocalFieldToLabel(key)
             let fieldValue: string = localData.asset_metadata[key]
             // all objects in formattedMetadata are arrays, but these should all be length 0
-            fieldValue && (this.assets[0].formattedMetadata[metadataLabel] = [fieldValue])
+            if (fieldValue) {
+                if (this.assets[0].formattedMetadata[metadataLabel] && this.assets[0].formattedMetadata[metadataLabel].indexOf(fieldValue) > -1) {
+                    // No change
+                } else {
+                   this.assets[0].formattedMetadata[metadataLabel] = [fieldValue]
+                   this.showMetadataPending = true
+                }
+            }
         }
     }
 

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -73,6 +73,7 @@ export class AssetPage implements OnInit, OnDestroy {
     private showServerErrorModal: boolean = false
     private showGenerateCitation: boolean = false
     private showMetadataPending: boolean = false
+    private showMetadataError: boolean = false
 
     private copyURLStatusMsg: string = ''
     private showCopyUrl: boolean = false
@@ -133,7 +134,8 @@ export class AssetPage implements OnInit, OnDestroy {
     private prevRouteTS: string = '' // Used to track the (Timestamp) key for previous route params in session storage
 
     private uiMessages: {
-        deleteFailure?: boolean
+        deleteFailure?: boolean,
+        saveFailure?: boolean
     } = {}
 
     private steps: TourStep[] = [
@@ -1048,7 +1050,7 @@ export class AssetPage implements OnInit, OnDestroy {
      * Called on edit (Asset) details form submission
      */
     private editDetailsFormSubmit(formValue: AssetDetailsFormValue): void {
-
+        this.uiMessages = {}
         this.editDetailsFormSubmitted = true
         if (!this.editDetailsForm.valid) {
             return
@@ -1079,6 +1081,8 @@ export class AssetPage implements OnInit, OnDestroy {
                 error => {
                     console.error(error)
                     this.isProcessing = false
+                    // Show user error message
+                    this.uiMessages.saveFailure = true
                 }
             );
     }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -147,7 +147,8 @@
       "TITLE_REQUIRED_MSG": "A title is required",
       "SAVE_BTN": "Save",
       "DELETE_BTN": "Delete Record",
-      "DELETE_ERROR": "There was an error in deleting the asset. Please try again."
+      "DELETE_ERROR": "There was an error in deleting the asset. Please try again.",
+      "SAVE_ERROR": "There was an error updating the record. Please try again or contact support."
     },
     "DELETE_PC_MODAL": {
       "TITLE": "Delete Asset Confirmation",

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -55,9 +55,14 @@ $iconBtnSize: $btnHeight;
     background: #C9510D;
     border-color: #C9510D;
 
-    &:hover, &:focus, &:active {
-       background: darken(#C9510D, 10%);
-       border-color: darken(#C9510D, 10%);
+    &:hover {
+        background: darken(#C9510D, 10%);
+        border-color: darken(#C9510D, 10%);
+    }
+
+    &:focus, &:active {
+        filter: brightness(80%);
+        border-color: darken(#C9510D, 10%);
     }
 }
  
@@ -67,8 +72,12 @@ $iconBtnSize: $btnHeight;
     border: solid 1px #C9510D;
     color: #C9510D;
 
-    &:hover, &:focus, &:active, &.active {
+    &:hover {
         background-color: #C9510D;
+    }
+
+    &:focus, &:active, &.active {
+        filter: brightness(80%);
         color: white;
     }
 


### PR DESCRIPTION
Two messages added to update users on what's going on:

<img width="523" alt="screen shot 2018-09-13 at 4 31 30 pm" src="https://user-images.githubusercontent.com/592344/45517269-3306b600-b773-11e8-91e2-041d2e4a2bb0.png">
Message while metadata still being saved

<img width="499" alt="screen shot 2018-09-13 at 4 35 27 pm" src="https://user-images.githubusercontent.com/592344/45517282-3b5ef100-b773-11e8-99c7-9543d28d8c19.png">
Message when saving metadata has failed