### PR TITLE
Air-1625 (Error after deleting 3 or 4 personal collection files in ADL)

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -82,7 +82,7 @@
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
-          button.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", tabindex="6", (click)="loadEditDetailsForm()")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", tabindex="6", (click)="loadEditDetailsForm()")
             | {{ 'ASSET_PAGE.BUTTONS.EDIT_DETAILS' | translate}}
 
           //- the .driver-find-group-btn class is important for the tour to find it, be careful when removing or changing it

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -377,7 +377,7 @@
   },
   "PERSONAL_COLLECTION_PAGE": {
     "BANNER": {
-      "DELETE_SUCCESS": "{{title}} was successfully deleted from your personal collection."
+      "DELETE_SUCCESS": "{{title}} has been deleted. There may be a delay before it no longer appears in your collection."
     },
     "MORE_ABOUT_PUBLISHING": "<a href=\"https://support.artstor.org/?article=upload-images-to-personal-collections#Upload_messaging_PC\" class=\"link\" target=\"_blank\">More about publishing</a>"
   },
@@ -661,7 +661,7 @@
     "geography" : "Geography",
     "collTypes" : "Collection Type",
     "collectiontypes" : "Collection Type",
-    "contributinginstitutionid": "Contributor",
+    "contributinginstitutionid" : "Contributor",
     "date" : "Date"
   },
   "FIELD" : {


### PR DESCRIPTION
 - About the problem: The images are actually deleted but it needs some time for it to be really deleted. In the meantime, the deleted thumbnail still appears in the personal collection and it is still clickable, which leads the user to land on an asset page that has content unavailable. 
 - About the solution: We now update the message after a successful deletion from personal collections to inform users that there may be a delay.