### PR TITLE
AIR-2134 (Display "Exporting Terms and Conditions" modal once per session)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -58,7 +58,7 @@ import { BrowsePage, LibraryComponent, AdlCollectionFilterPipe, IgGroupFilterPip
 import { AssetPage, AgreeModalComponent, ArtstorViewerComponent } from './asset-page'
 import { AccountPage } from './account-page'
 import { AssociatedPage } from './associated-page'
-import { ImageGroupPage, PptModalComponent } from './image-group-page'
+import { ImageGroupPage, PptModalComponent, TermsAndConditionsComponent } from './image-group-page'
 import { Login } from './login'
 import { NoContent } from './no-content'
 import { LinkPage } from './link-page'
@@ -231,6 +231,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     SkyBannerComponent,
     TagComponent,
     TagsListComponent,
+    TermsAndConditionsComponent,
     ThumbnailComponent,
     ToastComponent,
     PromptComponent,

--- a/src/app/image-group-page/image-group-page.component.pug
+++ b/src/app/image-group-page/image-group-page.component.pug
@@ -13,8 +13,8 @@ div
           = " "
           | Unable to load the thumbnails for this group.
 
-ang-terms-and-conditions(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
-//ang-ig-download-modal(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
+ang-terms-and-conditions(*ngIf="showTermsConditions", (exportType)="exportType", (closeModal)="showTermsConditions = false", [ig]="ig")
+ang-ig-download-modal(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
 ang-download-limit-modal(*ngIf="showDownloadLimitModal", (closeModal)="showDownloadLimitModal = false", [ig]="ig")
 ang-login-req-modal(*ngIf="showLoginModal", (closeModal)="showLoginModal = false")
 ang-no-ig-modal(*ngIf="showNoIgModal || showNoAccessIgModal", [noAccessIg]="showNoAccessIgModal", (closeModal)="showNoIgModal = false")

--- a/src/app/image-group-page/image-group-page.component.pug
+++ b/src/app/image-group-page/image-group-page.component.pug
@@ -13,7 +13,8 @@ div
           = " "
           | Unable to load the thumbnails for this group.
 
-ang-ig-download-modal(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
+ang-terms-and-conditions(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
+//ang-ig-download-modal(*ngIf="showPptModal", (closeModal)="showPptModal = false", [ig]="ig")
 ang-download-limit-modal(*ngIf="showDownloadLimitModal", (closeModal)="showDownloadLimitModal = false", [ig]="ig")
 ang-login-req-modal(*ngIf="showLoginModal", (closeModal)="showLoginModal = false")
 ang-no-ig-modal(*ngIf="showNoIgModal || showNoAccessIgModal", [noAccessIg]="showNoAccessIgModal", (closeModal)="showNoIgModal = false")

--- a/src/app/image-group-page/image-group-page.component.ts
+++ b/src/app/image-group-page/image-group-page.component.ts
@@ -246,7 +246,7 @@ export class ImageGroupPage implements OnInit, OnDestroy {
     // the template will not show the button if there is not an ig.igName and ig.igDownloadInfo
     // if the user is logged in and the download info is available
     if (this.user.isLoggedIn) {
-      // If we specify an export type, trigger terms and conditions modal if user havn't agreed
+      // If we specify an export type, trigger terms and conditions modal if user hasn't agreed
       if (exportType && exportType.length) {
         if (!this._storage.getSession('termAgreed')) {
           this.showTermsConditions = true;

--- a/src/app/image-group-page/index.ts
+++ b/src/app/image-group-page/index.ts
@@ -1,2 +1,3 @@
 export * from './image-group-page.component';
 export * from './ig-download-modal/ig-download-modal.component';
+export * from './terms-and-conditions/terms-and-conditions.component';

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -10,4 +10,4 @@
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total>100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_BIG' | translate")
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total<=100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_SMALL' | translate")
       .modal-footer
-        button#generatePowerpointLink.btn.btn-primary(*ngIf="!downloadLink  && !isLoading", (click)="hideModal($event)", aria-label="Request Powerpoint") I Agree
+        button#generatePowerpointLink.btn.btn-primary(*ngIf="!downloadLink  && !isLoading", (click)="termAgreed($event)", aria-label="Request Powerpoint") I Agree

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -1,0 +1,13 @@
+.modal.fade-in(tabindex="0")
+  .modal-dialog(role="dialog", (keydown.esc)="hideModal($event)")
+    .modal-content
+      .modal-header
+        h4.modal-title#ig-download-title(tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
+        button.close#ig-modal-close((click)="hideModal($event)", aria-label="Close")
+          span(aria-hidden="true") &times;
+      .modal-body
+        div([innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TEXT' | translate")
+        .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total>100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_BIG' | translate")
+        .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total<=100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_SMALL' | translate")
+      .modal-footer
+        button#generatePowerpointLink.btn.btn-primary(*ngIf="!downloadLink  && !isLoading", (click)="hideModal($event)", aria-label="Request Powerpoint") I Agree

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -2,8 +2,8 @@
   .modal-dialog(role="dialog", (keydown.esc)="hideModal($event)")
     .modal-content
       .modal-header
-        h4.modal-title#ig-download-title(tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
-        button.close#ig-modal-close((click)="hideModal($event)", aria-label="Close")
+        h4.modal-title#term-condition-title(tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
+        button.close#term-condition-close((click)="hideModal($event)", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body
         div([innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TEXT' | translate")
@@ -11,4 +11,4 @@
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total>100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_BIG' | translate")
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total<=100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_SMALL' | translate")
       .modal-footer
-        button#generatePowerpointLink.btn.btn-primary(*ngIf="!downloadLink  && !isLoading", (click)="termAgreed($event)", aria-label="Request Powerpoint") I Agree
+        button#AgreeButton.btn.btn-primary(*ngIf="!downloadLink && !isLoading", (click)="termAgreed($event)", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()", aria-label="I agree to the Exporting Terms and Conditions") I Agree

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -7,6 +7,7 @@
           span(aria-hidden="true") &times;
       .modal-body
         div([innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TEXT' | translate")
+        //- We may need a different alert
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total>100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_BIG' | translate")
         .alert.alert-danger(*ngIf="!(isLoading || zipLoading || downloadLink || zipDownloadLink) && error && ig.total<=100", style="margin:0;", [innerHtml]="'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.DOWNLOAD_ERROR_SMALL' | translate")
       .modal-footer

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { Angulartics2 } from 'angulartics2';
 
 import { AssetService, AuthService, ImageGroup, DomUtilityService } from './../../shared';
+import { ArtstorStorageService } from '../../../../projects/artstor-storage/src/public_api';
 
 @Component({
   selector: 'ang-terms-and-conditions',
@@ -21,6 +22,8 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   public closeModal: EventEmitter<any> = new EventEmitter();
   @Input()
   public ig: ImageGroup;
+  @Input()
+  public exportType: string;
 
   @ViewChild("ig-download-title", {read: ElementRef}) downloadTitleElement: ElementRef;
 
@@ -41,6 +44,7 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
     private _auth: AuthService,
     private _angulartics: Angulartics2,
     private _dom: DomUtilityService,
+    private _storage: ArtstorStorageService,
     private http: HttpClient,
   ) {}
 
@@ -62,6 +66,37 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
 
   trackDownload(downloadType: string): void {
     this._angulartics.eventTrack.next({ action: 'downloadGroup' + downloadType, properties: { category: this._auth.getGACategory(), label: this.ig.id }})
+  }
+
+  /**
+   * When user click I agree, set session storage to make the modal appear once per session
+   * Then trigger download process
+   * @param event needed by hideModal()
+   */
+  private termAgreed(event: any) {
+    // Set session storage
+    this._storage.setSession('termAgreed', true)
+
+    // Trigger download
+    this.triggerDownload(event)
+  }
+
+  /**
+   * Trigger download when user clicks on I agree
+   * Decide whether it is PPT, ZIP, or Google Slides to trigger based on exportType
+   * @param event needed by hideModal()
+   */
+  private triggerDownload(event: any) {
+    if (this.exportType === 'PPT') {
+      this.getPPT()
+    }
+    else if (this.exportType === 'ZIP') {
+      this.getZip()
+    }
+    else if (this.exportType === 'GoogleSlides') {
+      // Google Slides option going here
+    }
+    this.hideModal(event)
   }
 
   private getPPT() {

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
@@ -55,7 +55,7 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   }
   // Set initial focus on the modal Title h4
   public startModalFocus() {
-    let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('ig-download-title');
+    let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('term-condition-title');
     htmlelement.focus()
 
     if (this.downloadTitleElement && this.downloadTitleElement.nativeElement){

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
@@ -1,0 +1,167 @@
+import { Component, OnInit, Input, Output, EventEmitter, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Angulartics2 } from 'angulartics2';
+
+import { AssetService, AuthService, ImageGroup, DomUtilityService } from './../../shared';
+
+@Component({
+  selector: 'ang-terms-and-conditions',
+  templateUrl: './terms-and-conditions.component.pug',
+  styles: [`
+  .modal {
+    display: block;
+  }
+`]
+})
+export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
+
+  /** Meant only to trigger display of modal */
+  @Output()
+  public closeModal: EventEmitter<any> = new EventEmitter();
+  @Input()
+  public ig: ImageGroup;
+
+  @ViewChild("ig-download-title", {read: ElementRef}) downloadTitleElement: ElementRef;
+
+  public isLoading: boolean = false;
+  public zipLoading: boolean = false;
+  public downloadLink: string = '';
+  public zipDownloadLink: string = '';
+  public error: boolean = false;
+  private downloadTitle: string = 'Image Group';
+  private allowedDownloads: number = 0;
+
+  private header = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
+  private defaultOptions = { withCredentials: true};
+  // private defaultOptions = new RequestOptions({ headers: this.header, withCredentials: true});
+
+  constructor(
+    private _assets: AssetService,
+    private _auth: AuthService,
+    private _angulartics: Angulartics2,
+    private _dom: DomUtilityService,
+    private http: HttpClient,
+  ) {}
+
+  ngOnInit() {}
+
+  ngAfterViewInit() {
+    this.startModalFocus()
+  }
+  // Set initial focus on the modal Title h4
+  public startModalFocus() {
+    let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('ig-download-title');
+    htmlelement.focus()
+
+    if (this.downloadTitleElement && this.downloadTitleElement.nativeElement){
+      this.downloadTitleElement.nativeElement.focus()
+    }
+
+  }
+
+  trackDownload(downloadType: string): void {
+    this._angulartics.eventTrack.next({ action: 'downloadGroup' + downloadType, properties: { category: this._auth.getGACategory(), label: this.ig.id }})
+  }
+
+  private getPPT() {
+    this.isLoading = true
+    // Setup PPT Download
+    this.getDownloadLink(this.ig)
+    .then((data) => {
+      this.isLoading = false
+      // Goal: A downlink that looks like:
+      // http://mdxdv.artstor.org/thumb/imgstor/...
+      if (data.path) {
+        this.downloadLink = this._auth.getThumbHostname() + data.path.replace('/nas/', '/thumb/')
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      this.error = true
+      this.isLoading = false
+    })
+  }
+
+  private getZip() {
+    this.zipLoading = true;
+    // Setup Zip download
+    this.getDownloadLink(this.ig, true)
+    .then((data) => {
+      this.zipLoading = false;
+      // Goal: A downlink that looks like:
+      // http://mdxdv.artstor.org/thumb/imgstor/...
+      if (data.path) {
+        this.zipDownloadLink = this._auth.getThumbHostname() + data.path.replace('/nas/', '/thumb/');
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      this.error = true
+      this.zipLoading = false
+    })
+  }
+
+  // Closes the IG download modal and sets focus back to initial download button
+  public hideModal(event: any): void {
+    this.closeModal.emit()
+    setTimeout( () => {
+      let downloadButtonElement: HTMLElement = document.getElementById('ig-download-btn')
+      downloadButtonElement.focus()
+    }, 250)
+  }
+
+  /** Gets the link at which the resource can be downloaded. Will be set to the "accept" button's download property */
+  private getDownloadLink(group: ImageGroup, zip ?: boolean): Promise<any> {
+    let header = new HttpHeaders().set('content-type', 'application/x-www-form-urlencoded')
+    let options = { headers: header, withCredentials: true }
+    let useLegacyMetadata: boolean = true
+    let url = this._auth.getHostname() + '/api/group/export'
+    let format: string
+    let data: any
+
+    if (!zip) {
+      format = 'pptx'
+    } else {
+      format = 'zip'
+    }
+
+    /**
+     * We're using this as an auth check - instead of simply using all of the group.items strings and calling for downloads,
+     *  which was allowing restricted assets to be downloaded, we first ask for each assets' thumbnail, which will ensure
+     *  that only assets which the user has access to are returned
+     */
+    return this._assets.getAllThumbnails(group.items, group.id)
+    .then((thumbnails) => {
+      let imgDownloadStrings: string[] = []
+
+      thumbnails.forEach((thumbnail, index) => {
+        let imgStr: string = [(index + 1), thumbnail.objectId, '1024x1024'].join(':')
+        thumbnail.status == 'available' && imgDownloadStrings.push(imgStr)
+      })
+
+      data = {
+          igName: group.name,
+          images: imgDownloadStrings.join(',')
+      }
+
+      return data
+    })
+    .then((data) => {
+      // Return request that provides file URL
+      return this.http
+        .post(url + '/' + format + '/' + group.id + '/' + useLegacyMetadata, this._auth.formEncode(data), options)
+        .toPromise()
+    })
+    .then((res) => {
+      // Make authorization call to increment download count after successful response is received
+      this.http
+      .get(url + '/auth/' + group.id + '/true', options)
+      .toPromise()
+
+      return res
+    })
+  }
+
+
+}

--- a/src/app/nav-menu/nav-menu.component.pug
+++ b/src/app/nav-menu/nav-menu.component.pug
@@ -44,9 +44,9 @@
             // Active on Image Group Page
             button.dropdown-item(*ngIf="!exportReframeFlag && params['igId']", (click)="_ig.triggerIgDownload()", tabindex="1") {{ 'NAV_MENU.SHARE.DOWNLOAD_GROUP' | translate }}
             // Active on Image Group Page
-            button.dropdown-item(*ngIf="exportReframeFlag && params['igId']", tabindex="1") {{ 'NAV_MENU.SHARE.EXPORT_TO_PPT' | translate }}
+            button.dropdown-item(*ngIf="exportReframeFlag && params['igId']", (click)="_ig.triggerPPTExport()", tabindex="1") {{ 'NAV_MENU.SHARE.EXPORT_TO_PPT' | translate }}
             // Active on Image Group Page
-            button.dropdown-item(*ngIf="exportReframeFlag && params['igId']", tabindex="1") {{ 'NAV_MENU.SHARE.EXPORT_AS_ZIP' | translate }}
+            button.dropdown-item(*ngIf="exportReframeFlag && params['igId']", (click)="_ig.triggerZIPExport()", tabindex="1") {{ 'NAV_MENU.SHARE.EXPORT_AS_ZIP' | translate }}
         .nav-item
           a#viewMenu.btn.btn-link(*ngIf="_auth.isPublicOnly()", href="//support.artstor.org/?article-category=05-public-access-to-artstor", target="_blank", tabindex="1", (focus)="closeNavMenuDropdowns()") Support
           a#viewMenu.btn.btn-link(*ngIf="!_auth.isPublicOnly()", href="//support.artstor.org", target="_blank", tabindex="1", (focus)="closeNavMenuDropdowns()") Support

--- a/src/app/shared/group-title/group-title.component.pug
+++ b/src/app/shared/group-title/group-title.component.pug
@@ -15,19 +15,19 @@
               | Export
               = " "
             .dropdown-menu([ngClass]="{ 'hovered' : dropDownOptHovered || dropDownOptFocused }", ngbDropdownMenu)
-              a#exportPptLink.dropdown-item((mouseover)="dropDownOptHovered = true", (mouseout)="dropDownOptHovered = false",(focus)="dropDownOptFocused = true", (focusout)="dropDownOptFocused = false", tabindex="3", aria-label="Powerpoint", role="button")
+              a#exportPptLink.dropdown-item((click)="_ig.triggerPPTExport()", (mouseover)="dropDownOptHovered = true", (mouseout)="dropDownOptHovered = false",(focus)="dropDownOptFocused = true", (focusout)="dropDownOptFocused = false", tabindex="3", aria-label="Powerpoint", role="button")
                 i.icon.icon-powerpoint
                 .content
                   label PowerPoint
                   .caption Exports as one image per slide, with metadata in the speaker notes
 
-              a#exportGsLink.dropdown-item(tabindex="3", aria-label="Google Slides", role="button")
+              a#exportGsLink.dropdown-item((click)="_ig.triggerGoogleSlides()", tabindex="3", aria-label="Google Slides", role="button")
                 i.icon.icon-google-slides
                 .content
                   label Google Slides
                   .new-badge New!
                   .caption Exports as one image per slide, with metadata in the speaker notes
-              a#exportZipLink.dropdown-item(tabindex="3", aria-label="Zip File", role="button")
+              a#exportZipLink.dropdown-item((click)="_ig.triggerZIPExport()", tabindex="3", aria-label="Zip File", role="button")
                 i.icon.icon-zip
                 .content
                   label ZIP File

--- a/src/app/shared/group-title/group-title.component.ts
+++ b/src/app/shared/group-title/group-title.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core'
 import { Subscription } from 'rxjs'
 import { ActivatedRoute } from '@angular/router'
-import { ImageGroup, FlagService } from './../'
+import { ImageGroup, FlagService, ImageGroupService } from './../'
 
 
 @Component({
@@ -25,6 +25,7 @@ import { ImageGroup, FlagService } from './../'
     private subscriptions: Subscription[] = []
 
     constructor(
+      private _ig: ImageGroupService,
       private route: ActivatedRoute,
       public _flags: FlagService
     ){ }

--- a/src/app/shared/image-group.service.ts
+++ b/src/app/shared/image-group.service.ts
@@ -28,7 +28,7 @@ export class ImageGroupService {
   private assetsSource = new BehaviorSubject<any>(this.assetsValue);
   public assets = this.assetsSource.asObservable();
 
-  public igDownloadTrigger: EventEmitter<any> = new EventEmitter();
+  public igDownloadTrigger: EventEmitter<string> = new EventEmitter();
 
   constructor(private _router: Router, private http: HttpClient, private _auth: AuthService ){
     this.baseUrl = this._auth.getUrl();
@@ -64,6 +64,18 @@ export class ImageGroupService {
 
   public triggerIgDownload(): void {
     this.igDownloadTrigger.emit();
+  }
+
+  public triggerPPTExport(): void {
+    this.igDownloadTrigger.emit('PPT');
+  }
+
+  public triggerZIPExport(): void {
+    this.igDownloadTrigger.emit('ZIP');
+  }
+
+  public triggerGoogleSlides(): void {
+    this.igDownloadTrigger.emit('GoogleSlides');
   }
 
   public triggerIgExport(): void {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -182,6 +182,12 @@
       "DOWNLOAD_ERROR_BIG": "We're sorry, we were unable to generate your file. The recommended group size is under 100 images.",
       "DOWNLOAD_ERROR_SMALL": "We're sorry, we were unable to generate your file. Please try again. If the problem persists, contact us at <a href=\"mailto:support@artstor.org\" class=\"link\" target=\"_blank\">support@artstor.org</a>"
     },
+    "TERMS_AND_CONDITIONS": {
+      "TITLE": "Exporting Terms and Conditions",
+      "TEXT": "<p>All logged in users may export/download up to 2000 images in a 120 day period.</p><p>For groups larger than 150, only the first 150 images are exported as presentation slides. Multimedia files are not exported to Powerpoint, ZIP files and Google Slides.</p> <p>By accepting this, you are agreeing to the <a href=\"http://www.artstor.org/terms\" class=\"link\" name=\"Terms and conditions of use\" target=\"_blank\">terms and conditions of use.</a></p>",
+      "DOWNLOAD_ERROR_BIG": "We're sorry, we were unable to generate your file. The recommended group size is under 100 images.",
+      "DOWNLOAD_ERROR_SMALL": "We're sorry, we were unable to generate your file. Please try again. If the problem persists, contact us at <a href=\"mailto:support@artstor.org\" class=\"link\" target=\"_blank\">support@artstor.org</a>"
+    },
     "DOWNLOAD_LIMIT_MODAL": {
       "TITLE": "Download Limit Reached",
       "CLOSE_BUTTON": "Ok",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -184,7 +184,7 @@
     },
     "TERMS_AND_CONDITIONS": {
       "TITLE": "Exporting Terms and Conditions",
-      "TEXT": "<p>All logged in users may export/download up to 2000 images in a 120 day period.</p><p>For groups larger than 150, only the first 150 images are exported as presentation slides. Multimedia files are not exported to Powerpoint, ZIP files and Google Slides.</p> <p>By accepting this, you are agreeing to the <a href=\"http://www.artstor.org/terms\" class=\"link\" name=\"Terms and conditions of use\" target=\"_blank\">terms and conditions of use.</a></p>",
+      "TEXT": "<p>All logged in users may export/download up to 2000 images in a 120 day period.</p><p>For groups larger than 150, only the first 150 images are exported as presentation slides. Multimedia files are not exported to PowerPoint, ZIP files and Google Slides.</p> <p>By accepting this, you are agreeing to the <a href=\"http://www.artstor.org/terms\" class=\"link\" name=\"Terms and conditions of use\" target=\"_blank\">terms and conditions of use.</a></p>",
       "DOWNLOAD_ERROR_BIG": "We're sorry, we were unable to generate your file. The recommended group size is under 100 images.",
       "DOWNLOAD_ERROR_SMALL": "We're sorry, we were unable to generate your file. Please try again. If the problem persists, contact us at <a href=\"mailto:support@artstor.org\" class=\"link\" target=\"_blank\">support@artstor.org</a>"
     },


### PR DESCRIPTION
 - Create new component Terms and Conditions.
 - For igDownloadTrigger EventEmitter, specify export type by emitting a string "PPT", "ZIP" or "GoogleSlides". If no string specified, use old download image modal.
 - Give export type as input to the Terms and Conditions modal so it knows which download to trigger when user agrees with the terms.
 - Assign session storage called "termAgreed" with a boolean value to make the modal display only once per session.
 - Currently clicking on "I agree" on Terms and Condition modal will have same effect as clicking on "Request PPT"/"Request Zip" on the old download image modal.
 - Add label for "I agree" button according to Kelsey's suggestion.

Note: The download process will not be triggered by clicking on "I agree" on Terms and Conditions modal or on the new export dropdown. I guess triggering download feature is not supposed to be included in this story so I didn't do that.