### PR TITLE
AIR-2406

### DIFF
--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -138,7 +138,7 @@
           p.sr-only Press enter again to tun off reording for that image. Pressing the escape key places focus back on the save reorder button to save your changes.
           .row.no-gutters([sortablejs]="results", [sortablejsOptions]="sortableOptions")
             ng-container(*ngFor="let asset of results; let i = index")
-              .col-sm-4.col-md-2.col-xl-1.col--reorder.draggable
+              .col-sm-4.col-md-2.col-xl-1.col--reorder.draggable(*ngIf="asset['status'] === 'available'")
                 .card.card--asset([ngClass]="{ 'lrgThmb': largeThmbView }")
                   ang-thumbnail(
                     [thumbnail]="asset",


### PR DESCRIPTION
Remove ghost asset in the group (during reorder mode) once deleted from PC. Let's just make sure that we are only showing thumbnails for assets with `status` === `available`.