### PR TITLE
AIR-2041

### DIFF
--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -79,9 +79,9 @@ export class RegisterComponent implements OnInit {
     this.userDepts = USER_DEPTS
     this.userRoles = USER_ROLES
 
-    // If logged in OR not proxied/IP-authed OR not Shibboleth workflow, redirect to Home
+    // If logged in OR not proxied/IP-authed OR not Shibboleth workflow, redirect to Login
     if (!this.isShibbFlow && (this._auth.isPublicOnly() || this._auth.getUser().isLoggedIn)) {
-      this._router.navigate(['/home'])
+      this._router.navigate(['/login'])
     }
   } // OnInit
 

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -460,9 +460,10 @@ export class AuthService implements CanActivate {
         observer.next(true)
       })
     } else if (this.isPublicOnly() && state.url.includes('/register')) {
-      // For unaffiliated users, trying to access /register route
+      // For unaffiliated users, trying to access /register route,
+      // user get's redirected to /login from register coomponent
       return new Observable(observer => {
-        observer.next(false)
+        observer.next(true)
       })
     } else if (this.canUserAccess(this.getUser())) {
       // If user object already exists, we're done here

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -459,12 +459,6 @@ export class AuthService implements CanActivate {
       return new Observable(observer => {
         observer.next(true)
       })
-    } else if (this.isPublicOnly() && state.url.includes('/register')) {
-      // For unaffiliated users, trying to access /register route,
-      // user get's redirected to /login from register coomponent
-      return new Observable(observer => {
-        observer.next(true)
-      })
     } else if (this.canUserAccess(this.getUser())) {
       // If user object already exists, we're done here
       return new Observable(observer => {


### PR DESCRIPTION
AuthService, Register: Add navigate to Login from Register

Due to Angular6 upgrade:
We needed to pass true to observer.next in canActivate for public users, so that the register component initializes, where logic for navigating to /login from there is handled.
Otherwise, register is never loaded and the Home component is not rendered.