### PR TITLE
AIR-2391 (Remove deleted image button not functioning)

### DIFF
--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -873,7 +873,7 @@ export class AssetGrid implements OnInit, OnDestroy {
   private removeFromGroup(assetsToRemove: AssetThumbnail[], clearRestricted?: boolean): void {
     for (let i = 0; i < assetsToRemove.length; i++) {
       let assetId = assetsToRemove[i].id
-      let igIndex = this.ig.items.indexOf(assetId)
+      let igIndex = this.ig.items.findIndex(item => item.id === assetId)
       // Passing -1 will splice the wrong asset!
       if (igIndex >= 0) {
         this.ig.items.splice(igIndex, 1)


### PR DESCRIPTION
 - Change from indexOf to findIndex because this.if.items is an array of objects instead of an array of numbers