### PR TITLE
AIR-2350 (Clean up Sentry deluge)

### DIFF
--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -146,11 +146,11 @@ export class GroupService {
      */
     public hasPrivateGroups(): void {
         let cachedUser = this._storage.getLocal('user')
-        let hasPrivate = cachedUser.isLoggedIn && this._storage.getLocal('hasPrivateGroups')
+        let hasPrivate = cachedUser && cachedUser.isLoggedIn && this._storage.getLocal('hasPrivateGroups')
         if (hasPrivate)  {
             this.hasPrivateGroupSource.next(true) 
         }
-        else if (!cachedUser.isLoggedIn) {
+        else if (!(cachedUser && cachedUser.isLoggedIn)) {
             this.hasPrivateGroupSource.next(false) 
         } else {
             this.http.get(this.groupUrl + '?size=1&level=private', this.options)

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1666,7 +1666,7 @@ export class AssetPage implements OnInit, OnDestroy {
     public isPrimaryAsset(asset: any): boolean{
         let primaryAsset: boolean = true
 
-        if (this.assets[0].id === asset.id){
+        if (this.assets[0] && (this.assets[0].id === asset.id)){
             if(asset['zoom']){
                 let primaryAssetZoomObj = this.indexZoomMap[0]
                 if(JSON.stringify(asset['zoom']) !== JSON.stringify(primaryAssetZoomObj)){

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -92,7 +92,7 @@ export class RegisterComponent implements OnInit {
 
     // If not proxied/IP-authed OR not Shibboleth workflow, redirect to Login
     // If logged in, redirect to Home
-    if (!this.isShibbFlow && this._auth.isPublicOnly() || this._auth.getUser().isLoggedIn) {
+    if (!this.isShibbFlow && this._auth.isPublicOnly() || (this._auth.getUser() && this._auth.getUser().isLoggedIn)) {
       this._auth.getUser().isLoggedIn ? this._router.navigate(['/home']) : this._router.navigate(['/login'])
     }
 


### PR DESCRIPTION
For TypeError `Cannot read property 'id' of undefined` that fired 37 times: 
 - On asset page, the `this.assets[0]` will take some time to load, otherwise it is undefined

For TypeError `Cannot read property 'isLoggedIn' of null`:
 - In group service, check the `cachedUser` before read `isLoggedIn`