### PR TITLE
2164-fix

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -273,7 +273,9 @@ $desktop: 992px;*/
     min-height:0px !important;
     min-width:0px;
     max-height: 100%;
+    max-height: 90vh;
     max-width: 100%;
+    display: inline-block; /* block or inline-block are required for transform */
     top: 50%;
     left: 50%;
     transform: translate3d(-50%,-50%,0);


### PR DESCRIPTION
- AssetViewer: Add inline-block to item--thumbnail
- Handles the background thumbnail behind viewer for downgraded "size4" thumbnails