### PR TITLE
Viewer Tooltip Fix - PDF Fast Follow

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -531,24 +531,13 @@ background:  #000 !important;
     border-bottom-color: $color-gray-7;
 }
 
-.tooltip-inner {
-    background-color: $color-gray-7;
-    font-family: Arial;
-    font-size: 10px;
-    font-weight: normal;
-    line-height: 1.2;
-    letter-spacing: normal;
-    text-align: center;
-    color: $color-white;
-}
-
 .pdf-viewer-container{
     position: relative;
     height: 90vh;
     width: 100%;
     min-height: 90vh;
     background-color: $color-gray-4;
-    
+
     pdf-viewer {
         display: block;
     }


### PR DESCRIPTION
AssestViewer SCSS: remove tooltip-inner style so the definition in app.scss isn't overridden