### PR TITLE
Air 1829: Safely check index before splicing

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -716,7 +716,11 @@ export class AssetGrid implements OnInit, OnDestroy {
   private removeFromGroup(assetsToRemove: Thumbnail[], clearRestricted?: boolean): void {
     for(let i = 0; i < assetsToRemove.length; i++) {
       let assetId = assetsToRemove[i].objectId
-      this.ig.items.splice(this.ig.items.indexOf(assetId), 1)
+      let igIndex = this.ig.items.indexOf(assetId)
+      // Passing -1 will splice the wrong asset!
+      if (igIndex >= 0) {
+        this.ig.items.splice(this.ig.items.indexOf(assetId), 1)
+      }
     }
     // Save removal to Group
     this._groups.update(this.ig)

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -719,7 +719,7 @@ export class AssetGrid implements OnInit, OnDestroy {
       let igIndex = this.ig.items.indexOf(assetId)
       // Passing -1 will splice the wrong asset!
       if (igIndex >= 0) {
-        this.ig.items.splice(this.ig.items.indexOf(assetId), 1)
+        this.ig.items.splice(igIndex, 1)
       }
     }
     // Save removal to Group

--- a/src/app/browse-page/card-view/card-view.component.ts
+++ b/src/app/browse-page/card-view/card-view.component.ts
@@ -57,13 +57,15 @@ export class CardViewComponent implements OnInit {
       }
     }
 
-    // Get the first three images of the image group to show on the card view
-    let itemIds: string[] = this.group.items.slice(0, 3)
+    // Get the first five images of the image group to show on the card view (5 incase there are unavailable assets amongst the first three)
+    let itemIds: string[] = this.group.items.slice(0, 5)
 
     if (itemIds.length) {
       this._assets.getAllThumbnails(itemIds)
         .then( allThumbnails => {
-          this.thumbnails = allThumbnails
+          this.thumbnails = allThumbnails.filter((thumbnail) => {
+            return thumbnail.status === 'available'
+          })
         })
         .catch( error => {
           console.error(error)


### PR DESCRIPTION
It was a pretty specific bug that would happen only if "deleted assets" wasn't reset, and the assets didn't exist in the group