### PR TITLE
AIR-2481

### DIFF
--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -154,7 +154,7 @@ export class GroupService {
             this.hasPrivateGroupSource.next(false) 
         } else {
             // forceReassess should fallback to querying the group service
-            this.http.get(this.groupUrl + '?size=1&level=private', this.options)
+            this.http.get(this.groupUrl + '?size=1&level=created', this.options)
             .toPromise()
             .then( res => {
                 if (res['total'] > 0) {


### PR DESCRIPTION
Add to an existing group: Make sure to query for editable groups for the logged-in user using `&level=created`, while fetching groups list.