### PR TITLE
AIR-2248 (Analytics/GTM: Events with missing information [PLACEHOLDER])

### DIFF
--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -245,7 +245,7 @@ export class NewIgModal implements OnInit {
       // analytics events
       if (this.copyIG) {
         // Copying old group
-        this._angulartics.eventTrack.next({ properties: { event: 'copyGroup', category: 'groups', label: group.id }})
+        this._angulartics.eventTrack.next({ properties: { event: 'copyGroup', category: 'groups', label: this.ig.id }})
       } else {
         // Create New Group
         this._angulartics.eventTrack.next({ properties: { event: 'newGroup', category: 'groups' }})


### PR DESCRIPTION
 - The labels are not showing in Analytics because of a wrong setting on the TagManager website. So setting a correct variable on TagManager does the fix once for all.
 - This branch just fixes the label for copyGroup where it is undefined.