### PR TITLE
AIR-2296 (Need groupid to play audio/video files and download media files)

### DIFF
--- a/src/app/_services/metadata.service.ts
+++ b/src/app/_services/metadata.service.ts
@@ -30,7 +30,7 @@ export class MetadataService {
             switch (assetData.object_type_id) {
             case 12:
             case 24:
-                return this.getFpxInfo(assetData.object_id)
+                return this.getFpxInfo(assetData.object_id, groupId)
                 .pipe(map((res) => {
                     assetData.fpxInfo = res
                     return assetData
@@ -162,8 +162,8 @@ export class MetadataService {
        * @param assetId The artstor id for the relevant asset
        * @param objectTypeId The number corresponding to the asset's type - a map to English names can be found in the Asset class
        */
-      private getFpxInfo(assetId: string): Observable<ImageFPXResponse> {
-        let requestUrl = this._auth.getUrl() + '/imagefpx/' + assetId + '/24'
+      private getFpxInfo(assetId: string, groupId?: string): Observable<ImageFPXResponse> {
+        let requestUrl = groupId ? this._auth.getUrl() + '/imagefpx/' + assetId + '/24?groupid=' + groupId : this._auth.getUrl() + '/imagefpx/' + assetId + '/24'
         let headers: HttpHeaders = new HttpHeaders().set('Content-Type', 'application/json')
         return this._http
             .get<ImageFPXResponse>(requestUrl, { headers: this._auth.getHeaders(), withCredentials: true })

--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -78,7 +78,7 @@ export class Asset {
         return formattedData
     }
 
-    private buildDownloadLink(data: AssetData): string {
+    private buildDownloadLink(data: AssetData, groupId?: string): string {
         let downloadLink: string
         switch (data.object_type_id) {
             case 20:
@@ -86,7 +86,9 @@ export class Asset {
             case 22:
             case 23:
                 // Non-image Download Link format: /media/ARTSTORID/TYPEID
+                let queryParam = '?groupid=' + groupId
                 downloadLink = [data.baseUrl, 'media', this.id, data.object_type_id].join("/")
+                downloadLink = groupId ?  downloadLink + queryParam : downloadLink
                 break
             default:
                 if (Array.isArray(this.tileSource) && this.tileSource.length >= 1) {
@@ -214,7 +216,7 @@ export class Asset {
             this.tileSource = data.tileSourceHostname + '/rosa-iiif-endpoint-1.0-SNAPSHOT/fpx' + encodeURIComponent(imgPath) + '/info.json'
         }
         // Set download after tilesource determined
-        this.downloadLink = this.buildDownloadLink(data)
+        this.downloadLink = this.buildDownloadLink(data, data.groupId)
 
         // set up kaltura info if it exists
         if (data.fpxInfo) {


### PR DESCRIPTION
 - Send groupid as query parameter to /api/imagefpx and /media calls when coming from a group