### PR TITLE
AIR-2383

### DIFF
--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -540,16 +540,10 @@ export class AssetService {
         })
     }
 
-    public getBlogEntries(query ?: string) {
-        if (!query || query == '*') {
-            // An asterisk query on the Wordpress API *LIMITS* results to those with an asterisk!
-            query = '';
-        } else {
-            // Force exact phrase match
-            query = '"' + query + '"';
-        }
+    public getBlogEntries() {
         return this.http
-            .get('https://public-api.wordpress.com/rest/v1.1/sites/artstor.wordpress.com/posts/?number=24&search=' + query)
+            // New enpoint for just Collection Release category
+            .get('https://www.artstor.org/wp-json/wp/v2/posts?categories=8')
             .toPromise()
     }
 

--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -27,9 +27,9 @@
             h2.h1([innerHtml]="'HOME.HEADINGS.FRM_BLOG' | translate")
           .loading(*ngIf="blogLoading")
           div(*ngIf="!blogLoading")
-            a.blog-post(*ngFor="let post of blogPosts | slice:0:3", [href]="post['URL']", target="_blank", tabindex="4", [attr.aria-label]="post.title")
-              h3.blog-post__title([innerHtml]="post.title", aria-hidden="true")
-              p.blog-post__preview([innerHtml]="post.excerpt", aria-hidden="true")
+            a.blog-post(*ngFor="let post of blogPosts | slice:0:3", [href]="post['link']", target="_blank", tabindex="4", [attr.aria-label]="post['title']['rendered']")
+              h3.blog-post__title([innerHtml]="post['title']['rendered']", aria-hidden="true")
+              p.blog-post__preview([innerHtml]="post['excerpt']['rendered']", aria-hidden="true")
       div([ngClass]="showBlog ? 'col-sm-3' : 'row'")
         //- Institution Shared Shelf Collections
         .card(*ngIf="institution && instCollections.length > 0", [class.col-sm-4]="!showBlog")

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -158,18 +158,37 @@ export class Home implements OnInit, OnDestroy {
     if (isPlatformBrowser(this.platformId)) {
       // Load blog posts for home page
       this._assets.getBlogEntries()
-      .then((data) => {
-        if (data['posts']) {
-          this.blogPosts = data['posts'];
+      .then((blogPosts) => {
+        if (Array.isArray(blogPosts)) {
+          // Format blogPosts to extract excerpt if its not available
+          for(let blogPost of blogPosts) {
+            if(blogPost['content'] && blogPost['content']['rendered']) {
+              let excerpt: string = '<div>'
+              let tempElement = document.createElement('div')
+              tempElement.innerHTML = blogPost['content']['rendered']
+              let pTags = tempElement.querySelectorAll('p')
+              for(let i = 0; i < 3; i++) {
+                if(pTags[i]) {
+                  excerpt += pTags[i].outerHTML
+                }
+              }
+              excerpt += '</div>'
+              if(blogPost['excerpt'] && blogPost['excerpt']['rendered'] === '') {
+                blogPost['excerpt']['rendered'] = excerpt
+              }
+            }
+          }
+
+          this.blogPosts = blogPosts
         }
-        this.blogLoading = false;
+        this.blogLoading = false
       } )
       .catch((error) => {
-        console.log(error);
-        this.blogLoading = false;
+        console.log(error)
+        this.blogLoading = false
       });
       // Device info for contact form
-      this.fetchDeviceInfo();
+      this.fetchDeviceInfo()
     }
 
   } // OnInit

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -167,9 +167,10 @@ export class Home implements OnInit, OnDestroy {
               let tempElement = document.createElement('div')
               tempElement.innerHTML = blogPost['content']['rendered']
               let pTags = tempElement.querySelectorAll('p')
-              for(let i = 0; i < 3; i++) {
-                if(pTags[i]) {
-                  excerpt += pTags[i].outerHTML
+              for(let i = 0; i < 10; i++) {
+                if(pTags[i] && pTags[i].innerText.length > 120) {
+                  excerpt += pTags[i].innerText.replace('Content:', '')
+                  break
                 }
               }
               excerpt += '</div>'

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -518,7 +518,7 @@
     "HEADINGS": {
       "SSC": "Public Collections",
       "BRWSE": "Browse",
-      "FRM_BLOG": "From Our Blog",
+      "FRM_BLOG": "New Collections",
       "INSTITUTION_COLLECTIONS": "{{institutionName}} Collections",
       "FEATURED": "Art and Multimedia"
     },


### PR DESCRIPTION
Display Collection Release category blog posts on the home page. 
- Note that at the moment the new call (https://www.artstor.org/wp-json/wp/v2/posts?categories=8) for fetching the Collection Release category posts returns an empty `excerpt` field. 
- For situations where we have an empty `excerpt` field, we are trying to extract the first three `p` tags from the post content as `excerpt` value.