### PR TITLE
Air 2002

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -98,9 +98,9 @@
               = " "
             .dropdown-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
               a#downloadAssetLink.dropdown-item(download,
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? generatedFullURL : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadImage() : setDownloadImage()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadImage() : setDownloadImage()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedFullURL : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadImage() : setDownloadImage()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadImage() : setDownloadImage()",
                 (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="assets[0].disableDownload",
@@ -112,9 +112,9 @@
                 i.icon.icon-download-black
                 | &nbsp;Download File
               a#downloadViewLink.dropdown-item(*ngIf="isMSAgent",
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? downloadViewLink : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? downloadViewLink : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_blank",
@@ -125,9 +125,9 @@
                 | &nbsp;Download View
               a#downloadViewLink.dropdown-item(*ngIf="!isMSAgent" download="download.jpg",
                 type="image/jpeg",
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? generatedBlobURL : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedBlobURL : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_self",

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -98,9 +98,9 @@
               = " "
             .dropdown-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
               a#downloadAssetLink.dropdown-item(download,
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedFullURL : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadImage() : setDownloadImage()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadImage() : setDownloadImage()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? generatedFullURL : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadImage() : setDownloadImage()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadImage() : setDownloadImage()",
                 (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="assets[0].disableDownload",
@@ -112,9 +112,9 @@
                 i.icon.icon-download-black
                 | &nbsp;Download File
               a#downloadViewLink.dropdown-item(*ngIf="isMSAgent",
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? downloadViewLink : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? downloadViewLink : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_blank",
@@ -125,9 +125,9 @@
                 | &nbsp;Download View
               a#downloadViewLink.dropdown-item(*ngIf="!isMSAgent" download="download.jpg",
                 type="image/jpeg",
-                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? generatedBlobURL : null",
-                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
-                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && downloadAuth()) ? trackDownloadView() : setDownloadView()",
+                [attr.href]="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? generatedBlobURL : null",
+                (click)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
+                (keydown.enter)="((assets[0].publicDownload || !assets[0].disableDownload) && acceptedTerms) ? trackDownloadView() : setDownloadView()",
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_self",

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -691,7 +691,10 @@ export class AssetPage implements OnInit, OnDestroy {
      * @returns boolean which is true if the user has accepted the agreement
      */
     private downloadAuth(): boolean {
-        return this.acceptedTerms ? this.acceptedTerms: this._auth.downloadAuthorized()
+        if (!this.acceptedTerms) {
+          this.acceptedTerms = this._auth.downloadAuthorized()
+        }
+        return this.acceptedTerms
     }
 
     // Calculate the index of current asset from the previous assets result set

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -198,15 +198,27 @@ export class AssetPage implements OnInit, OnDestroy {
         this.user = this._auth.getUser();
         this.solrMetadataFlag = this._flags.solrMetadata
 
+        // if (this.user) {
+        //   this.userSessionFresh = true
+        // }
+
+        // userSessionFresh: Do not attempt to load asset until we know user object is fresh
+
+        if (!this.userSessionFresh && this._auth.userSessionFresh) {
+            this.userSessionFresh = true
+        }
+
+        this.acceptedTerms = this.downloadAuth()
+
         // sets up subscription to allResults, which is the service providing thumbnails
         this.subscriptions.push(
-            this._auth.currentUser.subscribe((user) => {
-                this.user = user
-                // userSessionFresh: Do not attempt to load asset until we know user object is fresh
-                if (!this.userSessionFresh && this._auth.userSessionFresh) {
-                    this.userSessionFresh = true
-                }
-            }),
+            // this._auth.currentUser.subscribe((user) => {
+            //     this.user = user
+            //     // userSessionFresh: Do not attempt to load asset until we know user object is fresh
+            //     // if (!this.userSessionFresh && this._auth.userSessionFresh) {
+            //     //     this.userSessionFresh = true
+            //     // }
+            // }),
             this._assets.allResults.subscribe((allResults) => {
                 if (allResults.thumbnails) {
                     // Set asset id property to reference

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -198,12 +198,6 @@ export class AssetPage implements OnInit, OnDestroy {
         this.user = this._auth.getUser();
         this.solrMetadataFlag = this._flags.solrMetadata
 
-        // if (this.user) {
-        //   this.userSessionFresh = true
-        // }
-
-        // userSessionFresh: Do not attempt to load asset until we know user object is fresh
-
         if (!this.userSessionFresh && this._auth.userSessionFresh) {
             this.userSessionFresh = true
         }
@@ -212,13 +206,13 @@ export class AssetPage implements OnInit, OnDestroy {
 
         // sets up subscription to allResults, which is the service providing thumbnails
         this.subscriptions.push(
-            // this._auth.currentUser.subscribe((user) => {
-            //     this.user = user
+            this._auth.currentUser.subscribe((user) => {
+                this.user = user
             //     // userSessionFresh: Do not attempt to load asset until we know user object is fresh
             //     // if (!this.userSessionFresh && this._auth.userSessionFresh) {
             //     //     this.userSessionFresh = true
             //     // }
-            // }),
+            }),
             this._assets.allResults.subscribe((allResults) => {
                 if (allResults.thumbnails) {
                     // Set asset id property to reference

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -26,7 +26,6 @@ import {
 import { TitleService } from '../shared/title.service'
 import { ScriptService } from '../shared/script.service'
 import { LocalPCService, LocalPCAsset } from '../_local-pc-asset.service'
-import { TourStep } from '../shared/tour/tour.service'
 import { APP_CONST } from '../app.constants'
 import { LockerService } from 'app/_services'
 import { AppConfig } from '../app.service'
@@ -66,6 +65,9 @@ export class AssetPage implements OnInit, OnDestroy {
     // Variables related to how we call for metadata
     public assetIdProperty: string = 'artstorid'
     public fromOpenLibrary: boolean = false
+
+    // If user accepted terms and condition for download
+    public acceptedTerms: boolean = false
 
     // Feature Flags
     public relatedResFlag: boolean = false
@@ -153,55 +155,6 @@ export class AssetPage implements OnInit, OnDestroy {
         deleteFailure?: boolean,
         saveFailure?: boolean
     } = {}
-
-    private steps: TourStep[] = [
-        {
-            step: 1,
-            element: ['.btn--zoomIn'],
-            popover: {
-                position: 'bottom',
-                title: '<p>1 OF 5</p><b>Zoom and pan</b>',
-                description: 'You can zoom in with this button.',
-            }
-        },
-        {
-            step: 2,
-            element: ['.btn--zoomOut'],
-            popover: {
-                position: 'bottom',
-                title: '<p>2 OF 5</p><b>Zoom and pan</b>',
-                description: 'You can zoom out with this button.',
-            }
-        },
-        {
-            step: 3,
-            element: ['.btn--zoomFit'],
-            popover: {
-                position: 'bottom',
-                title: '<p>3 OF 5</p><b>Zoom and pan</b>',
-                description: 'You can fit the image with this button.',
-            }
-        },
-        {
-            step: 4,
-            element: ['.btn--fullScreen'],
-            popover: {
-                position: 'bottom',
-                title: '<p>4 OF 5</p><b>View full image and compare</b>',
-                description: 'If you came to this page from search or a group, you can enter fullscreen mode to see it side-by-side with others.'
-            }
-        },
-        {
-            step: 5,
-            element: ['.driver-find-group-btn'],
-            popover: {
-                position: 'bottom',
-                title: '<p>5 OF 5</p><b>Save the image for later</b>',
-                description: 'If you want to save the iamge for later, click this button.',
-            }
-        }
-    ]
-    private showTour: boolean = false
 
     // Flag for multiview items, true if the asset contains multiview items
     private multiviewItems: boolean = false
@@ -317,9 +270,7 @@ export class AssetPage implements OnInit, OnDestroy {
                 if (routeParams && routeParams['featureFlag']) {
                     this._flags[routeParams['featureFlag']] = true
                     this.relatedResFlag = this._flags['related-res-hack'] ? true : false
-                    if (routeParams['featureFlag'] === 'tour') {
-                        this.showTour = true
-                    }
+
                     if (routeParams['featureFlag'] === 'solrMetadata') {
                         this.solrMetadataFlag = true
                     }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -691,7 +691,7 @@ export class AssetPage implements OnInit, OnDestroy {
      * @returns boolean which is true if the user has accepted the agreement
      */
     private downloadAuth(): boolean {
-        return this._auth.downloadAuthorized();
+        return this.acceptedTerms ? this.acceptedTerms: this._auth.downloadAuthorized()
     }
 
     // Calculate the index of current asset from the previous assets result set

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -173,7 +173,7 @@ export class AuthService implements CanActivate {
 
     idle.onTimeout.pipe(
       map(() => {
-        let user = this.user.hasOwnProperty('status') ? this.user : this.getUser();
+        let user = this.getUser()
         // console.log(user);
         if (user && user.isLoggedIn){
           this.expireSession();
@@ -707,8 +707,6 @@ export class AuthService implements CanActivate {
         'isLoggedIn': false,
         'loggedInSessionLost': loggedInSessionLost
       }
-      // Track whether or not user object has been refreshed since app opened
-      this.userSessionFresh = true
       return user
     } else {
       console.error('Did not receive a valid user object', data)

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -173,7 +173,7 @@ export class AuthService implements CanActivate {
 
     idle.onTimeout.pipe(
       map(() => {
-        let user = this.getUser();
+        let user = this.user.hasOwnProperty('status') ? this.user : this.getUser();
         // console.log(user);
         if (user && user.isLoggedIn){
           this.expireSession();
@@ -474,8 +474,6 @@ export class AuthService implements CanActivate {
       map(
         (data)  => {
           let user = this.decorateValidUser(data)
-          // Track whether or not user object has been refreshed since app opened
-          this.userSessionFresh = true
 
           if (user && (this.isOpenAccess || user.status)) {
             // Clear expired session modal
@@ -709,6 +707,8 @@ export class AuthService implements CanActivate {
         'isLoggedIn': false,
         'loggedInSessionLost': loggedInSessionLost
       }
+      // Track whether or not user object has been refreshed since app opened
+      this.userSessionFresh = true
       return user
     } else {
       console.error('Did not receive a valid user object', data)

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -614,12 +614,11 @@ export class AuthService implements CanActivate {
 
   public isPublicOnly(): boolean {
     if (!this.user.hasOwnProperty('status')) {
-      this.user = this.getUser()
+      this.user = JSON.parse(localStorage.getItem('user')).data
     }
 
     return !(this.user && this.user.status)
   }
-
 
   /**
    * Return "category" to report to Google Analytics

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -49,6 +49,7 @@ export class AuthService implements CanActivate {
   private currentInstitutionObj: Observable<any> = this.institutionObjSource.asObservable();
 
   private userSource: BehaviorSubject<any> = new BehaviorSubject({});
+  private user: any = {}
 
   private idleState: string = 'Not started.';
 
@@ -611,8 +612,12 @@ export class AuthService implements CanActivate {
     )
   }
 
-  public isPublicOnly(): boolean{
-    return !(this.getUser() && this.getUser().status)
+  public isPublicOnly(): boolean {
+    if (!this.user.hasOwnProperty('status')) {
+      this.user = this.getUser()
+    }
+
+    return !(this.user && this.user.status)
   }
 
 
@@ -622,7 +627,7 @@ export class AuthService implements CanActivate {
    */
   public getGACategory(): string {
     let category = 'unaffiliatedUser'
-    let user = this.getUser()
+    let user = this.user.hasOwnProperty('status') ? this.user : this.getUser()
 
     if (user.isLoggedIn) {
       category = 'loggedInUser'
@@ -675,7 +680,7 @@ export class AuthService implements CanActivate {
    * - Used to decorate the user object for saving
    */
   private decorateValidUser(data: any): any {
-    let currentUser = this.getUser()
+    let currentUser = this.user.hasOwnProperty('status') ? this.user : this.getUser()
     let newUser = data['user'] ? data['user'] : {}
     let currentUsername = currentUser.username
     let loggedInSessionLost = currentUser.isLoggedIn ? (!newUser.username || currentUsername !== newUser.username) : false;


### PR DESCRIPTION
- Reduce the amount of calls to angular-safeguard from within emitted events / subscriptions
- in `isPublicOnly` don't rely on angular-safeguard at all because we call `isPublicOnly` many times across many templates.
- Cleans up asset-page Tour code no longer needed
- Removes calls to `downloadAuth()` in Asset Page Template and uses new `acceptedTerms` boolean instead.
- Reduces user lookup in localStorage in getUser and saveUser, by mostly checking if we already know the value of this.user and this.user.status in AssetPage