### PR TITLE
Air 1831

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1165,7 +1165,8 @@ export class AssetPage implements OnInit, OnDestroy {
                         // Reload asset metadata
                         this._router.navigate(['/asset', ''])
                         setTimeout(() => {
-                            this._router.navigate(['/asset', this.assets[0].id])
+                            // Pass the prevRouteTS param to make sure we load prevRouteParams
+                            this._router.navigate([ '/asset', this.assets[0].id, this.prevRouteTS ? { prevRouteTS: this.prevRouteTS } : {} ])
                         }, 250)
                     }
                 },


### PR DESCRIPTION
'Back to Results' link disappears after user updates PC assets metadata and saves it.
Make sure to pass **prevTS** param to the asset page route after save!