### PR TITLE
AIR-1424

### DIFF
--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -288,10 +288,12 @@ export class AuthService implements CanActivate {
    * @returns Chainable promise containing collection data
    */
   private refreshUserInstitution() {
-    let options = { withCredentials: true }
+    let header = new HttpHeaders().set('Cache-Control', 'no-store, no-cache')
+    let options = { headers: header, withCredentials: true }
+
     // Returns all of the collections names
     return this.http
-      .get(this.getUrl() + '/v2/institution', options)
+      .get(this.getUrl() + '/v2/institution?no-cache=' + new Date().valueOf(), options)
       .toPromise()
       .then((data) => {
         this.setInstitution(data)


### PR DESCRIPTION
Auth Service: add no-cache no-store to refreshUserInstitution

Note: We need to deploy to stage to check if this prevents IE11 from caching institution name from v2/institution