### PR TITLE
Air 2412: User cannot add to image group they created

### DIFF
--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -200,8 +200,11 @@ export class GroupService {
           group,
           this.options
       ).pipe(map(data => {
-          // Reassess whether user has groups
-          this.hasPrivateGroups(true)
+          if (data['id']) {
+            // If group created, ensure 'hasPrivateGroups' is true
+            this._storage.setLocal('hasPrivateGroups', true)
+            this.hasPrivateGroupSource.next(true)
+          }
           return data
       }))
     }
@@ -239,7 +242,9 @@ export class GroupService {
                 )
             ), map(data => {
                 // Reassess whether user has groups
-                this.hasPrivateGroups(true)
+                setTimeout(() => { // Allow elastic time to index groups
+                    this.hasPrivateGroups(true)
+                }, 400)
                 return data
             }))
     }

--- a/src/app/browse-page/browse-groups/groups.component.pug
+++ b/src/app/browse-page/browse-groups/groups.component.pug
@@ -53,7 +53,7 @@
         i.icon.icon-add
         i.icon.icon-close
       a#groupTagsClear.link--accent.small(*ngIf="_tagFilters.selectedFilters.length>1", style="margin:3px;", (click)="_tagFilters.clearFilters();", (keyup.enter)="_tagFilters.clearFilters();", tabindex="3", aria-label="Clear all tags") Clear All
-    .group-list.has-icon-overlay.px-2
+    .group-list.px-2
       .alert.alert-warning(*ngIf="selectedFilter && errorObj[selectedFilter.level]", [innerHtml]="errorObj[selectedFilter.level]")
       ng-container
         ang-card-view(*ngFor="let tag of tags; let i=index;", [tag]="tag", [group]="groups[i]", [browseLevel]="selectedFilter.level", link="true")
@@ -61,11 +61,11 @@
       //-   ang-tag(*ngFor="let tag of tags", [tag]="tag", link="true")
     .row.has-icon-overlay(*ngIf="loading")
       i.icon-lg.icon-overlay--top.icon-loading-large
-//- Don't show this if there is a filters list, if it's loading, or if the user hasn't searched for anything yet
-.alert.alert-info(*ngIf="!isSearch && tags.length < 1 && !loading")
-  h3 {{ 'BROWSE.ERRORS.NO_GROUPS_COLLECTIONS_HEADING' | translate }}
-  br
-  div(*ngIf="selectedFilter && selectedFilter.level === 'created'", [innerHtml]="'BROWSE.ERRORS.NO_PRIVATE_GROUPS_COLLECTIONS_PROMPT' | translate")
-  div(*ngIf="selectedFilter && selectedFilter.level === 'institution'", [innerHtml]="'BROWSE.ERRORS.NO_INSTITUTIONAL_GROUPS_COLLECTIONS_PROMPT' | translate")
+    //- Don't show this if there is a filters list, if it's loading, or if the user hasn't searched for anything yet
+    .alert.alert-info(*ngIf="!isSearch && tags.length < 1 && !loading")
+      h3 {{ 'BROWSE.ERRORS.NO_GROUPS_COLLECTIONS_HEADING' | translate }}
+      br
+      div(*ngIf="selectedFilter && selectedFilter.level === 'created'", [innerHtml]="'BROWSE.ERRORS.NO_PRIVATE_GROUPS_COLLECTIONS_PROMPT' | translate")
+      div(*ngIf="selectedFilter && selectedFilter.level === 'institution'", [innerHtml]="'BROWSE.ERRORS.NO_INSTITUTIONAL_GROUPS_COLLECTIONS_PROMPT' | translate")
 ang-access-denied-modal(*ngIf="showAccessDeniedModal")
 

--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -21,6 +21,10 @@
                 .recent-groups(*ngIf="!groupSearchTerm")
                   .hdr
                     label(tabindex="10") Recent Groups
+                  .no-result-row(*ngIf="!groupSearchTerm && totalGroups === 0 && !loading.recentGroups")
+                    .alert.alert-warning
+                      b No Groups Found
+                      | It looks like you have not created a group yet! Please try creating a group first.
                   .row.no-gutters(*ngFor="let recentGroup of recentGroups", [ngClass]="{ 'selectedGroup' : recentGroup.selected }", [attr.id]="recentGroup.id", (click)="selectGroup(recentGroup, 'recent');groupSelectKeyDown($event, recentGroup.selected)", (keydown.enter)="selectGroup(recentGroup, 'recent')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(recentGroup, 'recent')", (keydown)="groupSelectKeyDown($event, recentGroup.selected)", tabindex="10", [attr.aria-label]="recentGroup.name + ', ' + (recentGroup.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (recentGroup.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper
@@ -33,7 +37,7 @@
                     .dot
 
                 .all-my-groups
-                  .hdr(*ngIf="!groupSearchTerm")
+                  .hdr(*ngIf="!groupSearchTerm && totalGroups > 0")
                     label(tabindex="10") All My Groups
                   .no-result-row(*ngIf="groupSearchTerm && totalGroups === 0")
                     b.no-result-msg Sorry, we couldn’t find any groups related to your search. Please try a different search.

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -341,10 +341,13 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           .catch( error => {
             console.error(error)
           })
+        } else {
+          this.loading.recentGroups = false
         }
       },
       (error) => {
         console.error(error)
+        this.loading.recentGroups = false
       }
     )).subscribe()
   }
@@ -394,6 +397,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
       },
       (error) => {
         console.error(error)
+        this.loading.allGroups = false
       }
     )).subscribe()
   }


### PR DESCRIPTION
It looks like the primary fix to this issue was made by Jialin 2 days ago, when cleaning up a reference to "cachedUser.isLoggedIn", however I fixed a couple other things that, depending on the path the user took, may have caused an issue:
- When a group is created or destroy, reassess whether the user has private groups
- Properly display an error message when Recent Groups do not load in the Add to Group modal
- When we query for a user's groups, set "hasPrivateGroups" to false if no groups return
- Fix the error display in the Groups Browse layout