### PR TITLE
Air-1845 (Make advanced search modal keyboard accessible)

### DIFF
--- a/src/app/modals/search-modal/search-modal.component.pug
+++ b/src/app/modals/search-modal/search-modal.component.pug
@@ -3,7 +3,7 @@
   .modal-dialog.modal-lg
     .modal-content
       .modal-header
-        h1 {{ 'ADVANCED_SEARCH_MODAL.TITLE' | translate }}
+        h1#advanced-search-title(tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'ADVANCED_SEARCH_MODAL.TITLE' | translate }}
         button.close(type="button", (click)="close()", data-dismiss="modal", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
@@ -19,16 +19,16 @@
                       | {{ query.operator }}
                       = " "
                     .dropdown-menu(ngbDropdownMenu, aria-labelledby="dropdown")
-                      a.dropdown-item((click)="query.operator = 'AND'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.AND' | translate }}
-                      a.dropdown-item((click)="query.operator = 'OR'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.OR' | translate }}
-                      a.dropdown-item((click)="query.operator = 'NOT'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.NOT' | translate }}
+                      button.dropdown-item((click)="query.operator = 'AND'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.AND' | translate }}
+                      button.dropdown-item((click)="query.operator = 'OR'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.OR' | translate }}
+                      button.dropdown-item((click)="query.operator = 'NOT'") {{ 'ADVANCED_SEARCH_MODAL.BOOLEAN_OPTIONS.NOT' | translate }}
                   input.form-control(id="inputAdvanceQuery{{i + 1}}", [(ngModel)]="query.term", (change)="validateForm()", type="text")
                   .input-group-btn(ngbDropdown)
                     button.btn.btn-secondary.dropdown-toggle(id="advanceQueryField{{i + 1}}", ngbDropdownToggle, type="button")
                       | {{ query.field.name }}
                       = " "
                     .dropdown-menu(ngbDropdownMenu, aria-labelledby="fieldDropdown")
-                      a.dropdown-item(*ngFor="let field of fields", (click)="query.field = field", [attr.title]="field.description | translate") {{ field.name }}
+                      button.dropdown-item(*ngFor="let field of fields", (click)="query.field = field", [attr.title]="field.description | translate") {{ field.name }}
                   button.close(type="button", (click)="clearAdvanceQuery(i)")
                     span(style="font-family:Aria, Arial, Helvetica;") &times;
               .form-group(*ngIf="advanceQueries.length < 10")
@@ -74,4 +74,4 @@
         .alert.alert-warning(*ngIf="error.date", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE' | translate")
         a.btn.btn-link.with-pad(tabindex="1", (click)="openHelp()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.HELP' | translate }}
         button.btn.btn-secondary((click)="resetFilters()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.CLEAR' | translate }}
-        button.btn.btn-primary((click)="applyAllFilters()", data-sc="search: advanced query") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.SEARCH' | translate }}
+        button.btn.btn-primary((click)="applyAllFilters()", data-sc="search: advanced query", (focusout)="startModalFocus()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.SEARCH' | translate }}

--- a/src/app/modals/search-modal/search-modal.component.pug
+++ b/src/app/modals/search-modal/search-modal.component.pug
@@ -39,12 +39,12 @@
                 .form-card.card.dt-grp
                   .date-filter-row
                     input#inputDateFilterStart.form-control([(ngModel)]="advanceSearchDate['startDate']", (change)="validateForm()", type="number", (keypress)="dateKeyPress($event)", min="0", placeholder="Start Date")
-                    div#buttonDateFilterStartBCE.side-toggle-btn((click)="advanceSearchDate['startEra'] = 'BCE'", [ngClass]="{'active': advanceSearchDate['startEra'] == 'BCE' }") BCE
-                    div#buttonDateFilterStartCE.side-toggle-btn((click)="advanceSearchDate['startEra'] = 'CE'", [ngClass]="{'active': advanceSearchDate['startEra'] == 'CE' }") CE
+                    button#buttonDateFilterStartBCE.side-toggle-btn((click)="advanceSearchDate['startEra'] = 'BCE'", [ngClass]="{'active': advanceSearchDate['startEra'] == 'BCE' }", tabIndex="0", role="button") BCE
+                    button#buttonDateFilterStartCE.side-toggle-btn((click)="advanceSearchDate['startEra'] = 'CE'", [ngClass]="{'active': advanceSearchDate['startEra'] == 'CE' }", tabIndex="0", role="button") CE
                   .date-filter-row
                     input#inputDateFilterEnd.form-control([(ngModel)]="advanceSearchDate['endDate']", (change)="validateForm()", type="number", (keypress)="dateKeyPress($event)", min="0", placeholder="End Date")
-                    div#buttonDateFilterEndBCE.side-toggle-btn((click)="advanceSearchDate['endEra'] = 'BCE'", [ngClass]="{'active': advanceSearchDate['endEra'] == 'BCE' }") BCE
-                    div#buttonDateFilterEndCE.side-toggle-btn((click)="advanceSearchDate['endEra'] = 'CE'", [ngClass]="{'active': advanceSearchDate['endEra'] == 'CE' }") CE
+                    button#buttonDateFilterEndBCE.side-toggle-btn((click)="advanceSearchDate['endEra'] = 'BCE'", [ngClass]="{'active': advanceSearchDate['endEra'] == 'BCE' }", tabIndex="0", role="button") BCE
+                    button#buttonDateFilterEndCE.side-toggle-btn((click)="advanceSearchDate['endEra'] = 'CE'", [ngClass]="{'active': advanceSearchDate['endEra'] == 'CE' }", tabIndex="0", role="button") CE
             .col-lg-6
               h3 {{ 'ADVANCED_SEARCH_MODAL.FILTER_HEADING' | translate }}
               p.small {{ 'ADVANCED_SEARCH_MODAL.FILTER_DESCRIPTION' | translate }}

--- a/src/app/modals/search-modal/search-modal.component.pug
+++ b/src/app/modals/search-modal/search-modal.component.pug
@@ -72,6 +72,6 @@
       .modal-footer
         .alert.alert-warning(*ngIf="error.empty", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.EMPTY_SEARCH' | translate")
         .alert.alert-warning(*ngIf="error.date", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE' | translate")
-        a.btn.btn-link.with-pad(tabindex="1", (click)="openHelp()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.HELP' | translate }}
+        button.btn.btn-link.with-pad(tabindex="0", (click)="openHelp()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.HELP' | translate }}
         button.btn.btn-secondary((click)="resetFilters()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.CLEAR' | translate }}
         button.btn.btn-primary((click)="applyAllFilters()", data-sc="search: advanced query", (focusout)="startModalFocus()") {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.SEARCH' | translate }}

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -415,7 +415,8 @@ export class SearchModal implements OnInit, AfterViewInit {
   }
 
   private dateKeyPress(event: any): boolean{
-      if ((event.key == 'ArrowUp') || (event.key == 'ArrowDown') || (event.key == 'ArrowRight') || (event.key == 'ArrowLeft') || (event.key == 'Backspace')){
+      // Add check of Tab key to make sure the tabbingis enabled on Firefox
+      if ((event.key == 'ArrowUp') || (event.key == 'ArrowDown') || (event.key == 'ArrowRight') || (event.key == 'ArrowLeft') || (event.key == 'Backspace') || (event.key == 'Tab')){
         return true;
       }
 

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -416,7 +416,7 @@ export class SearchModal implements OnInit, AfterViewInit {
 
   private dateKeyPress(event: any): boolean{
       // Add check of Tab key to make sure the tabbingis enabled on Firefox
-      if ((event.key == 'ArrowUp') || (event.key == 'ArrowDown') || (event.key == 'ArrowRight') || (event.key == 'ArrowLeft') || (event.key == 'Backspace') || (event.key == 'Tab')){
+      if ((event.key === 'ArrowUp') || (event.key === 'ArrowDown') || (event.key === 'ArrowRight') || (event.key === 'ArrowLeft') || (event.key === 'Backspace') || (event.key === 'Tab')){
         return true;
       }
 

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -1,6 +1,6 @@
 import { Subscription } from 'rxjs/Rx';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, AfterViewInit } from '@angular/core';
 import { Angulartics2 } from 'angulartics2';
 
 // Project dependencies
@@ -14,7 +14,7 @@ import { AppConfig } from '../../app.service';
   templateUrl: 'search-modal.component.pug',
   styleUrls: [ 'search-modal.component.scss' ]
 })
-export class SearchModal implements OnInit {
+export class SearchModal implements OnInit, AfterViewInit {
   @Output()
   private closeModal: EventEmitter<any> = new EventEmitter();
 
@@ -108,6 +108,16 @@ export class SearchModal implements OnInit {
     this.hideLegacyFilters = true
     this.loadingFilters = true
     this.loadFilters()
+  }
+
+  ngAfterViewInit() {
+    this.startModalFocus()
+  }
+
+  // Set initial focus on the modal Title h1
+  private startModalFocus() {
+    let modalStartFocus = document.getElementById('advanced-search-title')
+    modalStartFocus.focus()
   }
 
   /**

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -77,8 +77,11 @@ $iconBtnSize: $btnHeight;
     }
 
     &:focus, &:active, &.active {
-        filter: brightness(80%);
-        color: white;
+        // filter: brightness(80%);
+        // color: white;
+        background: none;
+        color: #C9510D;
+        outline: 5px auto -webkit-focus-ring-color;
     }
 
     // Override Bootstrap default


### PR DESCRIPTION
 - Make the dropdown buttons in the "in any field" and "and/or" accessible.
 - Make the CE/BCE options accessible.
 - Make the help link accessible.
 - Disable tabbing outside of the modal.
 - Change secondary button styles in _buttons.scss to get rid of the grey look when buttons are focused.
 - Check for Tab key inside dateKeyPress function to enable tabbing on FireFox. (Otherwise, the keypress event will prevent user from tabbing to other elements on FireFox. )