### PR TITLE
AIR-1886

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -387,9 +387,9 @@ export class AssetPage implements OnInit, OnDestroy {
                     this.pagination.totalPages = parseInt(pagination.totalPages);
                 }
                 // Page size can't be altered in the asset drawer, endpoint response is limited to 5000
-                let maxPageCount = APP_CONST.MAX_RESULTS / this.pagination.size
+                let maxPageCount = Math.floor(APP_CONST.MAX_RESULTS / this.pagination.size)
                 if (this.pagination.totalPages > maxPageCount) {
-                    this.pagination.totalPages = maxPageCount
+                    this.pagination.totalPages = maxPageCount + 1
                 }
             })
         );

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -387,9 +387,9 @@ export class AssetPage implements OnInit, OnDestroy {
                     this.pagination.totalPages = parseInt(pagination.totalPages);
                 }
                 // Page size can't be altered in the asset drawer, endpoint response is limited to 5000
-                let maxPageCount = Math.floor(APP_CONST.MAX_RESULTS / this.pagination.size)
+                let maxPageCount = Math.ceil(APP_CONST.MAX_RESULTS / this.pagination.size)
                 if (this.pagination.totalPages > maxPageCount) {
-                    this.pagination.totalPages = maxPageCount + 1
+                    this.pagination.totalPages = maxPageCount
                 }
             })
         );


### PR DESCRIPTION
Asset Page: Fix possible decimal values in  pagination total pages in compare mode
In compare mode, we missed a case where we needed to Math.floor the pagination total pages.