### PR TITLE
AIR-2365

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -162,7 +162,7 @@
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
             input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL()", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL()", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
+            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL()", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -162,7 +162,7 @@
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
             input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL()", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
+            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1070,15 +1070,14 @@ export class AssetPage implements OnInit, OnDestroy {
 
         // Add Captain's log event: Copy image url
         let searchResults = this._storage.getLocal('results')
-        if (searchResults) {
-            this._log.log({
-                eventType: 'artstor_copy_link',
-                additional_fields: {
-                    referring_requestid: searchResults.requestId,
-                    item_id: asset.id
-                }
-            })
-        }
+        let requestedid = searchResults.requestId ? searchResults.requestId : null
+        this._log.log({
+            eventType: 'artstor_copy_link',
+            additional_fields: {
+                referring_requestid: requestedid,
+                item_id: asset.id
+            }
+        })
 
         setTimeout(() => {
             input.select();

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1049,7 +1049,7 @@ export class AssetPage implements OnInit, OnDestroy {
      * Adds a link to the current asset page to the user's clipboard
      * @requires browser
      */
-    private copyGeneratedImgURL(): void {
+    private copyGeneratedImgURL(asset: Asset): void {
 
         let statusMsg = '';
         let input: any;
@@ -1066,6 +1066,18 @@ export class AssetPage implements OnInit, OnDestroy {
         // Determine if on iOS (no copy functionality)
         if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) {
             iOSuser = true
+        }
+
+        // Add Captain's log event: Copy image url
+        let searchResults = this._storage.getLocal('results')
+        if (searchResults) {
+            this._log.log({
+                eventType: 'artstor_copy_link',
+                additional_fields: {
+                    referring_requestid: searchResults.requestId,
+                    item_id: asset.id
+                }
+            })
         }
 
         setTimeout(() => {

--- a/src/app/modals/share-link-modal/share-link-modal.component.ts
+++ b/src/app/modals/share-link-modal/share-link-modal.component.ts
@@ -34,7 +34,7 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
     if (this.asset) {
       let isPublic = this.asset.collectiontypes ? this.asset.collectiontypes.indexOf(5) >= 0 : false
       // External share links are not handled by this modal, since it is only called by Nav
-      this.shareLink = this._assets.getShareLink(this.asset.objectId ? this.asset.objectId : this.asset.artstorid, isPublic);
+      this.shareLink = this._assets.getShareLink(this.asset.id, isPublic);
       // Clean Group item data
       if (this.asset['tombstone']) {
         this.asset['name'] = this.asset['tombstone'][0]

--- a/src/app/modals/share-link-modal/share-link-modal.component.ts
+++ b/src/app/modals/share-link-modal/share-link-modal.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, Input, Output, EventEmitter, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
 
 // Project Dependencies
-import { AssetService, DomUtilityService, ThumbnailService } from '_services';
+import { AssetService, DomUtilityService, ThumbnailService, LogService } from '_services';
 import { Asset } from '../../asset-page/asset';
+import { ArtstorStorageService } from '../../../../projects/artstor-storage/src/public_api';
 
 @Component({
   selector: 'ang-share-link-modal',
@@ -24,7 +25,9 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
   constructor(
     private _assets: AssetService,
     private _thumbnail: ThumbnailService,
-    private _dom: DomUtilityService
+    private _dom: DomUtilityService,
+    private _log: LogService,
+    private _storage: ArtstorStorageService
   ) { }
 
   ngOnInit() {
@@ -90,6 +93,19 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
 
       if (id === 'copyURL'){
         this.copyURLStatusMsg = msg;
+
+        // Add Captain's log event: Copy image url
+        let searchResults = this._storage.getLocal('results')
+        if (searchResults) {
+          this._log.log({
+              eventType: 'artstor_copy_link',
+              additional_fields: {
+                referring_requestid: searchResults.requestId,
+                item_id: this.asset.id
+              }
+          })
+        }
+
         setTimeout(() => {
           this.copyURLStatusMsg = '';
         }, 8000);

--- a/src/app/modals/share-link-modal/share-link-modal.component.ts
+++ b/src/app/modals/share-link-modal/share-link-modal.component.ts
@@ -96,15 +96,14 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
 
         // Add Captain's log event: Copy image url
         let searchResults = this._storage.getLocal('results')
-        if (searchResults) {
-          this._log.log({
-              eventType: 'artstor_copy_link',
-              additional_fields: {
-                referring_requestid: searchResults.requestId,
+        let requestedid = searchResults.requestId ? searchResults.requestId : null
+        this._log.log({
+            eventType: 'artstor_copy_link',
+            additional_fields: {
+                referring_requestid: requestedid,
                 item_id: this.asset.id
-              }
-          })
-        }
+            }
+        })
 
         setTimeout(() => {
           this.copyURLStatusMsg = '';


### PR DESCRIPTION
 - Add eventtype `artstor_copy_link` for copying image url
 - Additional fields:
    - `referring_requestid` field: obtained from search response, stored as `results` field in local storage, null for image group assets
    - `item_id` field: the asset's id