### PR TITLE
AIR-2020 (Collection list not loading on homepage)

### DIFF
--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -38,8 +38,8 @@
             h2.h1 {{ 'HOME.HEADINGS.INSTITUTION_COLLECTIONS' | translate:{ institutionName: institution.shortName ? institution.shortName : 'Institutional' } }}
           .list--home-collections([class.loading]="loaders['instCollections']")
             .list-group.list-group-flush
-              a.list-group-item.list-group-item-action(*ngFor="let collection of instCollections", [routerLink]="[ '/collection', collection.collectionid ]")
-                span.notranslate  {{ collection.collectionname }}
+              a.list-group-item.list-group-item-action(*ngFor="let collection of instCollections", [routerLink]="[ '/collection', collection.tagId ]")
+                span.notranslate  {{ collection.title }}
           .card-block(*ngIf="errors.instCollections")
             #errorCollectionsLoading.alert.alert-warning(role="alert")
               strong Error

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -7,6 +7,7 @@ import { DeviceDetectorModule, DeviceDetectorService } from 'ngx-device-detector
 import { AssetService, AuthService, ScriptService } from '../shared'
 import { AppConfig } from '../app.service'
 import { Featured } from './featured'
+import { TagsService } from '../browse-page/tags.service';
 
 declare var initPath: string
 
@@ -54,7 +55,8 @@ export class Home implements OnInit, OnDestroy {
     private _router: Router,
     public _auth: AuthService,
     private deviceService: DeviceDetectorService,
-    private _script: ScriptService
+    private _script: ScriptService,
+    private _tags: TagsService
   ) {
     // this makes the window always render scrolled to the top
     this._router.events.pipe(
@@ -105,26 +107,24 @@ export class Home implements OnInit, OnDestroy {
         map(userObj => {
           if (userObj.institutionId && (this.instCollections.length === 0)) {
 
-            this.subscriptions.push(this._assets.getCollectionsList().pipe(
-                map(data => {
-                  // Filter SSC content
-                  this.collections = data['Collections'].filter((collection) => {
-                    return collection.collectionType == 5
-                  })
-                  this.loaders['collections'] = false;
-                  // Filter institutional content
-                  this.instCollections = data['Collections'].filter((collection) => {
-                    return collection.collectionType == 2 || collection.collectionType == 4
-                  })
-                  this.loaders['instCollections'] = false;
-                },
-                err => {
-                  if (err && err.status != 401 && err.status != 403) {
-                    console.error('Failed to load collection list', err)
-                  }
-                }
-              )).subscribe()
-            ) // end push
+            let queryType = {};
+            if (this._auth.isPublicOnly()) {
+              queryType['type'] = "ssc"
+            }
+            else {
+              queryType['type'] = "institution"
+            }
+
+            this._tags.initTags(queryType)
+              .then((tags) => {
+                this.instCollections = tags;
+                console.log(this.instCollections);
+                this.loaders['instCollections'] = false;
+              })
+              .catch((err) => {
+                console.error(err);
+              });
+              
           }
         },
         err => {


### PR DESCRIPTION
 - Binder doesn't support `api/v1/collections/` in new collection service. Switch to use search endpoint to get institution list on homepage.
 - Use existing tag service as what we did on browse institutional collection page.