### PR TITLE
AIR-2385 (Update copy for library.artstor.org slideshow)

### DIFF
--- a/src/app/home/featured/featured.component.pug
+++ b/src/app/home/featured/featured.component.pug
@@ -37,6 +37,6 @@
     p.photo-caption.small([innerHTML]="featured[primaryFeaturedIndex].caption | translate")
   .col
     p.text-right
-      a.link.text-right(*ngIf="!_auth.isPublicOnly() && siteId != 'SAHARA'", [routerLink]="['/browse', 'library']", [innerHtml]="headings + '.VIEW_ALL_LINK' | translate", tabindex="4")
-      a.link.text-right(*ngIf="!_auth.isPublicOnly() && siteId === 'SAHARA'", [routerLink]="['/browse', 'institution']", [innerHtml]="headings + '.VIEW_ALL_LINK' | translate", tabindex="4")
-      a.link.text-right(*ngIf="_auth.isPublicOnly()", [routerLink]="['/browse', 'commons']", [innerHtml]="headings + '.VIEW_PUBLIC_LINK' | translate", tabindex="4")
+      a.link.text-right(*ngIf="!_auth.isPublicOnly() && siteId != 'SAHARA'", href="https://www.artstor.org/blog/", [innerHtml]="headings + '.VIEW_ALL_LINK' | translate", tabindex="4")
+      a.link.text-right(*ngIf="!_auth.isPublicOnly() && siteId === 'SAHARA'", href="https://www.artstor.org/blog/", [innerHtml]="headings + '.VIEW_ALL_LINK' | translate", tabindex="4")
+      a.link.text-right(*ngIf="_auth.isPublicOnly()", href="https://www.artstor.org/blog/", [innerHtml]="headings + '.VIEW_PUBLIC_LINK' | translate", tabindex="4")

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -551,10 +551,10 @@
     },
     "FEATURED": {
       "HEADINGS": {
-        "PUBLIC": "Featured Public Collections",
-        "INST": "Featured Collections",
-        "VIEW_ALL_LINK": "View All Collections",
-        "VIEW_PUBLIC_LINK": "View All Public Collections"
+        "PUBLIC": "What's new",
+        "INST": "What's new",
+        "VIEW_ALL_LINK": "Read more on the blog",
+        "VIEW_PUBLIC_LINK": "Read more on the blog"
       },
       "COLLECTIONS": [{
           "SUBHEADING": "Panos Pictures",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -551,8 +551,8 @@
     },
     "FEATURED": {
       "HEADINGS": {
-        "PUBLIC": "What's new",
-        "INST": "What's new",
+        "PUBLIC": "What's New",
+        "INST": "What's New",
         "VIEW_ALL_LINK": "Read more on the blog",
         "VIEW_PUBLIC_LINK": "Read more on the blog"
       },


### PR DESCRIPTION
 - "Featured collections" change to "What's new"
 - The link text "View all collections" change to "Read more on the blog"
 - The link is updated to: https://www.artstor.org/blog/