### PR TITLE
AIR-1848 (Make generate citation modal keyboard accessible)

### DIFF
--- a/src/app/modals/generate-citation/generate-citation.component.pug
+++ b/src/app/modals/generate-citation/generate-citation.component.pug
@@ -1,8 +1,8 @@
-.modal.fade-in.show(id="modal", tabindex="-1")
+.modal.fade-in.show(id="modal", tabindex="0")
   .modal-dialog.modal-lg(role="document")
     .modal-content
       .modal-header
-        h4.modal-title {{ 'GENERATE_CITATION_MODAL.MAIN_HEADING' | translate }}
+        h4#generate-citation-title.modal-title(tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'GENERATE_CITATION_MODAL.MAIN_HEADING' | translate }}
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
@@ -12,20 +12,20 @@
             label(for="copyAPA") {{ 'GENERATE_CITATION_MODAL.COPY_APA' | translate }}
             .value
               textarea#copyAPA(#copyAPA="", readonly) {{ apa_citation }}
-            .copy-clipboard((click)=" copyAPA.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
+            button.copy-clipboard((click)=" copyAPA.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
           //- MLA
           .pb-3.form-group
             label(for="copyMLA") {{ 'GENERATE_CITATION_MODAL.COPY_MLA' | translate }}
             .value
               textarea#copyMLA(#copyMLA="", readonly) {{ mla_citation }}
-            .copy-clipboard((click)=" copyMLA.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
+            button.copy-clipboard((click)=" copyMLA.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
           //- Chicago
           .pb-3.form-group
             label(for="copyChicago") {{ 'GENERATE_CITATION_MODAL.COPY_CHICAGO' | translate }}
             .value
               textarea#copyChicago(#copyChicago="", readonly) {{ chicago_citation }}
-            .copy-clipboard((click)=" copyChicago.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
+            button.copy-clipboard((click)=" copyChicago.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
           .form-control-feedback(*ngIf="citationCopied") {{ 'GENERATE_CITATION_MODAL.COPY_SUCCESS' | translate }}
       .modal-footer
         a.btn.btn-link.with-pad(href="https://support.artstor.org/?article=export-citations", target="_blank") Help
-        button.btn.btn-primary((click)="closeModal.emit()") Close
+        button.btn.btn-primary((click)="closeModal.emit()", (focusout)="startModalFocus()") Close

--- a/src/app/modals/generate-citation/generate-citation.component.scss
+++ b/src/app/modals/generate-citation/generate-citation.component.scss
@@ -23,6 +23,8 @@
     padding: 5px 0;
 }
 .copy-clipboard{
+    background-color: transparent;
+    border: none;
     font-size: 12px;
     color: #a4a4a4;
     border-bottom: 1px dotted #ddd;

--- a/src/app/modals/generate-citation/generate-citation.component.ts
+++ b/src/app/modals/generate-citation/generate-citation.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core'
+import { Component, OnInit, Input, Output, EventEmitter, AfterViewInit } from '@angular/core'
 import { DatePipe } from '@angular/common'
 
 import { Asset } from '../../asset-page/asset'
@@ -9,7 +9,7 @@ import { LogService } from '../../shared'
   templateUrl: 'generate-citation.component.pug',
   styleUrls: ['./generate-citation.component.scss']
 })
-export class GenerateCitation implements OnInit {
+export class GenerateCitation implements OnInit, AfterViewInit {
   @Output()
   private closeModal: EventEmitter<any> = new EventEmitter()
 
@@ -39,6 +39,16 @@ export class GenerateCitation implements OnInit {
       eventType: 'artstor_citation',
       item_id: this.asset.id
     })
+  }
+
+  ngAfterViewInit() {
+    this.startModalFocus()
+  }
+
+  // Set initial focus on the modal Title h1
+  private startModalFocus() {
+    let modalStartFocus = document.getElementById('generate-citation-title')
+    modalStartFocus.focus()
   }
 
   /**

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -148,6 +148,7 @@ $iconBtnSize: $btnHeight;
     }
 
     &:focus {
+        background: none;
         text-decoration: none;
         color: #0039c6;
         outline: rgb(77, 144, 254) auto 5px;


### PR DESCRIPTION
 - Focus on the title of the modal
 - Disable tabbing outside the modal
 - Enable tabbing of the button of Copy-to-Clipboard
 - Change the focus style of help link

Note: Since we use "focusout" event on the last button, when we hit "shift tab" while focusing on the last button, we will go to the title instead of the previous button. This behavior appears on every newly changed modal. Currently haven't figured out a way to solve it.