### PR TITLE
AIR-2044

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -305,7 +305,7 @@ export class AssetGrid implements OnInit, OnDestroy {
     this.subscriptions.push(
       this._assets.allResults.pipe(
         map(allResults => {
-          if ( (this.activeSort.index && this.activeSort.index == '3') || (this.UrlParams['startDate'])) {
+          if (this.activeSort.index && this.activeSort.index == '3') {
             this.sortFilterByDateTotal =  allResults.total
 
             let withoutDateParams = Object.assign({}, this.UrlParams)


### PR DESCRIPTION
Search: Compute excluded assets count only once the user is sorting by date. No need to do that for the filter by date search