### PR TITLE
1951-2

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -1,6 +1,6 @@
 .card-block.card-text([attr.aria-labelledby]="thumbnail.artstorid", tabindex="3")
   .card-img-top
-    img(*ngIf="thumbnail.status != 'not-available'", id="{{thumbnail.artstorid}}", [class.disablePointerEvents]="reorderMode", [attr.src]="isMultiView ? thumbnail.thumbnailImgUrl : _search.makeThumbUrl(thumbnail.media.thumbnailSizeOnePath, thumbnailSize)", (error)="thumbnailError()", [attr.alt]="thumbnailAlt", [attr.aria-label]="thumbnailAlt", [attr.title]="thumbnailAlt", aria-role="image")
+    img(*ngIf="thumbnail.status != 'not-available'", id="{{thumbnail.artstorid}}", [class.disablePointerEvents]="reorderMode", [attr.src]="isMultiView ? thumbnail.thumbnailImgUrl : _search.makeThumbUrl(thumbnail.thumbnailImgUrl, thumbnailSize)", (error)="thumbnailError()", [attr.alt]="thumbnailAlt", [attr.aria-label]="thumbnailAlt", [attr.title]="thumbnailAlt", aria-role="image")
   .metadata-wrap
     //- New Asset display
     span.asset-title(*ngIf="thumbnail.name", title="{{ thumbnail.name }}", [innerHTML]="thumbnail.name", aria-hidden="true")

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -62,8 +62,10 @@ export class ThumbnailComponent implements OnInit, OnChanges {
       this.isMultiView = true
       this.thumbnail.thumbnailImgUrl = this.thumbnail['thumbnailUrls'][0]
     }
-    // Note: We don't need to handle thumbnail['media']) here because it is set from
-    // the template by asset-search.makeThumbUrl
+
+    else if (this.thumbnail['media']) {
+      this.thumbnail.thumbnailImgUrl = this.thumbnail.media.thumbnailSizeOnePath
+    }
 
     this.thumbnailAlt = this.thumbnail['name'] ? 'Thumbnail of ' + this.thumbnail['name'] : 'Untitled'
     this.thumbnailAlt = this.thumbnail['agent'] ? this.thumbnailAlt + ' by ' + this.thumbnail['agent'] : this.thumbnailAlt + ' by Unknown'


### PR DESCRIPTION
Thumbnail comp: Fix thumbnail error for browse groups page, follows 1951

-thumbnail.media field isn't defined from data on browse group asset-grid,
so `thumbnail.thumbailImgUrl` still needs set and used in thumbnail's img src

@codiak @pkathera 