### PR TITLE
Air-1740 (Improve tabbing order on collection browse page)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -66,10 +66,8 @@ export class App {
       if (event instanceof NavigationStart) {
         // focus on the wrapper of the "skip to main content link" everytime new page is loaded
         let mainEl = <HTMLElement>(document.getElementById('skip'))
-        mainEl.focus()
-        // For the filter to work on browse/library page, focus on the input to make user can type in search term continuously
-        if (document.getElementById('browsePageFilter'))
-          document.getElementById('browsePageFilter').focus()
+        if (!(event.url.indexOf('browse') >- 1)) // Don't set focus to skip to main content on browse pages so that we can easily go between browse levels
+          mainEl.focus()
 
         // Detect featureflag=solrmetadata and set cookie
         let routeParams = event.url.split(';')

--- a/src/app/browse-page/browse-page.component.pug
+++ b/src/app/browse-page/browse-page.component.pug
@@ -1,5 +1,5 @@
 nav-menu
-#mainContent.container.main-content(tabindex="-1")
+.container.main-content(tabindex="-1")
   nav.nav.nav-inline.coll-nav
-    a.nav-link(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)") {{ colOpt.label }}
+    a.nav-link#mainContent(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)", tabindex="3") {{ colOpt.label }}
   router-outlet

--- a/src/app/browse-page/browse-page.component.scss
+++ b/src/app/browse-page/browse-page.component.scss
@@ -213,6 +213,8 @@
     &.form-control__icon {
         opacity: 0.4;
         cursor: pointer;
+        border: none;
+        height: 90%;
 
         &:hover, &:focus {
             opacity: 0.9;

--- a/src/app/browse-page/browse-page.component.scss
+++ b/src/app/browse-page/browse-page.component.scss
@@ -10,7 +10,8 @@
 
 .nav-link{
     cursor: pointer;
-    border-bottom: 2px solid transparent;
+    //border-bottom: 2px solid transparent;
+    border: none;       
     padding-right: 0;
     padding-left: 0;
     margin-right: 1rem;

--- a/src/app/browse-page/library.component.pug
+++ b/src/app/browse-page/library.component.pug
@@ -1,6 +1,6 @@
 nav.nav.nav-inline.browse-nav
   a.label Browse By:&ensp;
-  a.nav-link(*ngFor="let browseOpt of browseMenuArray", [ngClass]="{'active': browseOpt.id == selectedBrowseId}", (click)="selectBrowseOpt(browseOpt.id)") {{ browseOpt.label }}
+  button.nav-link(*ngFor="let browseOpt of browseMenuArray", [ngClass]="{'active': browseOpt.id == selectedBrowseId}", (click)="selectBrowseOpt(browseOpt.id)") {{ browseOpt.label }}
 .row
   .col-md-8
     ul.filter-list

--- a/src/app/browse-page/library.component.pug
+++ b/src/app/browse-page/library.component.pug
@@ -1,12 +1,12 @@
 nav.nav.nav-inline.browse-nav
   a.label Browse By:&ensp;
-  button.nav-link(*ngFor="let browseOpt of browseMenuArray", [ngClass]="{'active': browseOpt.id == selectedBrowseId}", (click)="selectBrowseOpt(browseOpt.id)") {{ browseOpt.label }}
+  button.nav-link(*ngFor="let browseOpt of browseMenuArray", [ngClass]="{'active': browseOpt.id == selectedBrowseId}", (click)="selectBrowseOpt(browseOpt.id)", tabindex="4") {{ browseOpt.label }}
 .row
   .col-md-8
     ul.filter-list
       ng-container(*ngIf="facetQueryMap[facetType] == 'category'")
         .input-group
-          input#browsePageFilter.form-control.has-icon(placeholder="Search Collections", tabindex="0", [(ngModel)]="searchTerm", (keyup)="addRouteParam('searchTerm',searchTerm)")
+          input#browsePageFilter.form-control.has-icon(placeholder="Search Collections", tabindex="6", [(ngModel)]="searchTerm", (keyup)="addRouteParam('searchTerm',searchTerm)")
           i#iconSearchClear.icon.icon-close.form-control__icon(*ngIf="searchTerm && searchTerm.length > 0", (click)="clearSearchTerm(term)")
           i#iconSearchSubmit.icon.icon-filter.form-control__icon(*ngIf="!searchTerm || searchTerm.length == 0", (click)="addRouteParam('searchTerm',searchTerm)")
         #alertNoResults.alert.alert-warning.input-group(*ngIf="!(categoryFacets | iggroupfilter:searchTerm).length && !loading", [innerHtml]="'No search results found'")
@@ -32,7 +32,7 @@ nav.nav.nav-inline.browse-nav
         img.browse__img([attr.src]="descObj[selectedBrowseId] + '.LEAD_IMAGE' | translate", [attr.alt]="descObj[selectedBrowseId] + '.CAPTION' | translate")
         .small([innerHTML]="descObj[selectedBrowseId] + '.CAPTION' | translate")
       .title {{ descObj[selectedBrowseId] + ".HEADING" | translate }}
-      .browse__description([innerHTML]="descObj[selectedBrowseId] + '.DESCRIPTION' | translate")
+      .browse__description([innerHTML]="descObj[selectedBrowseId] + '.DESCRIPTION' | translate", tabindex="5")
   ang-access-denied-modal(*ngIf="unaffiliatedUser")
 //- .row.has-icon-overlay(*ngIf="loading")
 //-   i.icon-lg.icon-overlay--top.icon-loading-large

--- a/src/app/browse-page/library.component.pug
+++ b/src/app/browse-page/library.component.pug
@@ -7,8 +7,8 @@ nav.nav.nav-inline.browse-nav
       ng-container(*ngIf="facetQueryMap[facetType] == 'category'")
         .input-group
           input#browsePageFilter.form-control.has-icon(placeholder="Search Collections", tabindex="6", [(ngModel)]="searchTerm", (keyup)="addRouteParam('searchTerm',searchTerm)")
-          i#iconSearchClear.icon.icon-close.form-control__icon(*ngIf="searchTerm && searchTerm.length > 0", (click)="clearSearchTerm(term)")
-          i#iconSearchSubmit.icon.icon-filter.form-control__icon(*ngIf="!searchTerm || searchTerm.length == 0", (click)="addRouteParam('searchTerm',searchTerm)")
+          button#iconSearchClear.icon.icon-close.form-control__icon(*ngIf="searchTerm && searchTerm.length > 0", (click)="clearSearchTerm(term)", tabindex="6")
+          button#iconSearchSubmit.icon.icon-filter.form-control__icon(*ngIf="!searchTerm || searchTerm.length == 0", (click)="addRouteParam('searchTerm',searchTerm)", tabindex="6")
         #alertNoResults.alert.alert-warning.input-group(*ngIf="!(categoryFacets | iggroupfilter:searchTerm).length && !loading", [innerHtml]="'No search results found'")
       li.filter(*ngFor="let facet of categoryFacets | iggroupfilter:searchTerm", [class.hidden]="facet.title === '' || !facet.name")
         a.tag-link(*ngIf="facetQueryMap[facetType] == 'category'", [routerLink]="['/category', facet.name ]")

--- a/src/app/nav-menu/nav-menu.component.pug
+++ b/src/app/nav-menu/nav-menu.component.pug
@@ -2,53 +2,53 @@
 .container.nav-container
   nav.navbar.navbar-expand-sm.navbar-light.bg-faded
     div
-    button.navbar-toggler((click)="this.mobileCollapsed = !this.mobileCollapsed", [class.collapsed]="mobileCollapsed", type="button", aria-controls="navbarSupportedContent", aria-expanded="false", aria-label="Toggle navigation")
+    button.navbar-toggler(tabindex="3", (click)="this.mobileCollapsed = !this.mobileCollapsed", [class.collapsed]="mobileCollapsed", type="button", aria-controls="navbarSupportedContent", aria-expanded="false", aria-label="Toggle navigation")
       span.navbar-toggler-icon
     #navMenu.navbar-collapse.collapse([class.show]="!mobileCollapsed")
       ul.nav.navbar-nav
         li.nav-item
-          a.btn.btn-link([routerLink]="['/home']", routerLinkActive="active") {{ 'NAV_MENU.HOME' | translate }}
+          a.btn.btn-link(tabindex="3", [routerLink]="['/home']", routerLinkActive="active") {{ 'NAV_MENU.HOME' | translate }}
         li.nav-item(ngbDropdown, (mouseenter)="openDrop($event, drop1)", (mouseleave)="closeDrop($event, drop1)", #drop1="ngbDropdown")
-          button#dropdownMenu1.btn.btn-link(ngbDropdownToggle) {{ 'NAV_MENU.COLLECTIONS.TITLE' | translate }}
+          button#dropdownMenu1.btn.btn-link(tabindex="3", ngbDropdownToggle) {{ 'NAV_MENU.COLLECTIONS.TITLE' | translate }}
           .dropdown-menu(ngbDropdownMenu, aria-labelledby="dropdownMenu1")
-            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.artstorCol", [routerLink]="['/browse', 'library']") {{ 'NAV_MENU.COLLECTIONS.ARTSTOR' | translate }}
-            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.instCol", [routerLink]="['/browse', 'institution']") {{ 'NAV_MENU.COLLECTIONS.INSTITUTION' | translate }}
-            button.dropdown-item(*ngIf="browseOpts.openCol", [routerLink]="['/browse', 'commons']") {{ 'NAV_MENU.COLLECTIONS.OPEN' | translate }}
-            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.myCol", [class.disabled]="!user.isLoggedIn", [routerLink]="['/browse', 'mycollections']") {{ 'NAV_MENU.COLLECTIONS.OWNED' | translate }}
-            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.igs", [routerLink]="['/browse','groups']") {{ 'NAV_MENU.COLLECTIONS.GROUPS' | translate }}
+            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.artstorCol", tabindex="3", [routerLink]="['/browse', 'library']") {{ 'NAV_MENU.COLLECTIONS.ARTSTOR' | translate }}
+            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.instCol", tabindex="3", [routerLink]="['/browse', 'institution']") {{ 'NAV_MENU.COLLECTIONS.INSTITUTION' | translate }}
+            button.dropdown-item(*ngIf="browseOpts.openCol", tabindex="3", [routerLink]="['/browse', 'commons']") {{ 'NAV_MENU.COLLECTIONS.OPEN' | translate }}
+            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.myCol", tabindex="3", [class.disabled]="!user.isLoggedIn", [routerLink]="['/browse', 'mycollections']") {{ 'NAV_MENU.COLLECTIONS.OWNED' | translate }}
+            button.dropdown-item(*ngIf="!_auth.isPublicOnly() && browseOpts.igs", tabindex="3", [routerLink]="['/browse','groups']") {{ 'NAV_MENU.COLLECTIONS.GROUPS' | translate }}
         li.nav-item(*ngIf="!_auth.isPublicOnly()", ngbDropdown, (mouseenter)="openDrop($event, drop2)", (mouseleave)="closeDrop($event, drop2)", #drop2="ngbDropdown")
-          button#organizeMenu.btn.btn-link(ngbDropdownToggle) {{ 'NAV_MENU.ORGANIZE.TITLE' | translate }}
+          button#organizeMenu.btn.btn-link(tabindex="3", ngbDropdownToggle) {{ 'NAV_MENU.ORGANIZE.TITLE' | translate }}
           .dropdown-menu(ngbDropdownMenu, aria-labelledby="organizeMenu")
             // Active on Image Group Page
-            button.dropdown-item((click)="selectAllInAssetGrid()", [class.disabled]="!allowSelectAll || !user.isLoggedIn") {{ 'NAV_MENU.ORGANIZE.SELECT_ALL' | translate }}
-            button#btnSaveToNewGroup.dropdown-item([class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="copyIG = false; editIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.NEW_GROUP' | translate }}
-            button#btnSaveToExistingGroup.dropdown-item([class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="showAddToGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.EXISTING_GROUP' | translate }}
-            button#btnDeleteFromGroup.dropdown-item(*ngIf="params['igId']", [class.disabled]="selectedAssets.length < 1 || !allowIgUpdate", (click)="showConfirmationModal = true") {{ 'NAV_MENU.ORGANIZE.DELETE_SELECTIONS' | translate }}
-            button#btnDeselectImages.dropdown-item([class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="_assets.setSelectedAssets([])") {{ 'NAV_MENU.ORGANIZE.DESELECT' | translate }}
+            button.dropdown-item(tabindex="3", (click)="selectAllInAssetGrid()", [class.disabled]="!allowSelectAll || !user.isLoggedIn") {{ 'NAV_MENU.ORGANIZE.SELECT_ALL' | translate }}
+            button#btnSaveToNewGroup.dropdown-item(tabindex="3", [class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="copyIG = false; editIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.NEW_GROUP' | translate }}
+            button#btnSaveToExistingGroup.dropdown-item(tabindex="3", [class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="showAddToGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.EXISTING_GROUP' | translate }}
+            button#btnDeleteFromGroup.dropdown-item(*ngIf="params['igId']", tabindex="3", [class.disabled]="selectedAssets.length < 1 || !allowIgUpdate", (click)="showConfirmationModal = true") {{ 'NAV_MENU.ORGANIZE.DELETE_SELECTIONS' | translate }}
+            button#btnDeselectImages.dropdown-item(tabindex="3", [class.disabled]="selectedAssets.length < 1 || !user.isLoggedIn", (click)="_assets.setSelectedAssets([])") {{ 'NAV_MENU.ORGANIZE.DESELECT' | translate }}
             .dropdown-divider
             // Active on Image Group Page
-            button#btnEditGroup.dropdown-item([disabled]="!actionOptions.group || !allowIgUpdate", (click)="editIG = true; copyIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.EDIT' | translate }}
-            button#btnSaveGroupAs.dropdown-item([disabled]="!actionOptions.group  || !user.isLoggedIn", (click)="copyIG = true; editIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.SAVE' | translate }}
-            button#btnDeleteGroup.dropdown-item([disabled]="!actionOptions.group || !allowIgUpdate", (click)="deleteIgModal = true") {{ 'NAV_MENU.ORGANIZE.DELETE_GROUP' | translate }}
+            button#btnEditGroup.dropdown-item(tabindex="3", [disabled]="!actionOptions.group || !allowIgUpdate", (click)="editIG = true; copyIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.EDIT' | translate }}
+            button#btnSaveGroupAs.dropdown-item(tabindex="3", [disabled]="!actionOptions.group  || !user.isLoggedIn", (click)="copyIG = true; editIG = false; showImageGroupModal = true;") {{ 'NAV_MENU.ORGANIZE.SAVE' | translate }}
+            button#btnDeleteGroup.dropdown-item(tabindex="3", [disabled]="!actionOptions.group || !allowIgUpdate", (click)="deleteIgModal = true") {{ 'NAV_MENU.ORGANIZE.DELETE_GROUP' | translate }}
             .dropdown-divider(*ngIf="siteID!='SAHARA'")
             // Add Images to Personal Collection for AIW users
-            button#addImgsPC.dropdown-item(*ngIf="siteID!='SAHARA'", [disabled]="!user.isLoggedIn", [routerLink]="['/browse', 'mycollections', {upload:true}]") {{ 'NAV_MENU.ORGANIZE.ADD_IMGS_PC' | translate }}
+            button#addImgsPC.dropdown-item(*ngIf="siteID!='SAHARA'", tabindex="3", [disabled]="!user.isLoggedIn", [routerLink]="['/browse', 'mycollections', {upload:true}]") {{ 'NAV_MENU.ORGANIZE.ADD_IMGS_PC' | translate }}
         li.nav-item(ngbDropdown, (mouseenter)="openDrop($event, drop3)", (mouseleave)="closeDrop($event, drop3)", #drop3="ngbDropdown")
-          button#shareMenu.btn.btn-link(ngbDropdownToggle) {{ 'NAV_MENU.SHARE.TITLE' | translate }}
+          button#shareMenu.btn.btn-link(tabindex="3", ngbDropdownToggle) {{ 'NAV_MENU.SHARE.TITLE' | translate }}
           .dropdown-menu(ngbDropdownMenu, aria-labelledby="shareMenu")
-            button.dropdown-item([class.disabled]="selectedAssets.length !== 1", (click)="showShareLinkModal = true") {{ 'NAV_MENU.SHARE.GENERATE_IMAGE_LINK' | translate }}
+            button.dropdown-item(tabindex="3", [class.disabled]="selectedAssets.length !== 1", (click)="showShareLinkModal = true") {{ 'NAV_MENU.SHARE.GENERATE_IMAGE_LINK' | translate }}
             // Active on Image Group Page
-            button.dropdown-item([disabled]="!actionOptions.group || !genImgGrpLink", (click)="showShareIgModal = true") {{ 'NAV_MENU.SHARE.GENERATE_GROUP_LINK' | translate }}
+            button.dropdown-item(tabindex="3", [disabled]="!actionOptions.group || !genImgGrpLink", (click)="showShareIgModal = true") {{ 'NAV_MENU.SHARE.GENERATE_GROUP_LINK' | translate }}
             // Active on Image Group Page
-            button.dropdown-item([disabled]="!actionOptions.group", (click)="printImageGroupPage()") {{ 'NAV_MENU.SHARE.PRINT_GROUP' | translate }}
+            button.dropdown-item(tabindex="3", [disabled]="!actionOptions.group", (click)="printImageGroupPage()") {{ 'NAV_MENU.SHARE.PRINT_GROUP' | translate }}
             // Active on Image Group Page
-            button.dropdown-item(*ngIf="params['igId']", (click)="_ig.triggerIgDownload()") {{ 'NAV_MENU.SHARE.DOWNLOAD_GROUP' | translate }}
+            button.dropdown-item(*ngIf="params['igId']", tabindex="3", (click)="_ig.triggerIgDownload()") {{ 'NAV_MENU.SHARE.DOWNLOAD_GROUP' | translate }}
         li.nav-item
-          a#viewMenu.btn.btn-link(*ngIf="_auth.isPublicOnly()", href="//support.artstor.org/?article-category=05-public-access-to-artstor", target="_blank") Support
-          a#viewMenu.btn.btn-link(*ngIf="!_auth.isPublicOnly()", href="//support.artstor.org", target="_blank") Support
+          a#viewMenu.btn.btn-link(*ngIf="_auth.isPublicOnly()", tabindex="3", href="//support.artstor.org/?article-category=05-public-access-to-artstor", target="_blank") Support
+          a#viewMenu.btn.btn-link(*ngIf="!_auth.isPublicOnly()", tabindex="3", href="//support.artstor.org", target="_blank") Support
         li.nav-item(*ngIf="!mobileCollapsed")
-          a.link--accent((click)="logout()", *ngIf="user.isLoggedIn") Log Out
-          a.link--accent([routerLink]="['/login']", *ngIf="!user.isLoggedIn") Log In
+          a.link--accent(tabindex="3", (click)="logout()", *ngIf="user.isLoggedIn") Log Out
+          a.link--accent(tabindex="3", [routerLink]="['/login']", *ngIf="!user.isLoggedIn") Log In
         li.nav-item(*ngIf="!mobileCollapsed && institutionObj")
           | Institution: {{ institutionObj.shortName ? institutionObj.shortName : institutionObj.institutionName }}
 ang-delete-ig-modal(*ngIf="deleteIgModal", (closeModal)="deleteIgModal = false", [ig]="ig", [igId]="route.snapshot.params.igId", [igName]="route.snapshot.params.name")

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -26,7 +26,7 @@
     "WRONG_PASSWORD" : "Invalid email address or password. Try again.",
     "INVALID_EMAIL" : "Please enter a valid email address",
     "PASSWORD_REQUIRED": "Password must be 7-20 characters",
-    "EXPIRED" : "That login is expired. Please login from campus to renew your account.",
+    "EXPIRED" : "That login is expired. Please log in from campus to renew your account.",
     "REGISTER_PROMPT": "Not Registered?",
     "ACCESS_PROMPT": "How do I get access?",
     "LINK_ERROR" : "There was an error linking your institutional account. The session may have expired, please try again."
@@ -363,7 +363,7 @@
       "LOGIN_PC_HEADING": "Login Required",
       "NO_INSTITUTIONAL_COLLECTIONS_HEADING": "No Institutional Collections found",
       "NO_INSTITUTIONAL_COLLECTIONS_PROMPT": "<p>There are no institutional collections available for your institution. You can add institutional collections using JSTOR Forum.</p><p>Learn more about <a href=\"http://artstor.org/jstorforum\" class=\"link\">JSTOR Forum</a>.</p>",
-      "LOGIN_PC_COLLECTIONS_PROMPT": "<p>Please login to access your Personal Collection.</p><p>Learn more about <a href=\"https://support.artstor.org/?article-category=09-using-your-own-images\" class=\"link\">Personal Collections</a>.</p>",
+      "LOGIN_PC_COLLECTIONS_PROMPT": "<p>Please log in to access your Personal Collection.</p><p>Learn more about <a href=\"https://support.artstor.org/?article-category=09-using-your-own-images\" class=\"link\">Personal Collections</a>.</p>",
       "NO_GROUPS_COLLECTIONS_HEADING": "No Groups Found",
       "NO_PRIVATE_GROUPS_COLLECTIONS_PROMPT": "<p>You haven't created any image groups yet. Learn more about <a href='http://support.artstor.org/?article=create-and-manage-image-groups' class='link'>groups</a>.</p>",
       "NO_INSTITUTIONAL_GROUPS_COLLECTIONS_PROMPT": "<p>You haven't made any institutional groups yet. Learn more about <a href='http://support.artstor.org/?article=create-and-manage-image-groups' class='link'>groups</a>.</p>",


### PR DESCRIPTION
 - Improve tabbing order according to the SC. NOTE: there are two "search box" appearing in the SC. According to Kelsey, the search box should be in the "Order Main content".
 - Also according to Kelsey, it would be better to remember the tab position so that it would be easy to switch between type menu and browse level menu. I change the code in app.component to make sure of this (and make sure it only occurs on browse pages). And I also remove the specific focus for filter which caused some problem.
 - Change the main content of the browser page to be the first type menu item, i.e. "Artstor Digital Library". So "skip to main content" link will jump to "Artstor Digital Library" for browser pages.
 - Enable the accessibility of icon inside the filter.
 - For some error messages, change from "login" to "log in" inside en.json when there should be a verb.