### PR TITLE
AIR-2217 (Design Refine: toast fix, text box being pushed below icon)

### DIFF
--- a/src/app/shared/toast/toast.component.scss
+++ b/src/app/shared/toast/toast.component.scss
@@ -84,6 +84,7 @@ $toastPad: 14px;
 
     .toast-message {
         display: inline-block;
+        word-wrap: break-word;
         max-width: 88%;
 
         @media (max-width: $phone) {

--- a/src/app/shared/toast/toast.component.scss
+++ b/src/app/shared/toast/toast.component.scss
@@ -19,8 +19,7 @@ $toastPad: 14px;
     @media (max-width: $phone) {
         min-width: 280px;
         max-width: 280px;
-        position: absolute;
-        right: 0px;
+        float: right;
     }
 
     &.success {

--- a/src/app/shared/toast/toast.component.scss
+++ b/src/app/shared/toast/toast.component.scss
@@ -16,6 +16,13 @@ $toastPad: 14px;
     transform: translateX(100%);
     -webkit-transform: translateX(100%);
 
+    @media (max-width: $phone) {
+        min-width: 280px;
+        max-width: 280px;
+        position: absolute;
+        right: 0px;
+    }
+
     &.success {
         border-top-color: $green;
     }
@@ -77,6 +84,11 @@ $toastPad: 14px;
 
     .toast-message {
         display: inline-block;
+        max-width: 88%;
+
+        @media (max-width: $phone) {
+            max-width: 82%;
+        }
     }
 
     .icon-close {


### PR DESCRIPTION
 - Set a max-width to prevent text div being push to next line
 - Make toast smaller when the window is small (According to Kelsey, the width is 280px)
 - Wrap long word