### PR TITLE
Air-1906 (Artstor SAML Account Linking Showing Error in URL)

### DIFF
--- a/src/app/register/register.component.pug
+++ b/src/app/register/register.component.pug
@@ -6,7 +6,7 @@ nav-menu
       .alert.alert-danger.mb-4(*ngIf="serviceErrors['shibbolethInst']") 
         b Error Linking&nbsp;
         | {{ 'SHIBBOLETH_ERRORS.INST404' | translate }}
-      .alert.alert-danger.mb-4(*ngIf="serviceErrors['user']") 
+      .alert.alert-warning.mb-4(*ngIf="serviceErrors['user']") 
         b Step 2 of 2 (required): Link to an existing Artstor account or register for a new one.
       .text-right.mb-2(*ngIf="isShibbFlow")
         .btn.btn-secondary((click)="navigateToLogin()", [class.disabled]="!shibParameters.samlTokenId") {{ 'LINK_PAGE.LOGIN_OPTION' | translate }}

--- a/src/app/register/register.component.pug
+++ b/src/app/register/register.component.pug
@@ -7,7 +7,7 @@ nav-menu
         b Error Linking&nbsp;
         | {{ 'SHIBBOLETH_ERRORS.INST404' | translate }}
       .alert.alert-warning.mb-4(*ngIf="serviceErrors['user']") 
-        b Step 2 of 2 (required): Link to an existing Artstor account or register for a new one.
+        b {{ 'SHIBBOLETH_ERRORS.USER404' | translate }}
       .text-right.mb-2(*ngIf="isShibbFlow")
         .btn.btn-secondary((click)="navigateToLogin()", [class.disabled]="!shibParameters.samlTokenId") {{ 'LINK_PAGE.LOGIN_OPTION' | translate }}
       .card.card--light([class.disabled]="isShibbFlow && !shibParameters.samlTokenId")

--- a/src/app/register/register.component.pug
+++ b/src/app/register/register.component.pug
@@ -6,6 +6,8 @@ nav-menu
       .alert.alert-danger.mb-4(*ngIf="serviceErrors['shibbolethInst']") 
         b Error Linking&nbsp;
         | {{ 'SHIBBOLETH_ERRORS.INST404' | translate }}
+      .alert.alert-danger.mb-4(*ngIf="serviceErrors['user']") 
+        b Step 2 of 2 (required): Link to an existing Artstor account or register for a new one.
       .text-right.mb-2(*ngIf="isShibbFlow")
         .btn.btn-secondary((click)="navigateToLogin()", [class.disabled]="!shibParameters.samlTokenId") {{ 'LINK_PAGE.LOGIN_OPTION' | translate }}
       .card.card--light([class.disabled]="isShibbFlow && !shibParameters.samlTokenId")

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -66,6 +66,7 @@ export class RegisterComponent implements OnInit {
     let samlTokenId: string = this.route.snapshot.params.samlTokenId
     let type: string = this.route.snapshot.params.type
     this.serviceErrors['shibbolethInst'] = this.route.snapshot.params.error == 'INST404'
+    this.serviceErrors['user'] = this.route.snapshot.params.error == 'USER404'
 
     if (samlTokenId || type == 'shibboleth') {
       email && this.registerForm.controls.email.setValue(email) // set the email

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -75,6 +75,7 @@
   },
   "SHIBBOLETH_ERRORS": {
     "INST404": "There was a problem identifying your institution. Please contact your institution admin to report this error, and to learn more about off-campus access.",
+    "USER404": "Step 2 of 2 (required): Link to an existing Artstor account or register for a new one.",
     "2010": "This account is already linked to an Artstor account.",
     "2020": "There was an error linking your institutional account. The session may have expired, please try again.",
     "2040": "This account is associated with another institution. Please create a new account.",


### PR DESCRIPTION
 - Keep the error in the url
 - If there is "USER404" in the url, display message saying "Step 2 of 2 (required): Link to an existing Artstor account or register for a new one." with alert-warning.