### PR TITLE
AIR-2389 (On Registration, "Log in" link takes users to the "link account" page)

### DIFF
--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -197,7 +197,7 @@ export class RegisterComponent implements OnInit {
    * Navigates to correct page for login depending on whether or not shiboleth params exist
    */
   public navigateToLogin(): void {
-    if (this.shibParameters) {
+    if (this.shibParameters && this.shibParameters.email) {
       this._router.navigate(['/link', this.shibParameters])
     } else {
       this._router.navigate(['/login'])


### PR DESCRIPTION
 - `this.shibParameters` is an object, so check the email instead of checking itself