### PR TITLE
AIR-2292: Handle legacy link redirects

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -132,7 +132,12 @@ app.use('*', (req, res, next) => {
  */
 app.use('/assets/', express.static(join(DIST_FOLDER, 'browser')))
 app.use('/', express.static(join(DIST_FOLDER, 'browser')))
+// Specifically allow file types that live in the root of /dist/browser
 app.use(':filename.js', express.static(join(DIST_FOLDER, 'browser')))
+app.use(':filename.html', express.static(join(DIST_FOLDER, 'browser')))
+app.use(':filename.txt', express.static(join(DIST_FOLDER, 'browser')))
+app.use(':filename.xml', express.static(join(DIST_FOLDER, 'browser')))
+app.use(':filename.css', express.static(join(DIST_FOLDER, 'browser')))
 // Pass all other/unspecified routes to the Angular static app
 app.get('*', (req, res) => {
   // res.redirect('/#'+req.url)

--- a/server/server.ts
+++ b/server/server.ts
@@ -132,9 +132,11 @@ app.use('*', (req, res, next) => {
  */
 app.use('/assets/', express.static(join(DIST_FOLDER, 'browser')))
 app.use('/', express.static(join(DIST_FOLDER, 'browser')))
+app.use(':filename.js', express.static(join(DIST_FOLDER, 'browser')))
 // Pass all other/unspecified routes to the Angular static app
 app.get('*', (req, res) => {
-  res.redirect('/#'+req.url)
+  // res.redirect('/#'+req.url)
+  res.sendFile(join(DIST_FOLDER, 'browser/index.html'))
 })
 
 app.post('*', (req, res) => {

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
           || initPath.indexOf('/library/collection') > -1
           || initPath.indexOf('/library/welcome.html') > -1
           || initPath.indexOf('.org/library/#') > -1
+          || initPath.indexOf('4000/library/#') > -1
           || initPath.indexOf('/openlibrary') > -1
           || initPath.indexOf('/asset/') > -1
           || initPath.indexOf('/public/') > -1


### PR DESCRIPTION
Links such as:
library.artstor.org/library/#3%7Ccollections%7C87730435%7C%7CBrooklyn20College20Listening20Project%7C%7C%7C
Should be redirected to the appropriate collection page.