### PR TITLE
AIR-1924 (Fix artClassification filter on production)

### DIFF
--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -204,6 +204,12 @@ export class AssetFilters {
             filters['contributinginstitutionid'] = null
           }
 
+          // Filter out categories containing pipe in name field
+          if (filters && filters.artclassification_str && filters.artclassification_str.length !== 0 ) {
+            filters.artclassification_str = filters.artclassification_str.filter((category) => {
+              return category.name.indexOf('|') === -1
+            })
+          }
           this.availableFilters = filters
 
         }


### PR DESCRIPTION
**Test Note**: The problem in the ticket doesn’t occur on local because we are calling `//stage.artstor.org/api/search/v1.0/search`  on local and stage. The pipes only occur when we call `//library.artstor.org/api/search/v1.0/search`. So to test, we can set line 158 of auth.service.ts to be `this.solrUrl = '//library.artstor.org/api/search/v1.0/search'` to make the problem occur on local and see the difference of the change.