### PR TITLE
AIR-2191 Sentry: Move import to app.module

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@nguniversal/module-map-ngfactory-loader": "^7.1.0",
     "@ngx-translate/core": "^10.0.2",
     "@ngx-translate/http-loader": "^3.0.1",
-    "@sentry/browser": "^5.0.8",
+    "@sentry/browser": "^5.1.0",
     "@sentry/node": "^4.5.4",
     "angular-sortablejs": "^2.6.0",
     "angular2-medium-editor": "1.2.0",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,6 +45,7 @@ export class AppComponent {
 
   public showSkyBanner: boolean = false
   public skyBannerCopy: string = ''
+  public test: any = {}
   /**
    * Google Tag Manager variables
    * - In order of specificity 
@@ -87,6 +88,8 @@ export class AppComponent {
     @Inject(PLATFORM_ID) private platformId: Object
   ) {
     // console.info("Constructing app component")
+    this.test.thing = this.test.a.b
+    throw new Error("This is my fake error message")
     // Append timestamp param to dodge caching
     if (isPlatformBrowser(this.platformId)) {
       let langStr = 'en.json?no-cache=' + new Date().valueOf()

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, NgModule, Inject, APP_ID, PLATFORM_ID } from '@angular/core';
+import { ApplicationRef, NgModule, Inject, APP_ID, PLATFORM_ID, Injectable, ErrorHandler } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule, HttpClient } from '@angular/common/http';
@@ -120,7 +120,28 @@ import { LinkifyPipe } from './shared/linkify.pipe'
 import { KeysPipe } from './shared/keys.pipe'
 import { CustomUrlSerializer } from './shared/custom-url-serializer'
 import { LOCAL_STORAGE , WINDOW} from '@ng-toolkit/universal'
-import { ArtstorStorageService } from '../../../projects/artstor-storage/src/public_api'
+
+// Error tracking utility for sentry.io
+import * as Sentry from '@sentry/browser';
+// Project Dependencies
+import { version } from '../../package.json'
+
+// Sentry Raven reporter
+Sentry.init({ 
+  dsn: 'https://9ef1f98534914bf6826e202370d1f627@sentry.io/209953',
+  release: version
+});
+@Injectable()
+export class SentryErrorHandler implements ErrorHandler {
+  constructor() {}
+  handleError(error) {
+    const eventId = Sentry.captureException(error.originalError || error);
+    // Report bug modal option
+    // Sentry.showReportDialog({ eventId });
+    // For additional debugging
+    // console.log("Sentry ID: " + eventId)
+  }
+}
 
 const APP_PROVIDERS = [
   ...APP_RESOLVER_PROVIDERS,
@@ -150,7 +171,10 @@ const APP_PROVIDERS = [
   TitleService,
   MetadataService,
   { provide: UrlSerializer, useClass: CustomUrlSerializer },
-  { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true }
+  // 401/Unauthorized handler
+  { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
+  // Sentry error reporting
+  { provide: ErrorHandler, useClass: SentryErrorHandler }
   // { provide: RouteReuseStrategy, useClass: CustomReuseStrategy } // to be implemented later
 ];
 

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -2,10 +2,6 @@
 // rc2 workaround
 import { enableDebugTools, disableDebugTools } from '@angular/platform-browser';
 import { ApplicationRef, enableProdMode, ErrorHandler, Injectable } from '@angular/core';
-// Error tracking utility for sentry.io
-import * as Sentry from '@sentry/browser';
-// Project Dependencies
-import { version } from '../../package.json'
 // Env vars
 import { environment } from 'environments/environment'
 
@@ -18,20 +14,6 @@ let PROVIDERS: any[] = [
 // https://github.com/angular/angular/blob/86405345b781a9dc2438c0fbe3e9409245647019/TOOLS_JS.md
 let _decorateModuleRef = function identity<T>(value: T): T { return value; };
 
-// Sentry Raven reporter
-Sentry.init({ 
-  dsn: 'https://9ef1f98534914bf6826e202370d1f627@sentry.io/209953',
-  release: version
-});
-@Injectable()
-export class SentryErrorHandler implements ErrorHandler {
-  constructor() {}
-  handleError(error) {
-    const eventId = Sentry.captureException(error.originalError || error);
-    Sentry.showReportDialog({ eventId });
-  }
-}
-
 if (environment.production) {
   // Production
   disableDebugTools();
@@ -39,8 +21,6 @@ if (environment.production) {
 
   PROVIDERS = [
     ...PROVIDERS,
-    // Use Sentry error handler
-    { provide: ErrorHandler, useClass: SentryErrorHandler }
     // custom providers in production
   ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,14 +555,14 @@
     semver "5.5.1"
     semver-intersect "1.4.0"
 
-"@sentry/browser@^5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.8.tgz#12350d1e1d0881eb4641f44ffa8ddcefb2b03217"
-  integrity sha512-hMV3mF8R3YZ0IhkjdYMSNdPfC2XbImCL88Mqxkc53KPGMes/8psPd40aWChRcMw0qJIovgezAdn41oxMH8XimQ==
+"@sentry/browser@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.1.0.tgz#513f51f6f617f848cd031472a841efa7117a43f9"
+  integrity sha512-OS1r8cbccso+I7vV/jXsudAZ/vfxo9L7X+IdvYkHbUFDXMaSEjwY8WCZxB4J6Y3veM4qQIw1doWtpJd9BKiiLw==
   dependencies:
-    "@sentry/core" "5.0.8"
-    "@sentry/types" "5.0.6"
-    "@sentry/utils" "5.0.8"
+    "@sentry/core" "5.1.0"
+    "@sentry/types" "5.1.0"
+    "@sentry/utils" "5.1.0"
     tslib "^1.9.3"
 
 "@sentry/core@4.6.6":
@@ -576,15 +576,15 @@
     "@sentry/utils" "4.6.5"
     tslib "^1.9.3"
 
-"@sentry/core@5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.8.tgz#8a05f1c024cda726b4cabeb2e56c5a6e3857e475"
-  integrity sha512-LGTPMx4PqSOCUiUjHZ45kwealcqAnHgUZonnIv8pcqd1NmY5oOUAhI/rO60Yj9Ij6TVaSHppWpYHI7Wt9Ot6kQ==
+"@sentry/core@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.1.0.tgz#c2a5522593cf8fe07c1da8d6af8d5fbaff3300df"
+  integrity sha512-i7kDqpJuSv4FBs3UvexPvt8Tr1jrbJqHxMeWKoURbMd4btd/sgv7lCXLKOuiRVy2V2IZ3NAPiCikVqK2rEdKKA==
   dependencies:
-    "@sentry/hub" "5.0.8"
-    "@sentry/minimal" "5.0.8"
-    "@sentry/types" "5.0.6"
-    "@sentry/utils" "5.0.8"
+    "@sentry/hub" "5.1.0"
+    "@sentry/minimal" "5.1.0"
+    "@sentry/types" "5.1.0"
+    "@sentry/utils" "5.1.0"
     tslib "^1.9.3"
 
 "@sentry/hub@4.6.5":
@@ -596,13 +596,13 @@
     "@sentry/utils" "4.6.5"
     tslib "^1.9.3"
 
-"@sentry/hub@5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.8.tgz#9a229c4afee0b59a238b7c804d20369e7d3346b2"
-  integrity sha512-a9+hnYO42Rpdk7lrxk3dhmZYfOGMDEq2WP2blNiKIU2efI6CQ3G9Ka/6WzVOXSgV3rY+4zx60vHUhNkQVgsbsg==
+"@sentry/hub@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.1.0.tgz#edcff4b85c10e6f44c603202da23776af36aeca0"
+  integrity sha512-gz46z4u65Uywn9ZrSuWNDJRjBgllA1pqov27fhdSPu5yvSr7dwdUCKO/5pvuXNQrBl79OxKzsXwUySX/9p5M1g==
   dependencies:
-    "@sentry/types" "5.0.6"
-    "@sentry/utils" "5.0.8"
+    "@sentry/types" "5.1.0"
+    "@sentry/utils" "5.1.0"
     tslib "^1.9.3"
 
 "@sentry/minimal@4.6.5":
@@ -614,13 +614,13 @@
     "@sentry/types" "4.5.3"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.8.tgz#21a6521dfbc02d098ae604813e90d945fec6c820"
-  integrity sha512-MP5bFuqC0xMWT9LTkX0rkX1Xxlj3G4zKdhF8rxwM9YLZUUmS5vvNs/AiPGaEAlw8i9C+0TBTcvQt3va2qVVEHA==
+"@sentry/minimal@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.1.0.tgz#7892908c70d4f9f85b79eb861e561b82a170bfc2"
+  integrity sha512-+TySfvc6DiZ/06m5HePBNkIoDiWsRQClYWrVMysHRz1GzJhvWLmPdCikMXrfSZinlyrGIZGZAuNkd3LhmmtUrQ==
   dependencies:
-    "@sentry/hub" "5.0.8"
-    "@sentry/types" "5.0.6"
+    "@sentry/hub" "5.1.0"
+    "@sentry/types" "5.1.0"
     tslib "^1.9.3"
 
 "@sentry/node@^4.5.4":
@@ -645,10 +645,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.5.3.tgz#3350dce2b7f9b936a8c327891c12e3aef7bd8852"
   integrity sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag==
 
-"@sentry/types@5.0.6":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.6.tgz#df1b318977e5308741049cc4f35986cf8255115f"
-  integrity sha512-EJYzjfnTfTQgqR3p6dSvIVZe0xe2Jz+tSmvuPABf7VoCmrFtEYkMCSf5IshMHeebmXUS5prrPSCAgVcIrJC+Bw==
+"@sentry/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.1.0.tgz#2acda336c73c996b42ca03887679599c78751f10"
+  integrity sha512-Uo5Fla1RjCfmliQWsV4ehZ1Q4z4taMC66ZGrqrUWx7FyQsaps+TJfQE5QiTIs+jWD6CbgVRf/N+pNMmpIK8JVA==
 
 "@sentry/utils@4.6.5":
   version "4.6.5"
@@ -658,12 +658,12 @@
     "@sentry/types" "4.5.3"
     tslib "^1.9.3"
 
-"@sentry/utils@5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.8.tgz#3dcc95b84fef1a862236c9950c257322817bf0da"
-  integrity sha512-NZUVl3i2Rm5WKgPEb0DSPYTMQsCxdbZXOiOEq2/9Ee1bY29VTzmjM08KZTYI8+ZiUJwB2l3y/nvNGkqlEoXQCg==
+"@sentry/utils@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.1.0.tgz#15067fe64248948379518c23fe9949aae430cf78"
+  integrity sha512-p2W9Zg6IAtVFd2ejk850ixcv/01++eXA4y1t9YT+feocV3GyhHirz6aGFviPFGcOjSeAai+uuV2rvzFeLJtmkg==
   dependencies:
-    "@sentry/types" "5.0.6"
+    "@sentry/types" "5.1.0"
     tslib "^1.9.3"
 
 "@types/anymatch@*":
@@ -1482,6 +1482,50 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+"appdynamics-jre@https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-jre.tgz":
+  version "4.5.13"
+  resolved "https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-jre.tgz#addff96b74d9454df8bf2963d65440950d27d288"
+
+"appdynamics-libagent@https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-libagent-node.tgz":
+  version "4.5.13"
+  resolved "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-libagent-node.tgz#8f5076d4149e2e0f006969300d427e4cadb6d921"
+  optionalDependencies:
+    request "2.88.0"
+
+"appdynamics-native@https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-native-node.tgz":
+  version "4.5.13"
+  resolved "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-native-node.tgz#058d86fee13d06e9490f9fbbbd9a32b2a98f87ce"
+
+"appdynamics-protobuf@https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-protobuf-node.tgz":
+  version "4.5.13"
+  resolved "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-protobuf-node.tgz#2f19a94baaa2ddf1a08a6a05b6c5284d64d32cf3"
+
+"appdynamics-proxy@https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-proxy.tgz":
+  version "4.5.13"
+  resolved "https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-proxy.tgz#a56c17f6ec67474b61ef3b856934747d91dbefd6"
+
+"appdynamics-zmq@https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-zmq-node.tgz":
+  version "4.5.13"
+  resolved "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-zmq-node.tgz#9054b840e6b13467506a22e93f44868d42e97455"
+
+appdynamics@4.5.13:
+  version "4.5.13"
+  resolved "https://registry.yarnpkg.com/appdynamics/-/appdynamics-4.5.13.tgz#ea9ecfdc10c61bf735e03b5c79648711db599239"
+  integrity sha512-9R1XHib4/XaEErSjACexhsihwIQ/A6tIsNZdNRHoCsUv1/Ve8nESk192Iss4dvc1AvPNsCSq0PTmxvvSw8+RAQ==
+  dependencies:
+    appdynamics-jre "https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-jre.tgz"
+    appdynamics-libagent "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-libagent-node.tgz"
+    appdynamics-native "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-native-node.tgz"
+    appdynamics-protobuf "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-protobuf-node.tgz"
+    appdynamics-proxy "https://packages.appdynamics.com/nodejs/4.5.13.0/appdynamics-proxy.tgz"
+    appdynamics-zmq "https://cdn.appdynamics.com/packages/nodejs/4.5.13.0/appdynamics-zmq-node.tgz"
+    cls-hooked "^4.2.2"
+    log4js "0.6.38"
+    set-immediate "0.1.1"
+    uuid "3.1.0"
+  optionalDependencies:
+    n "^2.1.8"
 
 append-transform@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
After a lot of trial and error, I discovered the Sentry import does not compile correctly from the environment.ts providers convenience file. Couple other notes:
- Sentry no longer prevents the errors from logging correctly so using it locally doesn't hurt anything now
- Our environment variables do work, that was an assumption I made