### PR TITLE
AIR-1962 (Unable to download media files from image groups)

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -527,7 +527,7 @@ export class AssetPage implements OnInit, OnDestroy {
      */
     setDownloadFull(): void {
         let url = this.assets[0] ? this.assets[0].downloadLink : '';
-        if (this.assetGroupId) {
+        if (this.assetGroupId && url.indexOf("/media/") === -1 ) {
             // Group id needs to be passed to allow download for images accessed via groups
             // - Binder prefers lowercase service url params
             url = url + '&groupid=' + this.assetGroupId


### PR DESCRIPTION
- Media files cannot be downloaded from localhost, the href we are using: "//stage.artstor.org/media/SS34216_34216_33832185/22" is reporting "This site can’t be reached" (So I cannot test from localhost). 
 -Media files can be downloaded from prod. Before added to image group, the download link of a media file is something like "/media/SS34216_34216_33832187/21". After added to image group, we will add image group id to the url, resulting the href to be "/media/SS34216_34216_33832187/21&groupid=f374dae5-0a13-49ef-9883-f6ba16b20cfb". 
 - It turns out that **the file can only be downloaded without the groupid parameter being added**.
 - Manually check for media file and don't append groupid to solve this (I realize it is really ugly code. I don't know if it is a good solution. It should work on prod but it'll be better to find out why media link with groupid is failing.)