### PR TITLE
AIR-1743 (Indicate focus in main nav by more than color)

### DIFF
--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -156,7 +156,6 @@ $iconBtnSize: $btnHeight;
         
         &:-moz-focusring:not(input):not(select):not(textarea):not(iframe):not(frame):not(body):not(html) {
             outline: 1px dotted;
-            // outline: rgb(77, 144, 254) auto 2px;
         }
     }
     

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -132,17 +132,39 @@ $iconBtnSize: $btnHeight;
      &.active{
         color: #0039c6;
      }
+  
+    &:hover  {
+        text-decoration: none;
+        color: #0039c6;
+        outline: none;
+        background: none;
 
-     &:hover, &:focus  {
-         text-decoration: none;
-         color: #0039c6;
-         outline: none;
-         background: none;
+        & .value {
+            text-decoration: underline;
+        }
+    }
 
-         & .value {
-             text-decoration: underline;
-         }
-     }
+    &:focus {
+        text-decoration: none;
+        color: #0039c6;
+        outline: rgb(77, 144, 254) auto 5px;
+        outline-offset: -2px;
+        // outline:none; 
+        // border:1px solid #4D90FE;
+        // -webkit-box-shadow: 0px 0px 5px  #4D90FE;
+        // box-shadow: 0px 0px 5px  #4D90FE;
+        // background: none;
+
+        & .value {
+            text-decoration: underline;
+        }
+        
+        &:-moz-focusring:not(input):not(select):not(textarea):not(iframe):not(frame):not(body):not(html) {
+            outline: 1px dotted;
+            // outline: rgb(77, 144, 254) auto 2px;
+        }
+    }
+    
 
      & .value {
          color: #000;

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -39,7 +39,7 @@ $iconBtnSize: $btnHeight;
 }
 
 /**
- * @atom Button 
+ * @atom Button
  * @section Navigation > Buttons
  * @markup
  *  <button type="button" class="btn btn-primary">Primary</button>
@@ -65,7 +65,7 @@ $iconBtnSize: $btnHeight;
         border-color: darken(#C9510D, 10%);
     }
 }
- 
+
 
  .btn-secondary, a.btn-secondary {
     background: white;
@@ -114,12 +114,12 @@ $iconBtnSize: $btnHeight;
     transform: translateY(-0.1em);
  }
 
- .btn.btn-link, a.btn.btn-link { 
+ .btn.btn-link, a.btn.btn-link {
      text-transform: none !important;
      padding: 0 6px 0 0;
      color: #000;
      background: none;
-     
+
      &.with-pad {
         margin: 0 24px;
      }
@@ -132,7 +132,7 @@ $iconBtnSize: $btnHeight;
      &.active{
         color: #0039c6;
      }
-  
+
     &:hover  {
         text-decoration: none;
         color: #0039c6;
@@ -153,12 +153,12 @@ $iconBtnSize: $btnHeight;
         & .value {
             text-decoration: underline;
         }
-        
-        &:-moz-focusring:not(input):not(select):not(textarea):not(iframe):not(frame):not(body):not(html) {
+
+        &:-moz-focusring {
             outline: 1px dotted;
         }
     }
-    
+
 
      & .value {
          color: #000;

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -149,11 +149,6 @@ $iconBtnSize: $btnHeight;
         color: #0039c6;
         outline: rgb(77, 144, 254) auto 5px;
         outline-offset: -2px;
-        // outline:none; 
-        // border:1px solid #4D90FE;
-        // -webkit-box-shadow: 0px 0px 5px  #4D90FE;
-        // box-shadow: 0px 0px 5px  #4D90FE;
-        // background: none;
 
         & .value {
             text-decoration: underline;


### PR DESCRIPTION
 - For Chrome and Safari, create an outline around the main nav when focused, which looks like the browser's default focus style.
 - For FireFox, the default outline looks terrible. Specify FireFox's focus style with "-moz-focusring"