### PR TITLE
AIR-2419 (Design Refine: Fix asset control icons)

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -28,10 +28,10 @@
     <!--Viewer Buttons-->
     <div *ngIf="!thumbnailMode">
         <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
-            <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" placement="bottom"><i class="icon icon-zoom-in-v2"></i></button>
-            <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" placement="bottom"><i class="icon icon-zoom-out-v2"></i></button>
+            <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" placement="bottom"><i class="icon icon-zoom-in"></i></button>
+            <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" placement="bottom"><i class="icon icon-zoom-out"></i></button>
             <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
-            <button class="btn btn--icon btn--fullScreen" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present-dark"></i></button>
+            <button class="btn btn--icon btn--fullScreen" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
             <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
         </div>
 

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -52,10 +52,10 @@ $desktop: 992px;*/
     opacity: 0;
     transition: opacity 0.2s linear;
     position: absolute;
-    top: 20px;
-    left: 20px;
+    top: 0;
+    left: 0;
     z-index: 1000;
-    margin: 10px;
+    margin: 20px;
     box-shadow: 0 0 4px 1px #0000003b;
     border-radius: 4px;
 

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -270,7 +270,7 @@
           title="Exit Fullscreen"
         )
         | Exit
-        .icon.icon-close
+        .icon.icon-exit-fullscreen
     //- Asset Drawer
     .asset-drawer(*ngIf="isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
       .col-sm-12

--- a/src/app/asset-page/asset-page.component.scss
+++ b/src/app/asset-page/asset-page.component.scss
@@ -130,7 +130,7 @@ $titleNavBg: #eee;
     position: fixed;
     top:0;
     right: 0;
-    margin: 20px*2;
+    margin: 20px;
     z-index: 2000;
 
     opacity: 0.8;
@@ -146,7 +146,8 @@ $titleNavBg: #eee;
     }
 
     & .btn {
-        padding: 0 12px;
+        padding: 0 8px;
+        height: 40px;
     }
 }
 

--- a/src/assets/img/icon-compare.svg
+++ b/src/assets/img/icon-compare.svg
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="415px" height="377px" viewBox="0 0 415 377" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 6</title>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>icon-compare</title>
     <desc>Created with Sketch.</desc>
-    <defs>
-        <polygon id="path-1" points="0 0 202.5 0 255 61 255 341 0 341"></polygon>
-    </defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-6">
-            <path d="M170,45.0981085 L170,366.098108 L405,366.098108 L405,99.8088446 L357.912891,45.0981085 L170,45.0981085 Z" id="Rectangle-2-Copy" stroke="#000000" stroke-width="20"></path>
-            <g id="Rectangle-2">
-                <use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-1"></use>
-                <path stroke="#000000" stroke-width="20" d="M10,10 L10,331 L245,331 L245,64.7107361 L197.912891,10 L10,10 Z"></path>
-            </g>
-            <path d="M70.347962,170.099892 L69.4452866,170.116615 L69.8869911,170.5 L69.4452866,170.883385 L70.347962,170.900108 L145.184123,235.855451 L145.184123,203.697742 L225.560002,203.697742 L225.560002,170.5 L225.560002,137.302258 L145.184123,137.302258 L145.184123,105.144549 L70.347962,170.099892 Z" id="Combined-Shape-Copy" fill="#000000" transform="translate(147.502644, 170.500000) rotate(-180.000000) translate(-147.502644, -170.500000) "></path>
-            <path d="M264.299141,214.877765 L263.484827,214.895422 L263.881596,215.232631 L263.484827,215.56984 L264.299141,215.587498 L330.101409,271.512005 L330.101409,244.431919 L380.796532,244.431919 L380.796532,215.232631 L380.796532,186.033343 L330.101409,186.033343 L330.101409,158.953258 L264.299141,214.877765 Z" id="Combined-Shape-Copy-2" fill="#000000" transform="translate(322.140680, 215.232631) rotate(-360.000000) translate(-322.140680, -215.232631) "></path>
-        </g>
+    <g id="icons/actions/compare" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M13.6833751,8.95833333 L17.5679672,12.9328465 L16.1376663,14.3307877 L9.90938512,7.95833333 L16.1376663,1.585879 L17.5679672,2.98382013 L13.6833751,6.95833333 L21,6.95833333 L21,8.95833333 L13.6833751,8.95833333 Z M10.3166249,15.0416667 L6.43203284,11.0671535 L7.86233372,9.66921233 L14.0906149,16.0416667 L7.86233372,22.414121 L6.43203284,21.0161799 L10.3166249,17.0416667 L3,17.0416667 L3,15.0416667 L10.3166249,15.0416667 L10.3166249,15.0416667 Z" id="icon---compare" fill="#333333" fill-rule="nonzero"></path>
     </g>
 </svg>

--- a/src/assets/img/icon-exit-fullscreen.svg
+++ b/src/assets/img/icon-exit-fullscreen.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>icon-exit-fullscreen</title>
+    <desc>Created with Sketch.</desc>
+    <g id="icons/actions/exit-fullscreen" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <polygon id="Path" fill="#333333" fill-rule="nonzero" points="13.4142136 12 18.7071068 17.2928932 17.2928932 18.7071068 12 13.4142136 6.70710678 18.7071068 5.29289322 17.2928932 10.5857864 12 5.29289322 6.70710678 6.70710678 5.29289322 12 10.5857864 17.2928932 5.29289322 18.7071068 6.70710678"></polygon>
+    </g>
+</svg>

--- a/src/assets/img/icon-fit-to-view.svg
+++ b/src/assets/img/icon-fit-to-view.svg
@@ -1,31 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="26px" height="26px" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 54.1 (76490) - https://sketchapp.com -->
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
     <title>icon-fit-to-view</title>
     <desc>Created with Sketch.</desc>
     <defs>
-        <filter x="-6.4%" y="-25.0%" width="112.8%" height="150.0%" filterUnits="objectBoundingBox" id="filter-1">
-            <feOffset dx="0" dy="0" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
-            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
-            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
-            <feMerge>
-                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
-                <feMergeNode in="SourceGraphic"></feMergeNode>
-            </feMerge>
-        </filter>
+        <path d="M3,3 L21,3 L21,21 L3,21 L3,3 Z M5,5 L5,19 L19,19 L19,5 L5,5 Z M12.6962783,15.7637085 L13.8318963,14.6280904 L14.8925565,15.6887506 L11.9462783,18.6350288 L9,15.6887506 L10.0606602,14.6280904 L11.1962783,15.7637085 L11.1962783,12.5743687 L12.6962783,12.5743687 L12.6962783,15.7637085 Z M11.1962783,8.07132034 L10.0606602,9.20693843 L9,8.14627825 L11.9462783,5.2 L14.8925565,8.14627825 L13.8318963,9.20693843 L12.6962783,8.07132034 L12.6962783,11.2606602 L11.1962783,11.2606602 L11.1962783,8.07132034 Z" id="path-1"></path>
     </defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="hovers-on-image-controls" transform="translate(-292.000000, -428.000000)">
-            <g id="controls---zoom-in" filter="url(#filter-1)" transform="translate(227.000000, 425.000000)">
-                <g id="icon-fit-to-view" transform="translate(69.000000, 7.000000)">
-                    <g id="icons/actions/fit-to-view">
-                        <g id="icon-fit-to-view">
-                            <path d="M8.17157288,4.17157288 L4.17157288,8.17157288 L4.17157288,4.17157288 L8.17157288,4.17157288 Z M9.82842712,4.17157288 L13.8284271,4.17157288 L13.8284271,8.17157288 L9.82842712,4.17157288 Z M8.17157288,13.8284271 L4.17157288,13.8284271 L4.17157288,9.82842712 L8.17157288,13.8284271 Z M9.82842712,13.8284271 L13.8284271,9.82842712 L13.8284271,13.8284271 L9.82842712,13.8284271 Z" id="Shape" fill="#333333" fill-rule="nonzero" transform="translate(9.000000, 9.000000) rotate(-315.000000) translate(-9.000000, -9.000000) "></path>
-                            <rect id="Rectangle" stroke="#333333" stroke-width="1.5" x="0.75" y="0.75" width="16.5" height="16.5"></rect>
-                        </g>
-                    </g>
-                </g>
-            </g>
-        </g>
+    <g id="icons/actions/fit-to-view" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="icon---fit-to-view" fill="#333333" fill-rule="nonzero" xlink:href="#path-1"></use>
     </g>
 </svg>

--- a/src/assets/img/icon-present.svg
+++ b/src/assets/img/icon-present.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>icon-present</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M18.59375,17.1795364 L18.59375,14.59375 L20.59375,14.59375 L20.59375,20.59375 L14.59375,20.59375 L14.59375,18.59375 L17.1795364,18.59375 L13.6383464,15.0525599 L15.0525599,13.6383464 L18.59375,17.1795364 Z M6.82046356,18.59375 L9.40625,18.59375 L9.40625,20.59375 L3.40625,20.59375 L3.40625,14.59375 L5.40625,14.59375 L5.40625,17.1795364 L8.94744008,13.6383464 L10.3616536,15.0525599 L6.82046356,18.59375 Z M17.1795364,5.40625 L14.59375,5.40625 L14.59375,3.40625 L20.59375,3.40625 L20.59375,9.40625 L18.59375,9.40625 L18.59375,6.82046356 L15.0525599,10.3616536 L13.6383464,8.94744008 L17.1795364,5.40625 Z M5.40625,6.82046356 L5.40625,9.40625 L3.40625,9.40625 L3.40625,3.40625 L9.40625,3.40625 L9.40625,5.40625 L6.82046356,5.40625 L10.3616536,8.94744008 L8.94744008,10.3616536 L5.40625,6.82046356 Z" id="path-1"></path>
+    </defs>
+    <g id="icons/actions/present" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="icon---present" fill="#333333" fill-rule="nonzero" xlink:href="#path-1"></use>
+        <g id="mixins/color-gray-7" mask="url(#mask-2)" fill="#333333">
+            <rect id="🎨Color" x="0" y="0" width="24" height="24"></rect>
+        </g>
+    </g>
+</svg>

--- a/src/assets/img/icon-remove-from-comparison.svg
+++ b/src/assets/img/icon-remove-from-comparison.svg
@@ -1,31 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="33px" height="33px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 54.1 (76490) - https://sketchapp.com -->
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
     <title>icon-remove-from-comparison</title>
     <desc>Created with Sketch.</desc>
-    <defs>
-        <filter x="-12.8%" y="-50.0%" width="125.6%" height="200.0%" filterUnits="objectBoundingBox" id="filter-1">
-            <feOffset dx="0" dy="0" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
-            <feGaussianBlur stdDeviation="4" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
-            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.4 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
-            <feMerge>
-                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
-                <feMergeNode in="SourceGraphic"></feMergeNode>
-            </feMerge>
-        </filter>
-    </defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="hovers-on-image-controls" transform="translate(-1048.000000, -424.000000)" stroke="#333333" stroke-width="1.5">
-            <g id="item-controls-copy-6" filter="url(#filter-1)" transform="translate(956.000000, 425.000000)">
-                <g id="icon-remove-from-comparison" transform="translate(101.000000, 8.000000)">
-                    <polyline id="Rectangle" transform="translate(6.117647, 6.117647) rotate(-180.000000) translate(-6.117647, -6.117647) " points="8.7394958 0 12.2352941 0 12.2352941 12.2352941 0 12.2352941 0 8.7394958"></polyline>
-                    <rect id="Rectangle" x="3.57352941" y="3.57352941" width="11.6764706" height="11.6764706"></rect>
-                    <g id="close-icon" transform="translate(6.588235, 6.588235)">
-                        <path d="M-9.81437154e-14,5.59030302 L5.59030302,9.85878046e-14" id="arrow-right-copy" transform="translate(2.795152, 2.795152) rotate(-90.000000) translate(-2.795152, -2.795152) "></path>
-                        <path d="M3.10862447e-15,5.59030302 L5.59030302,1.33226763e-15" id="arrow-right-copy" transform="translate(2.795152, 2.795152) scale(-1, 1) rotate(-90.000000) translate(-2.795152, -2.795152) "></path>
-                    </g>
-                </g>
-            </g>
-        </g>
+    <g id="icons/actions/remove-from-comparison" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M13.4142136,12 L16.1142136,14.7 L14.7,16.1142136 L12,13.4142136 L9.3,16.1142136 L7.88578644,14.7 L10.5857864,12 L7.88578644,9.3 L9.3,7.88578644 L12,10.5857864 L14.7,7.88578644 L16.1142136,9.3 L13.4142136,12 L13.4142136,12 Z M12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 Z M12,20 C16.418278,20 20,16.418278 20,12 C20,7.581722 16.418278,4 12,4 C7.581722,4 4,7.581722 4,12 C4,16.418278 7.581722,20 12,20 Z" id="icon---remove-from-comparison" fill="#333333" fill-rule="nonzero"></path>
     </g>
 </svg>

--- a/src/assets/img/icon-zoom-in.svg
+++ b/src/assets/img/icon-zoom-in.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>icon-zoom-in</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M12,10 L14,10 L14,12 L12,12 L12,14 L10,14 L10,12 L8,12 L8,10 L10,10 L10,8 L12,8 L12,10 Z M16.6176858,18.0318994 C15.078015,19.2635271 13.1250137,20 11,20 C6.02943725,20 2,15.9705627 2,11 C2,6.02943725 6.02943725,2 11,2 C15.9705627,2 20,6.02943725 20,11 C20,13.1250137 19.2635271,15.078015 18.0318994,16.6176858 L22.4142136,21 L21,22.4142136 L16.6176858,18.0318994 Z M16.2040997,15.6816867 C17.3205406,14.4414726 18,12.8000844 18,11 C18,7.13400675 14.8659932,4 11,4 C7.13400675,4 4,7.13400675 4,11 C4,14.8659932 7.13400675,18 11,18 C12.8000844,18 14.4414726,17.3205406 15.6816867,16.2040997 L16.2040997,15.6816867 Z" id="path-1"></path>
+    </defs>
+    <g id="icons/actions/zoom-in" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="icon---zoom-in" fill="#333333" fill-rule="nonzero" xlink:href="#path-1"></use>
+    </g>
+</svg>

--- a/src/assets/img/icon-zoom-out.svg
+++ b/src/assets/img/icon-zoom-out.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>icon-zoom-out</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M16.6176858,18.0318994 C15.078015,19.2635271 13.1250137,20 11,20 C6.02943725,20 2,15.9705627 2,11 C2,6.02943725 6.02943725,2 11,2 C15.9705627,2 20,6.02943725 20,11 C20,13.1250137 19.2635271,15.078015 18.0318994,16.6176858 L22.4142136,21 L21,22.4142136 L16.6176858,18.0318994 Z M16.2040997,15.6816867 C17.3205406,14.4414726 18,12.8000844 18,11 C18,7.13400675 14.8659932,4 11,4 C7.13400675,4 4,7.13400675 4,11 C4,14.8659932 7.13400675,18 11,18 C12.8000844,18 14.4414726,17.3205406 15.6816867,16.2040997 L16.2040997,15.6816867 Z M8,12 L8,10 L14,10 L14,12 L8,12 Z" id="path-1"></path>
+    </defs>
+    <g id="icons/actions/zoom-out" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="icon---zoom-out" fill="#333333" fill-rule="nonzero" xlink:href="#path-1"></use>
+    </g>
+</svg>

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -142,9 +142,9 @@ $iconBtnSize: $btnHeight;
  }
 
  .btn:not(.btn--icon) > .icon {
-    margin: 0 0.5em;
-    width: 1.2em;
-    height: 1.2em;
+    margin: 0 0 0 4px;
+    width: 24px;
+    height: 24px;
     vertical-align: middle;
     transform: translateY(-0.1em);
  }
@@ -247,7 +247,6 @@ $iconBtnSize: $btnHeight;
     border-bottom: none;
 
     & .icon {
-        opacity: 0.8;
         height: 18px;
         width: 18px;
         position: absolute;

--- a/src/sass/modules/_icons.scss
+++ b/src/sass/modules/_icons.scss
@@ -92,16 +92,17 @@
 @include icon--hover('study-mode', 'svg');
 
 @include icon('fit-to-view', 'svg');
-@include icon('present-dark', 'svg');
+@include icon('present', 'svg');
 @include icon('remove-from-comparison', 'svg');
+@include icon('exit-fullscreen', 'svg');
 
 @include icon('more', 'svg');
 @include icon('info', 'svg');
 @include icon('share', 'svg');
 @include icon('share-white', 'svg');
 @include icon('star', 'svg');
-@include icon('zoom-in-v2', 'svg');
-@include icon('zoom-out-v2', 'svg');
+@include icon('zoom-in', 'svg');
+@include icon('zoom-out', 'svg');
 @include icon('large-view', 'svg');
 @include icon('small-view', 'svg');
 @include icon('detail-view', 'svg');


### PR DESCRIPTION
 - For .btn--icon remove the opacity 0.8 because we have hover states
 - Replace all asset control icons, including compare and exit
 - Update css styles according to Kelsey