### PR TITLE
AIR-2198: Asset search: hasOwnProperty can't be used for proto properties

### DIFF
--- a/src/app/shared/assets.service.ts
+++ b/src/app/shared/assets.service.ts
@@ -854,7 +854,7 @@ export class AssetService {
      */
     private loadSearch(term: string): void {
         // Don't wait for previous subscription anymore
-        if (this.searchSubscription && this.searchSubscription.hasOwnProperty('unsubscribe')) {
+        if (this.searchSubscription && this.searchSubscription.unsubscribe) {
             this.searchSubscription.unsubscribe()
         }
 


### PR DESCRIPTION
We had a loophole where a search subscription could overwrite subsequent searches, and this fix properly prevents that from happening