### PR TITLE
AIR-2403 (Disabled Cluster Icon)

### DIFF
--- a/src/app/_services/thumbnail.service.ts
+++ b/src/app/_services/thumbnail.service.ts
@@ -41,7 +41,8 @@ export class ThumbnailService {
         ssid: cleanedSSID,
         iap: asset.iap,
         frequentlygroupedwith: asset.frequentlygroupedwith,
-        partofcluster: asset.partofcluster
+        partofcluster: asset.partofcluster,
+        clusterid: asset.clusterid
       }
       // Parse stringified compound media if available
       if (cleanedAsset.compound_media) {


### PR DESCRIPTION
 - There is a missing `clusterid` in `AssetThumbnail`, after adding it back it works fine