### PR TITLE
AIR-2088

### DIFF
--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -201,7 +201,7 @@ export class RegisterComponent implements OnInit {
    * @returns error which should be assigned to the email input
    */
   private emailValidator(control: FormControl): any {
-    let emailRe: RegExp = /^\w+([\+\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+    let emailRe: RegExp = /^\w+([\+\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,30})+$/;
     return emailRe.test(control.value) ? null : { 'emailInvalid': true };
   }
 

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -49,7 +49,7 @@ export class RegisterComponent implements OnInit {
     this.registerForm = _fb.group({
       // The first value of this array is the initial value for the control, the second is the
       //  validator for the control. Validators.compose allows you to use multiple validators against a single field
-      email: [null, Validators.compose([Validators.required, this.emailValidator])],
+      email: [null, { updateOn: 'blur' }, Validators.compose([Validators.required, this.emailValidator])],
       emailConfirm: [null, Validators.required],
       password: [null, Validators.compose([Validators.required, Validators.minLength(7)])],
       passwordConfirm: [null, Validators.required],


### PR DESCRIPTION
Registration:  Increase regex accepted size range of second level domains for long email address domains

- Increased accepted range to 30 chars after name@ in email validation