### PR TITLE
Air-1970 (Add and create labels on Log In page)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,14 +24,12 @@ import { ScriptService, FlagService } from './shared'
         <button id="button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
       </div>
       <nav-bar tabindex="-1"></nav-bar>
+      <main>
+        <router-outlet></router-outlet>
+      </main>
+      
+      <footer></footer>
     </div>
-    <main tabindex="-1">
-      <router-outlet></router-outlet>
-    </main>
-
-    <footer>
-    </footer>
-
   `
 })
 export class App {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,7 +27,7 @@ import { ScriptService, FlagService } from './shared'
       <main>
         <router-outlet></router-outlet>
       </main>
-      
+
       <footer></footer>
     </div>
   `

--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -1,10 +1,10 @@
 form((ngSubmit)="login(user)")
   #mainContent.form-group
     label#emailLabel(for="inputLoginEmail") {{ 'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate }}
-    input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-labeledby="emailLabel")
+      input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-label="Email address, required")
   .form-group
     label(for="inputLoginPassword") {{ 'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate }}
-    input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-describedby="info")
+      input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-label="Artstor password, required")
     #errorMsg.form-text.text-danger(
       *ngIf="errorMsg",
       [innerHtml]="errorMsg | translate"

--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -1,9 +1,11 @@
 form((ngSubmit)="login(user)")
   #mainContent.form-group
-    label#emailLabel(for="inputLoginEmail") {{ 'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate }}
+    label#emailLabel(for="inputLoginEmail")
+      span([innerHtml]="'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate")
       input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-label="Email address, required" tabindex="1")
   .form-group
-    label(for="inputLoginPassword") {{ 'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate }}
+    label(for="inputLoginPassword")
+      span([innerHtml]="'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate")
       input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-label="Artstor password, required" tabindex="1")
     #errorMsg.form-text.text-danger(
       *ngIf="errorMsg",

--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -1,10 +1,10 @@
 form((ngSubmit)="login(user)")
   #mainContent.form-group
     label#emailLabel(for="inputLoginEmail") {{ 'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate }}
-      input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-label="Email address, required")
+      input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-label="Email address, required" tabindex="1")
   .form-group
     label(for="inputLoginPassword") {{ 'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate }}
-      input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-label="Artstor password, required")
+      input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-label="Artstor password, required" tabindex="1")
     #errorMsg.form-text.text-danger(
       *ngIf="errorMsg",
       [innerHtml]="errorMsg | translate"
@@ -12,5 +12,5 @@ form((ngSubmit)="login(user)")
     p.form-text.text-danger(*ngIf="forcePwdRst", [innerHtml]="'LOGIN.REG_LOGIN.FORCE_PW_RESET_MSG' | translate")
   p.notranslate([innerHtml]=" copyBase + 'LOGIN.TERMS' | translate ")
   .form-group
-    button#btnLoginRemote.btn.btn-primary([class.loading]="loginLoading" type="submit" name="action" data-sc="account: remote user log in" data-automation-component="artstor-login-button") 
+    button#btnLoginRemote.btn.btn-primary([class.loading]="loginLoading" type="submit" name="action" data-sc="account: remote user log in" data-automation-component="artstor-login-button" tabindex="1") 
       | {{ 'LOGIN_FORM.LOGIN_BUTTON.' + copyModifier | translate }}

--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -1,10 +1,10 @@
 form((ngSubmit)="login(user)")
   #mainContent.form-group
-    label(for="loginEmail") {{ 'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate }}
-    input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Username")
+    label#emailLabel(for="inputLoginEmail") {{ 'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate }}
+    input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-labeledby="emailLabel")
   .form-group
-    label(for="loginPassword") {{ 'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate }}
-    input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password")
+    label(for="inputLoginPassword") {{ 'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate }}
+    input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-describedby="info")
     #errorMsg.form-text.text-danger(
       *ngIf="errorMsg",
       [innerHtml]="errorMsg | translate"

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -22,8 +22,8 @@
           h2.h1#institutionHeading {{ 'LOGIN.INSTITUTION_LOGIN.HEADING' | translate }}
         .card-body
           .form-group
-            label {{ 'LOGIN.INSTITUTION_LOGIN.SELECT_LABEL' | translate }}
-            ng2-completer(
+            label(for="completer") {{ 'LOGIN.INSTITUTION_LOGIN.SELECT_LABEL' | translate }}
+            ng2-completer#completer(
               [(ngModel)]="loginInstName",
               (keyup)="sortInstitution($event, loginInstName)",
               (click)="(instErrorMsg ? sortInstitution($event, loginInstName): 'null')",
@@ -33,7 +33,7 @@
               [placeholder]=`"Type to search your institution's name"`,
               [textSearching]="'Searching Institutions...'",
               [clearUnselected]="true",
-              name="institutionSelector"
+              aria-live="polite"
             )
             .login-errorMsg(*ngIf="instErrorMsg") {{ instErrorMsg | translate }}
           .form-group

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -30,7 +30,7 @@
               [datasource]="dataService",
               [minSearchLength]="0",
               [openOnFocus]="true",
-              [placeholder]="'Type to search...'",
+              [placeholder]=`"Type to search your institution's name"`,
               [textSearching]="'Searching Institutions...'",
               [clearUnselected]="true",
               name="institutionSelector"

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -8,14 +8,14 @@
           h2.h1#loginHeading {{ copyBase + 'LOGIN.REG_LOGIN.HEADING' | translate }}
         .card-body
           ang-login-form#mainContent
-          a#linkLoginResetModal((click)="showPwdModal = true" tabindex="0" class="link" data-automation-component="artstor-pw-reset-link") {{ 'LOGIN.REG_LOGIN.FORGOT_PW_PROMPT' | translate }}
+          a#linkLoginResetModal((click)="showPwdModal = true" tabindex="1" class="link" data-automation-component="artstor-pw-reset-link") {{ 'LOGIN.REG_LOGIN.FORGOT_PW_PROMPT' | translate }}
           br
           div(*ngIf="showRegister")
-            a.link([routerLink]="['/register']" tabindex="0") {{ 'LOGIN.REGISTER_PROMPT' | translate }}
+            a.link([routerLink]="['/register']" tabindex="1") {{ 'LOGIN.REGISTER_PROMPT' | translate }}
             br
-          a.link([attr.href]="'LOGIN.REG_LOGIN.LOGIN_HELP_LINK' | translate" target="_blank" data-automation-component="artstor-login-help-link" tabindex="0") {{ 'LOGIN.REG_LOGIN.LOGIN_HELP_PROMPT' | translate }}
+          a.link([attr.href]="'LOGIN.REG_LOGIN.LOGIN_HELP_LINK' | translate" target="_blank" data-automation-component="artstor-login-help-link" tabindex="1") {{ 'LOGIN.REG_LOGIN.LOGIN_HELP_PROMPT' | translate }}
         .block-right
-          a.link((click)="showHelpModal = true" tabindex="0" data-automation-component="artstor-access-help-link") {{ 'LOGIN.ACCESS_PROMPT' | translate }}
+          a.link((click)="showHelpModal = true" tabindex="1" data-automation-component="artstor-access-help-link") {{ 'LOGIN.ACCESS_PROMPT' | translate }}
     .col-sm-6(*ngIf="_app.config.showInstitutionalLogin")
       .card.card--v-pad
         .card-header
@@ -33,14 +33,15 @@
               [placeholder]=`"Type to search your institution's name"`,
               [textSearching]="'Searching Institutions...'",
               [clearUnselected]="true",
-              aria-live="polite"
+              aria-live="polite",
+              tabindex="1"
             )
             .login-errorMsg(*ngIf="instErrorMsg") {{ instErrorMsg | translate }}
           .form-group
             p.notranslate([innerHtml]="'LOGIN.TERMS' | translate")
             p.small {{ 'LOGIN.INSTITUTION_LOGIN.LIST_INFO' | translate }}
           .form-group
-            button#btnLoginProxy.btn.btn-primary((click)="goToInstLogin()" type="submit" name="action" data-sc="account: institutional user log in" data-automation-component="artstor-institution-login-button" tabindex="0")
+            button#btnLoginProxy.btn.btn-primary((click)="goToInstLogin()" type="submit" name="action" data-sc="account: institutional user log in" data-automation-component="artstor-institution-login-button" tabindex="1")
               | {{ 'LOGIN.LOGIN_BTN' | translate }}
     .col-sm-6(*ngIf="_app.config.saharaLogin")
       .card.card--v-pad
@@ -48,15 +49,15 @@
           h1#saharaLoginHeading {{ copyBase + 'LOGIN.SAHARA_LOGIN.HEADING' | translate }}
         .card-body
           .form-group
-            | #[a#linkLoginSaharaSS.link(tabindex="0", [attr.href]="_auth.getEnv() === 'test' ? FORUM_TEST : FORUM_PROD", target="_blank", data-automation-component="ss-login-link") Log in] to JSTOR Forum
+            | #[a#linkLoginSaharaSS.link(tabindex="1", [attr.href]="_auth.getEnv() === 'test' ? FORUM_TEST : FORUM_PROD", target="_blank", data-automation-component="ss-login-link") Log in] to JSTOR Forum
 ang-pwd-reset-modal(*ngIf="showPwdModal", (closeModal)="showPwdModal = false")
 #helpModal.modal([ngClass]="{'show': showHelpModal }")
   .modal-dialog
     .modal-content
       .modal-header
         h5 {{ 'ACCESS_HELP_MODAL.HEADING' | translate }}
-        button.close((click)="showHelpModal = false" type="button" tabindex="0")
+        button.close((click)="showHelpModal = false" type="button" tabindex="1")
           span(aria-hidden="true") &times;
       .modal-body([innerHtml]="'ACCESS_HELP_MODAL.PROMPT' | translate")
       .modal-footer
-        button#btnLoginDismissHelp.btn.btn-primary((click)="showHelpModal = false" tabindex="0") {{ 'ACCESS_HELP_MODAL.DISMISS' | translate }}
+        button#btnLoginDismissHelp.btn.btn-primary((click)="showHelpModal = false" tabindex="1") {{ 'ACCESS_HELP_MODAL.DISMISS' | translate }}

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -33,8 +33,8 @@
               [placeholder]=`"Type to search your institution's name"`,
               [textSearching]="'Searching Institutions...'",
               [clearUnselected]="true",
+              [fieldTabindex]="1",
               aria-live="polite",
-              tabindex="1"
             )
             .login-errorMsg(*ngIf="instErrorMsg") {{ instErrorMsg | translate }}
           .form-group

--- a/src/app/modals/change-password/change-password.component.pug
+++ b/src/app/modals/change-password/change-password.component.pug
@@ -21,7 +21,7 @@
             div#msgNewPassRequired.form-control-feedback(*ngIf="submitted && passForm.controls['newPass'].hasError('required')")
               | {{ 'ACCOUNT.CHANGE_PASS.NEW_PASS_REQUIRED' | translate }}
           .form-group([class.has-danger]="submitted && passForm.controls['newPassConfirm'].hasError('required')", [class.has-warning]="passForm.hasError('passwordMismatch')")
-            label(for="inputOldPassword") {{ 'ACCOUNT.CHANGE_PASS.LABELS.NEW_PASS_CONFIRM' | translate }}
+            label(for="inputNewPasswordConfirm") {{ 'ACCOUNT.CHANGE_PASS.LABELS.NEW_PASS_CONFIRM' | translate }}
             input#inputNewPasswordConfirm.form-control([formControl]="passForm.controls['newPassConfirm']", type="password")
             div#msgPassConfirmError.form-control-feedback(*ngIf="passForm.hasError('passwordMismatch')") {{ 'ACCOUNT.CHANGE_PASS.PASS_CONFIRM_ERROR' | translate }}
           .form-group([class.has-danger]="serviceResponses.generalError || serviceResponses.wrongPass", [class.has-success]="serviceResponses.success")

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,7 +3,7 @@
     "REG_LOGIN": {
       "HEADING": "Log in with your Artstor account",
       "EMAIL_LABEL": "Email Address",
-      "PASSWORD_LABEL": "Artstor Password",
+      "PASSWORD_LABEL": "<span class=\"sr-only\">Artstor </span>Password",
       "FORCE_PW_RESET_MSG": "Please <a id=\"forcePwdResetModal\" (click)=\"showPwdModal = true\" class=\"link\">reset your password</a> in order to log in.",
       "FORGOT_PW_PROMPT": "Forgot password?",
       "LOGIN_HELP_LINK": "http://support.artstor.org/?article-category=03-accessing-the-artstor-digital-library",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2,8 +2,8 @@
   "LOGIN": {
     "REG_LOGIN": {
       "HEADING": "Log in with your Artstor account",
-      "EMAIL_LABEL": "Email Address",
-      "PASSWORD_LABEL": "Password",
+      "EMAIL_LABEL": "Email Address, required",
+      "PASSWORD_LABEL": "Artstor Password, required",
       "FORCE_PW_RESET_MSG": "Please <a id=\"forcePwdResetModal\" (click)=\"showPwdModal = true\" class=\"link\">reset your password</a> in order to log in.",
       "FORGOT_PW_PROMPT": "Forgot password?",
       "LOGIN_HELP_LINK": "http://support.artstor.org/?article-category=03-accessing-the-artstor-digital-library",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -22,7 +22,7 @@
     "LOGIN_BTN": "Log in",
     "SERVER_ERROR": "Server is not responding. Please try again later.",
     "ARCHIVED_ERROR": "That login has been disabled. Please contact your institutional contact.",
-    "TERMS": "By using Artstor Digital Library, I agree to the <a id=\"linkTermsAndConditions\" data-automation-component=\"artstor-login-terms\" href=\"http://www.artstor.org/terms\" class=\"link\" target=\"_blank\">Terms</a>",
+    "TERMS": "By using Artstor Digital Library, I agree to the <a id=\"linkTermsAndConditions\" tabindex=\"1\" data-automation-component=\"artstor-login-terms\" href=\"http://www.artstor.org/terms\" class=\"link\" target=\"_blank\">Terms</a>",
     "WRONG_PASSWORD" : "Invalid email address or password. Try again.",
     "INVALID_EMAIL" : "Please enter a valid email address",
     "PASSWORD_REQUIRED": "Password must be 7-20 characters",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2,8 +2,8 @@
   "LOGIN": {
     "REG_LOGIN": {
       "HEADING": "Log in with your Artstor account",
-      "EMAIL_LABEL": "Email Address, required",
-      "PASSWORD_LABEL": "Artstor Password, required",
+      "EMAIL_LABEL": "Email Address",
+      "PASSWORD_LABEL": "Artstor Password",
       "FORCE_PW_RESET_MSG": "Please <a id=\"forcePwdResetModal\" (click)=\"showPwdModal = true\" class=\"link\">reset your password</a> in order to log in.",
       "FORGOT_PW_PROMPT": "Forgot password?",
       "LOGIN_HELP_LINK": "http://support.artstor.org/?article-category=03-accessing-the-artstor-digital-library",


### PR DESCRIPTION
 - Some fields read the whole page problem should be solved in a general way in the app component
 - Change e-mail field placeholder
 - Change institution dropdown placeholder
 - Correct tabindex

Note: ng2-completer is still having weird behavior of reading half of the previous thing. AIR-1999 is created for this.