### PR TITLE
2164-fix Badge / Icon layout in downgraded media icon conditional

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -57,7 +57,7 @@
       //- Workaround for downgraded multiview items, until services around this are consistent.
       //- 'media.format' is null, and we also have compound_media - where compund_media.mediaType is still '10' or other invalid media type
       //- So the reliable way we can display the correct icon is via media.adlObjectType
-      i( *ngIf="thumbnail.media && thumbnail.compound_media", class="icon icon-{{thumbnail.media.adlObjectType | typeIdPipe}}")
+      i( *ngIf="thumbnail.media && thumbnail.compound_media && thumbnail.media.format === 'null' ", class="icon icon-{{thumbnail.media.adlObjectType | typeIdPipe}}")
       //- Detail view icon
       i.icon(*ngIf="thumbnail.zoom", [ngClass]="[ mouseOverDetailIcon ? 'icon-detail-hover' : 'icon-detail' ]", [ngbTooltip]="tipDetailView", ngbTooltip, triggers="focusin:focusout mouseenter:mouseleave", placement="right", aria-haspopup="true", tabIndex="3", (mouseover)="mouseOverDetailIcon=true", (mouseout)="mouseOverDetailIcon=false")
 


### PR DESCRIPTION
Thumbnail comp template: For downgraded MV media icon, add media.format is null to condition to fix MV icon layout