### PR TITLE
AIR-2354

### DIFF
--- a/src/app/shared/group-title/group-title.component.pug
+++ b/src/app/shared/group-title/group-title.component.pug
@@ -16,22 +16,22 @@
               = " "
             .dropdown-menu([ngClass]="{ 'hovered' : dropDownOptHovered || dropDownOptFocused }", ngbDropdownMenu)
               a#exportPptLink.dropdown-item((click)="_ig.triggerPPTExport()", (keyup.enter)="_ig.triggerPPTExport()", (mouseover)="dropDownOptHovered = true", (mouseout)="dropDownOptHovered = false",(focus)="dropDownOptFocused = true", (focusout)="dropDownOptFocused = false", tabindex="3", aria-label="Powerpoint", role="button")
-                i.icon.icon-powerpoint
-                .content
-                  label PowerPoint
-                  .caption Exports as one image per slide, with metadata in the speaker notes
+                i#exportPptIcon.icon.icon-powerpoint
+                .content#exportPptContent
+                  label#exportPptLabel PowerPoint
+                  .caption#exportPptCaption Exports as one image per slide, with metadata in the speaker notes
 
               a#exportGsLink.dropdown-item(*ngIf="exportGoogleFlag", (click)="_ig.triggerGoogleSlides()", (keyup.enter)="_ig.triggerGoogleSlides()", tabindex="3", aria-label="Google Slides", role="button")
-                i.icon.icon-google-slides
-                .content
-                  label Google Slides
-                  .new-badge New!
-                  .caption Exports as one image per slide, with metadata in the speaker notes
+                i#exportGsIcon.icon.icon-google-slides
+                .content#exportGsContent
+                  label#exportGsLabel Google Slides
+                  .new-badge#exportGsBadge New!
+                  .caption#exportGsCaption Exports as one image per slide, with metadata in the speaker notes
               a#exportZipLink.dropdown-item((click)="_ig.triggerZIPExport()", (keyup.enter)="_ig.triggerZIPExport()", tabindex="3", aria-label="Zip File", role="button")
-                i.icon.icon-zip
-                .content
-                  label ZIP File
-                  .caption Items and their metadata are combined as a compressed file
+                i#exportZipIcon.icon.icon-zip
+                .content#exportZipContent
+                  label#exportZipLabel ZIP File
+                  .caption#exportZipCaption Items and their metadata are combined as a compressed file
 
         a#presentLink.icon-link(tabindex="3", (click)="presentStudyGroup('present')", (keyup.enter)="presentStudyGroup('present')")
           i.icon.icon-present-mode--orange


### PR DESCRIPTION
 - Cause: the text in the button is overriding the visiblity of the links id's (exportPptLink, exportZipLink)
 - Solution: Give both parent and child element an id start with "exportPpt" (for example, the parent element is called "exportPptLink", and the child elements are called "exportPptIcon" and "exportPptContent"). Then in the Tag Manager setting, we can set the Click to be triggered by Click ID starts with "exportPpt".
 - For test: Tag Manager preview link of the new change: https://www.googletagmanager.com/start_preview/gtm?uiv2&id=GTM-TMVNHFH&gtm_auth=C06s3pTeBCJh_owwOJafRA&gtm_preview=env-25&gtm_debug=x