### PR TITLE
AIR-2398 (Support Search3 filters with flag)

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -215,6 +215,8 @@ export class AssetSearchService {
    * Uses wildcard search to retrieve filters
    */
   public getFacets() {
+    this.contentQueryKey = this._auth.useSearch3 ? 'content_set_flags' : 'content_types'
+    this.filterQueryKey = this._auth.useSearch3 ? 'filter_queries' : 'filter_query'
     let query = {
       'limit': 0,
       'start': 1,
@@ -430,6 +432,8 @@ export class AssetSearchService {
    * @param assetId The id of the desired asset
    */
   public getAssetById(assetId: string, ssid?: boolean): Observable<AssetThumbnail> {
+    this.contentQueryKey = this._auth.useSearch3 ? 'content_set_flags' : 'content_types'
+
     let assetQuery: SearchRequest
     assetQuery['query'] = ssid ? 'ssid:' + assetId : assetId
     assetQuery[this.contentQueryKey] = ['art']

--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -450,17 +450,22 @@ export class AssetService {
     public categoryByFacet(facetName: string, collectionType ?: number): Promise<SolrFacet[]> {
       let options = { withCredentials: true };
 
+      let contentQueryKey = this._auth.useSearch3 ? 'content_set_flags' : 'content_types'
+      let filterQueryKey = this._auth.useSearch3 ? 'filter_queries' : 'filter_query'
       let query = {
             // Base solr query
             'limit': 0,
             'start': 1,
-            'content_types': [
-                'art'
-            ],
+            // 'content_set_flags': [
+            //     'art'
+            // ],
             'hier_facet_fields2': [],
             'facet_fields' : [],
-            'filter_query' : []
+            // 'filter_queries' : []
         };
+      query[contentQueryKey] = ['art']
+      query[filterQueryKey] = []
+
       let isHierarchy = facetName === 'artstor-geography'
       if (isHierarchy) {
         let hierarchy = {
@@ -517,7 +522,7 @@ export class AssetService {
         filterArray.push('contributinginstitutionid:' + institutionFilters[i])
       }
 
-      query['filter_query'] = filterArray
+      query[filterQueryKey] = filterArray
 
       return this.http.post(this._auth.getSearchUrl(), query, options)
         .toPromise()


### PR DESCRIPTION
 - Change `content_types` to `content_set_flags` in the query
 - Change `filter_query` to `filter_queries` in the query

Note: the two variables "contentQueryKey" & "filterQueryKey" are temporarily set up to simplify the code because currently we need to account for two types of search, they can be removed after we completely switched to search3.