### PR TITLE
Add unaffiliated modal for pcollection and image-group-page pages

### DIFF
--- a/src/app/image-group-page/image-group-page.component.pug
+++ b/src/app/image-group-page/image-group-page.component.pug
@@ -36,3 +36,4 @@ ang-ig-download-modal(*ngIf="showPptModal", (closeModal)="showPptModal = false",
 ang-download-limit-modal(*ngIf="showDownloadLimitModal", (closeModal)="showDownloadLimitModal = false", [ig]="ig")
 ang-login-req-modal(*ngIf="showLoginModal", (closeModal)="showLoginModal = false")
 ang-no-ig-modal(*ngIf="showNoIgModal || showNoAccessIgModal", [noAccessIg]="showNoAccessIgModal", (closeModal)="showNoIgModal = false")
+ang-access-denied-modal(*ngIf="showAccessDeniedModal")

--- a/src/app/image-group-page/image-group-page.component.ts
+++ b/src/app/image-group-page/image-group-page.component.ts
@@ -31,7 +31,7 @@ export class ImageGroupPage implements OnInit, OnDestroy {
   private showNoIgModal: boolean = false;
   /** controls the modal to tell that the user does not have the rights to access the IG */
   private showNoAccessIgModal: boolean = false;
-  /** controls access denied modal for unaffiliated users landing on /geoup/id pages */
+  /** controls access denied modal for unaffiliated users landing on /group/id pages */
   private showAccessDeniedModal: boolean = false;
   /** set to true when the call to download info has returned. We won't know what modal to show before that */
   private downloadInfoReturned: boolean = false;

--- a/src/app/image-group-page/image-group-page.component.ts
+++ b/src/app/image-group-page/image-group-page.component.ts
@@ -31,12 +31,16 @@ export class ImageGroupPage implements OnInit, OnDestroy {
   private showNoIgModal: boolean = false;
   /** controls the modal to tell that the user does not have the rights to access the IG */
   private showNoAccessIgModal: boolean = false;
+  /** controls access denied modal for unaffiliated users landing on /geoup/id pages */
+  private showAccessDeniedModal: boolean = false;
   /** set to true when the call to download info has returned. We won't know what modal to show before that */
   private downloadInfoReturned: boolean = false;
   /** Enables / Disables the IG deletion based on user ownership */
   private allowIgUpdate: boolean = false;
 
   private genImgGrpLink: boolean = false;
+
+  private unaffiliatedUser: boolean = false
 
   /** Options object passed to the asset-grid component */
   private actionOptions: any = {
@@ -54,9 +58,16 @@ export class ImageGroupPage implements OnInit, OnDestroy {
     private _auth: AuthService,
     private route: ActivatedRoute,
     private _title: TitleService
-  ) {}
+  ) {
+    this.unaffiliatedUser = this._auth.isPublicOnly() ? true : false
+  }
 
   ngOnInit() {
+    if (this.unaffiliatedUser) {
+      this.showAccessDeniedModal = true
+      return
+    }
+
     this.user = this._auth.getUser();
     let id = null;
 

--- a/src/app/pcollection-page/pcollection-page.component.pug
+++ b/src/app/pcollection-page/pcollection-page.component.pug
@@ -35,4 +35,4 @@ ang-sky-banner(*ngIf="showDeleteSuccessBanner", textValue="{{ 'PERSONAL_COLLECTI
         button.close(type="button", (click)="closePublishingMsgs()", aria-label="Close")
           span(aria-hidden="true") &times;
       ang-asset-grid([actionOptions]="{collection: true}", [assetCount]="assetCount", [hasMaxAssetLimit]="true")
-  ang-access-denied-modal(*ngIf="showaccessDeniedModal")
+  ang-access-denied-modal(*ngIf="showAccessDeniedModal")

--- a/src/app/pcollection-page/pcollection-page.component.ts
+++ b/src/app/pcollection-page/pcollection-page.component.ts
@@ -57,6 +57,7 @@ export class PCollectionPage implements OnInit, OnDestroy {
     // Unaffiliated users show login modal when accessing /pcollection/
     if (this.unaffiliatedUser) {
       this.showAccessDeniedModal = true
+      return
     }
 
     this.pollNewPCAssetsStatus()

--- a/src/app/pcollection-page/pcollection-page.component.ts
+++ b/src/app/pcollection-page/pcollection-page.component.ts
@@ -27,7 +27,7 @@ export class PCollectionPage implements OnInit, OnDestroy {
   private colThumbnail: string = ''
   private assetCount: number
   private descCollapsed: boolean = true
-  private showaccessDeniedModal: boolean = false
+  private showAccessDeniedModal: boolean = false
   private showDeleteSuccessBanner: boolean = false
   private deleteBannerParams: { title?: string } = {}
 
@@ -39,6 +39,7 @@ export class PCollectionPage implements OnInit, OnDestroy {
   }
   private pub_que_count: number = 0
   private pub_failure_count: number = 0
+  private unaffiliatedUser: boolean = false
 
   constructor(
     private _assets: AssetService,
@@ -47,9 +48,17 @@ export class PCollectionPage implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private http: HttpClient,
     private _title: TitleService
-  ) {}
+  ) {
+    this.unaffiliatedUser = this._auth.isPublicOnly() ? true : false
+  }
 
   ngOnInit() {
+
+    // Unaffiliated users show login modal when accessing /pcollection/
+    if (this.unaffiliatedUser) {
+      this.showAccessDeniedModal = true
+    }
+
     this.pollNewPCAssetsStatus()
 
     this.subscriptions.push(
@@ -100,7 +109,7 @@ export class PCollectionPage implements OnInit, OnDestroy {
             .catch((error) => {
               console.error(error);
               if (error.status === 401){
-                this.showaccessDeniedModal = true;
+                this.showAccessDeniedModal = true;
               }
             });
         }


### PR DESCRIPTION
Add unaffiliated modal for pcollection and image-group-page pages

- We need to check for public users clicking or pasting a link straight to group/id or pcollection/id
pages.