### PR TITLE
Air 1544: sscommons.org redirects

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -37,6 +37,7 @@ export const ROUTES: Routes = [
   { path: 'home',  component: Home, canActivate: [AuthService] },
   { path: 'search/', redirectTo: '/search/*', pathMatch: 'full', canActivate: [AuthService] },
   { path: 'asset/:assetId', component: AssetPage, pathMatch: 'full' },
+  { path: 'object/:assetId', redirectTo: '/asset/*', pathMatch: 'full' },
   { path: 'asset/external/:encryptedId', component: AssetPage, pathMatch: 'full' },
   { path: 'search/:term', component: SearchPage, canActivate: [AuthService] },
   { path: 'search', component: SearchPage, pathMatch: 'full', canActivate: [AuthService] },

--- a/src/app/legacy.service.ts
+++ b/src/app/legacy.service.ts
@@ -44,7 +44,7 @@ export class LegacyRouteResolver implements Resolve<boolean> {
     } else if (url.endsWith('welcome.html')) { // If the legacy URL ends with 'welcome.html'
       this._router.navigate(['/home'])
       return true
-    } else if (url.indexOf('/library') == 0) {
+    } else if (url.indexOf('/library') == 0 || url.indexOf('/openlibrary') == 0) {
       // This is the normal expectation for old links!
     } else {
       return true

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
           || initPath.indexOf('/library/collection') > -1
           || initPath.indexOf('/library/welcome.html') > -1 
           || initPath.indexOf('.org/library/#') > -1
+          || initPath.indexOf('/openlibrary') > -1
           || initPath.indexOf('/asset/') > -1
           || initPath.indexOf('/assetprint/') > -1
           || initPath.indexOf('/group/') > -1
@@ -24,7 +25,10 @@
         ) {
           if (initPath.indexOf('/library/') > -1) {
             initPath = initPath.substr(initPath.indexOf('/library/'));
+          } else if (initPath.indexOf('/openlibrary/') > -1) {
+            initPath = initPath.substr(initPath.indexOf('/openlibrary/'));
           } else if (initPath.indexOf(initOrigin) > -1) {
+            // Handle cases where hostname exists within the URL multiple times, especially on proxies
             initPath = initPath.substr(initPath.lastIndexOf(initOrigin) + initOrigin.length);
           } else {
             initPath = null

--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,7 @@
           || initPath.indexOf('.org/library/#') > -1
           || initPath.indexOf('/openlibrary') > -1
           || initPath.indexOf('/asset/') > -1
+          || initPath.indexOf('/object/') > -1
           || initPath.indexOf('/assetprint/') > -1
           || initPath.indexOf('/group/') > -1
           || initPath.indexOf('/browse/') > -1


### PR DESCRIPTION
Links like:
http://sscommons.org/openlibrary/secure/ViewImages?id=4jEkdDElKzQ3RkY6fz57RH1DOHQqeFlxdg%3D%3D&userId=gDFB&zoomparams=
Will be redirected to:
http://library.artstor.org/openlibrary/secure/ViewImages?id=4jEkdDElKzQ3RkY6fz57RH1DOHQqeFlxdg%3D%3D&userId=gDFB&zoomparams=

So we can verify our app will handle them by replacing "sscommons.org" with our hostname

(To test locally you will also need to add the hash "/#" to the path)