### PR TITLE
AIR-1873 ('Download' button disappears on asset page after downloading media file)

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1020,6 +1020,9 @@ export class AssetPage implements OnInit, OnDestroy {
               this.runDownloadView(this.downloadViewLink)
             }, 1000);
         }
+        else {
+            this.downloadLoading = false
+        }
     }
 
     /**


### PR DESCRIPTION
 - In function genDownloadViewLink() we make the download button disappear and in function runDownloadView() we make it back. However, we wrap the function runDownloadView() in an if clause. So if we don't enter the if clause we will never make the button back. Add  an else to solve it.