### PR TITLE
AIR-2247 (Add email input from pw reset modal)

### DIFF
--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -2,7 +2,7 @@ form((ngSubmit)="login(user)")
   #mainContent.form-group
     label#emailLabel(for="inputLoginEmail")
       span([innerHtml]="'LOGIN.REG_LOGIN.EMAIL_LABEL' | translate")
-      input#inputLoginEmail.form-control([(ngModel)]="user.username" name="username" type="text" placeholder="Email address" aria-label="Email address, required" tabindex="1")
+      input#inputLoginEmail.form-control([(ngModel)]="user.username", (keyup)="userEmail.emit(user.username)" name="username" type="text" placeholder="Email address" aria-label="Email address, required" tabindex="1")
   .form-group
     label(for="inputLoginPassword")
       span([innerHtml]="'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate")

--- a/src/app/login-form/login-form.component.ts
+++ b/src/app/login-form/login-form.component.ts
@@ -1,4 +1,4 @@
-import { OnInit, Input } from '@angular/core'
+import { OnInit, Input, Output, EventEmitter } from '@angular/core'
 import { Component } from '@angular/core'
 import { Router, ActivatedRoute } from '@angular/router'
 import { Location } from '@angular/common'
@@ -35,6 +35,7 @@ export class LoginFormComponent implements OnInit {
   public loginInstitutions = [] /** Stores the institutions returned by the server */
 
   @Input() public copyModifier: string = 'DEFAULT'
+  @Output() public userEmail: EventEmitter<any> = new EventEmitter()
   public loginLoading = false
 
   private loginInstName: string = '' /** Bound to the autocomplete field */

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -7,7 +7,7 @@
         .card-header
           h2.h1#loginHeading {{ copyBase + 'LOGIN.REG_LOGIN.HEADING' | translate }}
         .card-body
-          ang-login-form#mainContent
+          ang-login-form((userEmail)="username = $event")#mainContent
           a#linkLoginResetModal((click)="showPwdModal = true" tabindex="1" class="link" data-automation-component="artstor-pw-reset-link") {{ 'LOGIN.REG_LOGIN.FORGOT_PW_PROMPT' | translate }}
           br
           div(*ngIf="showRegister")
@@ -55,7 +55,7 @@
         .card-body
           .form-group
             | #[a#linkLoginSaharaSS.link(tabindex="1", [attr.href]="_auth.getEnv() === 'test' ? FORUM_TEST : FORUM_PROD", target="_blank", data-automation-component="ss-login-link") Log in] to JSTOR Forum
-ang-pwd-reset-modal(*ngIf="showPwdModal", (closeModal)="showPwdModal = false")
+ang-pwd-reset-modal(*ngIf="showPwdModal", [username]="username", (closeModal)="showPwdModal = false")
 #helpModal.modal([ngClass]="{'show': showHelpModal }")
   .modal-dialog
     .modal-content

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -45,6 +45,8 @@ export class Login implements OnInit, OnDestroy {
   public showRegister: boolean = false
   public showHelpModal: boolean = false
 
+  public username: string = '';
+
   private loginInstName: string = '' /** Bound to the autocomplete field */
   private stashedRoute: string
   private dataService: LocalData

--- a/src/app/modals/pwd-reset/pwd-reset.component.pug
+++ b/src/app/modals/pwd-reset/pwd-reset.component.pug
@@ -12,7 +12,7 @@
             p Enter the email address that you used when registering.
             .form-group
               label(for="pwdresetEmailInput") Email Address:
-              input#pwdresetEmailInput.form-control(type="text", [formControl]="pwdResetForm.controls['email']", spellcheck="false", tabindex="0")
+              input#pwdresetEmailInput.form-control(type="text", [formControl]="pwdResetForm.controls['email']", (value)="username", spellcheck="false", tabindex="0")
           .has-danger(*ngIf="submitted && pwdResetForm.controls['email'].invalid && !errorMsgPwdRst && !successMsgPwdRst")
             p.form-control-feedback A valid email is required
           .form-control-feedback.has-danger(*ngIf="errorMsgPwdRst")

--- a/src/app/modals/pwd-reset/pwd-reset.component.ts
+++ b/src/app/modals/pwd-reset/pwd-reset.component.ts
@@ -1,5 +1,5 @@
 import { AuthService } from '../../shared';
-import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
 import { formGroupNameProvider } from '@angular/forms/src/directives/reactive_directives/form_group_name';
 import { FormGroup, FormControl, FormBuilder, Validators } from '@angular/forms';
 
@@ -8,6 +8,7 @@ import { FormGroup, FormControl, FormBuilder, Validators } from '@angular/forms'
   templateUrl: 'pwd-reset.component.pug'
 })
 export class PwdResetModal implements OnInit {
+  @Input() username: string;
   @Output() closeModal: EventEmitter<any> = new EventEmitter();
 
   public pwdResetForm: FormGroup;
@@ -21,13 +22,13 @@ export class PwdResetModal implements OnInit {
   constructor(
     private _auth: AuthService,
     private _fb: FormBuilder
-  ) {
-    this.pwdResetForm = _fb.group({
-      'email': ['', [Validators.required, Validators.pattern(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)]]
+  ) { }
+
+  ngOnInit() { 
+    this.pwdResetForm = this._fb.group({
+      'email': [this.username, [Validators.required, Validators.pattern(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)]]
     });
   }
-
-  ngOnInit() { }
 
 
   sendResetPwdRequest(){


### PR DESCRIPTION
 - Emit the email address from login-form component 
 - Receive the email address at login component
 - Login component then feed it to pwd-reset component

Note: I use the event emitter because we want the pwd-reset component to receive the email address even if user didn't submit any form