### PR TITLE
AIR-2191 Modals: Show session expired modal first, add priority classes

### DIFF
--- a/src/app/modals/session-expire/session-expire.component.pug
+++ b/src/app/modals/session-expire/session-expire.component.pug
@@ -1,4 +1,4 @@
-#inactiveUserLogoutModal.modal.fade-in.show
+#inactiveUserLogoutModal.modal.fade-in.show.modal--priority-1
   .modal-dialog
     .modal-content
       .modal-body

--- a/src/sass/modules/_modals.scss
+++ b/src/sass/modules/_modals.scss
@@ -11,6 +11,18 @@
     background-color: rgba(0, 0, 0, 0.55);
     z-index: 9000;
     overflow-y: auto;
+
+    // Currently reserved for the session expired modal
+    &.modal--priority-1 {
+      z-index: 9999;
+    }
+    // For specific cases where one modal should take priority over the other
+    &.modal--priority-2 {
+      z-index: 9900;
+    }
+    &.modal--priority-3 {
+      z-index: 9800;
+    }
 }
 
 .modal.show{


### PR DESCRIPTION
Praveena and I believe the users situation is caused by not giving priority to the Session Expired modal, which allowed the user to try to continue to download or add items while their session was expired