### PR TITLE
AIR-2061

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -761,7 +761,7 @@ export class AssetGrid implements OnInit, OnDestroy {
   /**
    * Closes "exiting reorder" modal
    */
-  private ditchingReorder(command) {
+  public ditchingReorder(command) {
     // Hide modal
     this.showLoseReorder = false;
     if (command.includes('Save')) {

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -761,15 +761,14 @@ export class AssetGrid implements OnInit, OnDestroy {
   /**
    * Closes "exiting reorder" modal
    */
-  public ditchingReorder(command) {
+  public ditchingReorder(confirmed: number) {
     // Hide modal
     this.showLoseReorder = false;
-    if (command.includes('Save')) {
-      this.saveReorder();
-    } else if (command.includes('Discard')) {
-      this.cancelReorder();
-    } else {
-      // Return to Reorder
+    if (confirmed && confirmed == 1) {
+        this.saveReorder();
+    }
+    else {
+        this.cancelReorder();
     }
   }
 

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -764,10 +764,10 @@ export class AssetGrid implements OnInit, OnDestroy {
   public ditchingReorder(confirmed: number) {
     // Hide modal
     this.showLoseReorder = false;
-    if (confirmed && confirmed == 1) {
+    if (confirmed === 1) {
         this.saveReorder();
     }
-    else {
+    else if (confirmed === 2) {
         this.cancelReorder();
     }
   }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1187,7 +1187,7 @@ export class AssetPage implements OnInit, OnDestroy {
                             asset_metadata: formValue
                         })
 
-                        this.closeEditDetails('Continue')
+                        this.closeEditDetails(1)
 
                         // Reload asset metadata
                         this._router.navigate(['/asset', ''])
@@ -1306,20 +1306,24 @@ export class AssetPage implements OnInit, OnDestroy {
         return fieldLabelMap[field]
     }
 
-    private closeEditDetails(action: string): void {
+    private closeEditDetails(confirmed: number): void {
         this.uiMessages = {}
         // Hide and reset the edit details form
-        if (action && action === 'Continue') {
+        if (confirmed === 1) {
             this.showEditDetails = false
             this.editDetailsForm.reset()
+        } else {
+            // Do nothing
         }
         this.showExitEdit = false
     }
 
-    private closeDeletePC(action: string): void {
-        if (action && action == 'Confirm') {
+    private closeDeletePC(confirmed: number): void {
+        if (confirmed === 1) {
+            // Confirmed
             this.deleteAsset()
-        } else {
+        } else if (confirmed === 0) {
+            // Canceled
             this.showDeletePCModal = false
         }
     }

--- a/src/app/image-group-page/ig-download-modal/ig-download-modal.component.ts
+++ b/src/app/image-group-page/ig-download-modal/ig-download-modal.component.ts
@@ -93,11 +93,10 @@ export class PptModalComponent implements OnInit, AfterViewInit {
     })
   }
 
-  public hideModal(event: any): void{
-    event.stopPropagation()
-    event.preventDefault()
+  // Closes the IG download modal and sets focus back to initial download button
+  public hideModal(event: any): void {
+    this.closeModal.emit()
     setTimeout( () => {
-      this.closeModal.emit()
       let downloadButtonElement: HTMLElement = document.getElementById('ig-download-btn')
       downloadButtonElement.focus()
     }, 250)

--- a/src/app/modals/confirm-modal/confirm-modal.component.pug
+++ b/src/app/modals/confirm-modal/confirm-modal.component.pug
@@ -4,7 +4,7 @@
     .modal-content(*ngIf="!groupDeleted")
       .modal-header
         h4.modal-title {{ title | translate }}
-        button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
+        button.close(type="button", (click)="closeModal.emit(dismiss)", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
         p([innerHtml]="description")

--- a/src/app/modals/confirm-modal/confirm-modal.component.pug
+++ b/src/app/modals/confirm-modal/confirm-modal.component.pug
@@ -4,7 +4,7 @@
     .modal-content(*ngIf="!groupDeleted")
       .modal-header
         h4.modal-title {{ title | translate }}
-        button.close(type="button", (click)="closeModal.emit(dismiss)", aria-label="Close")
+        button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
         p([innerHtml]="description")

--- a/src/app/modals/confirm-modal/confirm-modal.component.pug
+++ b/src/app/modals/confirm-modal/confirm-modal.component.pug
@@ -4,11 +4,11 @@
     .modal-content(*ngIf="!groupDeleted")
       .modal-header
         h4.modal-title {{ title | translate }}
-        button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
+        button.close(type="button", (click)="closeModal.emit(0)", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
         p([innerHtml]="description")
       .modal-footer
-        button.btn.btn-secondary(type="button", (click)="closeModal.emit(dismiss)") {{ dismiss | translate }}
-        button.btn.btn-primary(*ngIf="secondary", type="button", (click)="closeModal.emit(secondary)") {{ secondary | translate }}
-        button.btn.btn-primary(type="button", (click)="closeModal.emit(primary)") {{ primary | translate }}
+        button.btn.btn-secondary(type="button", (click)="closeModal.emit(0)") {{ dismiss | translate }}
+        button.btn.btn-primary(*ngIf="secondary", type="button", (click)="closeModal.emit(2)") {{ secondary | translate }}
+        button.btn.btn-primary(type="button", (click)="closeModal.emit(1)") {{ primary | translate }}

--- a/src/app/modals/confirm-modal/confirm-modal.component.ts
+++ b/src/app/modals/confirm-modal/confirm-modal.component.ts
@@ -6,8 +6,15 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
   templateUrl: 'confirm-modal.component.pug'
 })
 export class ConfirmModal implements OnInit {
+  /**
+   * ConfirmModal emits the following:
+   * 0 for "False" or "dismiss"
+   * 1 for "primary" action or "confirm"
+   * 2 for "secondary" action
+   * (could be extended by incrementing onward 3,4,5...)
+   */
   @Output()
-  closeModal: EventEmitter<any> = new EventEmitter();
+  closeModal: EventEmitter<number> = new EventEmitter();
 
   @Input() title: string = 'Confirm';
 

--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -222,13 +222,16 @@ export class NavMenu implements OnInit, OnDestroy {
   /**
    * Closes confirmation modal
    */
-  private closeConfirmationModal(command) {
+  private closeConfirmationModal(confirmed: number) {
     console.log(this.params);
     // Hide modal
     this.showConfirmationModal = false;
 
-    if (command && command.includes('Yes')) {
+    if (confirmed === 1) {
+      // Confirmed
       this.deleteSelectedAssets();
+    } else if (confirmed === 0) {
+      // Cancelled
     }
   }
 


### PR DESCRIPTION
IG Download Modal: fix download feature
-stopping event propagation on click or key events was 'throwing' the download link click event away
-Additional change: fixes console error when clicking the X close icon on Reorder mode

@codiak Note the change in `confirm-modal.component` Do we need to handle this differently for different modals, or does passing the same `closeModal(dismiss)` event on the X icon on every modal make sense here? If needed, I can remove this change and open a new ticket for "console error when closing reorder mode with X icon"