### PR TITLE
Air-1876 (GA event: click on associated images icon)

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -21,12 +21,11 @@
     i.icon.icon-iap.float-right(*ngIf="thumbnail.iap")
     //- New search icons
     i.icon.icon-cluster.float-right(
-      *ngIf="thumbnail.partofcluster", 
-      [id]="thumbnail.objectId + '_clustered_images'", 
+      *ngIf="thumbnail.partofcluster",
       (click)="openLink($event, ['/cluster', thumbnail.clusterid ? thumbnail.clusterid : thumbnail.artstorid, { objTitle :  thumbnail.name }])", 
       title="View related media"
     )
-    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", [id]="thumbnail.objectId ? thumbnail.objectId + '_associated_images' : thumbnail.artstorid + '_associated_images'", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
+    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
     //- i.icon.icon-collection-type(class="icon-{{getCollectionType().name}}", [attr.title]="getCollectionType().alt")
     ang-collection-badge([collectionType]="getCollectionType()")
     i.float-right(*ngIf="thumbnail.media && thumbnail.media.adlObjectType && thumbnail.media.adlObjectType != 10", class="icon icon-{{thumbnail.media.adlObjectType | typeIdPipe}}")

--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -26,7 +26,7 @@
       (click)="openLink($event, ['/cluster', thumbnail.clusterid ? thumbnail.clusterid : thumbnail.artstorid, { objTitle :  thumbnail.name }])", 
       title="View related media"
     )
-    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", [id]="thumbnail.artstorid + '_associated_images'", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
+    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", [id]="thumbnail.objectId ? thumbnail.objectId + '_associated_images' : thumbnail.artstorid + '_associated_images'", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
     //- i.icon.icon-collection-type(class="icon-{{getCollectionType().name}}", [attr.title]="getCollectionType().alt")
     ang-collection-badge([collectionType]="getCollectionType()")
     i.float-right(*ngIf="thumbnail.media && thumbnail.media.adlObjectType && thumbnail.media.adlObjectType != 10", class="icon icon-{{thumbnail.media.adlObjectType | typeIdPipe}}")

--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -26,7 +26,7 @@
       (click)="openLink($event, ['/cluster', thumbnail.clusterid ? thumbnail.clusterid : thumbnail.artstorid, { objTitle :  thumbnail.name }])", 
       title="View related media"
     )
-    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", [id]="thumbnail.objectId + '_associated_images'", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
+    i.icon.icon-collab.float-right(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", [id]="thumbnail.artstorid + '_associated_images'", (click)="openLink($event, ['/associated', thumbnail.frequentlygroupedwith[0], 103])", title="Others are also interested in...")
     //- i.icon.icon-collection-type(class="icon-{{getCollectionType().name}}", [attr.title]="getCollectionType().alt")
     ang-collection-badge([collectionType]="getCollectionType()")
     i.float-right(*ngIf="thumbnail.media && thumbnail.media.adlObjectType && thumbnail.media.adlObjectType != 10", class="icon icon-{{thumbnail.media.adlObjectType | typeIdPipe}}")

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -65,7 +65,8 @@ export class ThumbnailComponent implements OnInit, OnChanges {
     // Prevent the parent anchor tag from firing
     event.preventDefault()
     event.stopPropagation()
-    this.angulartics.eventTrack.next({ action: 'view associated images', properties: { label: this.thumbnail.artstorid } })
+
+    this.angulartics.eventTrack.next({ action: 'view associated images', properties: { label: this.thumbnail.objectId ? this.thumbnail.objectId : this.thumbnail.artstorid } })
     this.router.navigate(urlParams)
   }
 

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -66,7 +66,13 @@ export class ThumbnailComponent implements OnInit, OnChanges {
     event.preventDefault()
     event.stopPropagation()
 
-    this.angulartics.eventTrack.next({ action: 'view associated images', properties: { label: this.thumbnail.objectId ? this.thumbnail.objectId : this.thumbnail.artstorid } })
+    console.log(urlParams)
+    if (urlParams[0] === '/associated') {
+      this.angulartics.eventTrack.next({ action: 'view associated images', properties: { label: this.thumbnail.objectId ? this.thumbnail.objectId : this.thumbnail.artstorid } })
+    }
+    if (urlParams[0] === '/cluster') {
+      this.angulartics.eventTrack.next({ action: 'view cluster', properties: { label: this.thumbnail.objectId ? this.thumbnail.objectId : this.thumbnail.artstorid } })
+    }
     this.router.navigate(urlParams)
   }
 

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -2,6 +2,7 @@ import { Router } from '@angular/router';
 import { Component, OnInit, OnChanges, Input, SimpleChanges } from '@angular/core';
 
 import { Thumbnail, AssetService, CollectionTypeHandler, AssetSearchService, CollectionTypeInfo } from './../../shared'
+import { Angulartics2 } from 'angulartics2';
 
 @Component({
   selector: 'ang-thumbnail',
@@ -40,6 +41,7 @@ export class ThumbnailComponent implements OnInit, OnChanges {
   private thumbnailSize: number = 1
 
   constructor(
+    private angulartics: Angulartics2,
     private _assets: AssetService,
     private _search: AssetSearchService,
     private router: Router
@@ -63,7 +65,7 @@ export class ThumbnailComponent implements OnInit, OnChanges {
     // Prevent the parent anchor tag from firing
     event.preventDefault()
     event.stopPropagation()
-
+    this.angulartics.eventTrack.next({ action: 'view associated images', properties: { label: this.thumbnail.artstorid } })
     this.router.navigate(urlParams)
   }
 


### PR DESCRIPTION
 - Add GA event for clicking on the little people icon.
 - Event action: "view associated images"
 - Label: thumbnail's objectId or artstorid depending on the thumbnail 
 - Distinguish between associated icon click and cluster icon click

Note: Job of AIR-1877 also done in this branch because it is one piece of code!!!