### PR TITLE
2467 Refactor - Collection Link Refactor

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -179,17 +179,20 @@
             | {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.PENDING_MESSAGE' | translate }}
           .meta-block.collection-type-display(*ngIf="collectionType")
             ang-collection-badge([collectionType]="collectionType")
-          //- Old metadata loop
+          //- Metadata loops
           .meta-block(*ngFor="let fieldName of assets[0].formattedMetadata | keys")
             ng-container(*ngIf="fieldName != 'Rights' && fieldName != 'License'")
               .label {{ fieldName }}
               div(*ngFor="let value of assets[0].formattedMetadata[fieldName]; let i=index")
+                //- Creator
                 a.value.col-link(*ngIf="fieldName === 'Creator'", [attr.id]="cleanId(fieldName)", (click)="trackCreatorLink(value)", [routerLink]="['/search', 'artcreator:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
+                //- Collections
                 ng-container(*ngIf="fieldName === 'Collection'")
-                  a.value.col-link(*ngFor="let col of assets[0].collections",[attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(value))", [routerLink]="setCollectionLink(assets[0], value)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
-                  br
+                  a.value.col-link(*ngFor="let col of assets[0].collections", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(value))", [routerLink]="setCollectionLink(assets[0], value, col)", [innerHTML]="cleanFieldValue(col.name) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
+                //- Subject
                 a.value.col-link(*ngIf="fieldName === 'Subject'", [attr.id]="cleanId(fieldName)", (click)="trackSubjectLink(value)", [routerLink]="['/search', 'artsubject:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 .value(*ngIf="fieldName !== 'Collection' && fieldName !== 'Subject' && fieldName !== 'Creator'", [attr.id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
+          //- Rights
           .meta-block(*ngIf="assets[0].formattedMetadata.Rights && assets[0].formattedMetadata.Rights.length > 0")
             .label#Rights Rights
             div(*ngFor="let right of assets[0].formattedMetadata.Rights")
@@ -198,6 +201,7 @@
                 | &nbsp;
                 a.value.col-link.rights-text([innerHTML]="cleanFieldValue(right) | lowercase | linkify", [attr.href]="rightsLink", aria-label="Learn about this rights statement on rightsstatements.org", target="_blank")
               .value(*ngIf="rightsText !== right", [innerHTML]="cleanFieldValue(right) | linkify", [attr.aria-labelledby]="'Rights'")
+          //- License
           .meta-block(*ngIf="assets[0].formattedMetadata.License && assets[0].formattedMetadata.License.length > 0")
             .label#License License
             .license(*ngFor="let license of assets[0].formattedMetadata.License")
@@ -206,23 +210,22 @@
                 | &nbsp;
                 span.value.license-text([innerHTML]="cleanFieldValue(license) | lowercase | linkify", title="License")
               .value(*ngIf="licenseText !== license", [innerHTML]="cleanFieldValue(license) | linkify")
-
+          //- File Properties
           .row-hdr.pt-3(*ngIf="assets[0].filePropertiesArray.length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.FILE_PROPS' | translate}}
-          //- Loop through File Properties Array
-          //- .meta-block(*ngFor="let filePropObj of assets[0].filePropertiesArray")
-          //-   .label([attr.id]="cleanId(filePropObj.fieldName)") {{ filePropObj.fieldName }}
-          //-     .value([innerHTML]="filePropObj.fieldValue")
+          //- File Name
           .meta-block(*ngIf="assets[0].fileName")
             .label#fileName {{ 'ASSET_PAGE.METADATA_LABELS.FILE_NAME' | translate }}
               .value([innerHtml]="assets[0].fileName", aria-labelledby="fileName")
+          //- SSID
           .meta-block(*ngIf="assets[0].SSID")
             .label#ssid {{ 'ASSET_PAGE.METADATA_LABELS.SSID' | translate }}
               .value([innerHtml]="assets[0].SSID", aria-labelledby="ssid")
+          //- IAP and Report Error
           .text-left.pt-2
             a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", tabindex="8", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
             a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", tabindex="14", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
 
-        //- Form hidden by default
+        //- Report Error Form, hidden by default
         .mt-2.d-none([class.d-block]="showEditDetails")
           button.close.mb-3((click)="showExitEdit = true", type="button", aria-label="Close")
             span(aria-hidden="true") &times;

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -187,8 +187,8 @@
                 //- Creator
                 a.value.col-link(*ngIf="fieldName === 'Creator'", [attr.id]="cleanId(fieldName)", (click)="trackCreatorLink(value)", [routerLink]="['/search', 'artcreator:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 //- Collections
-                ng-container(*ngIf="fieldName === 'Collection'")
-                  a.value.col-link(*ngFor="let col of collectionLinks", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(col.displayName))", [routerLink]="col.route", [innerHTML]="cleanFieldValue(col.displayName) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
+                ng-container(*ngIf="fieldName === 'Collection' && i === 0")
+                  a.value.col-link(*ngFor="let col of assets[0].collectionLinks", [attr.id]="Collections", (click)="trackCollectionLink(cleanFieldValue(col.displayName))", [routerLink]="col.route", [innerHTML]="cleanFieldValue(col.displayName) | linkify", [attr.aria-labelledby]="Collections")
                 //- Subject
                 a.value.col-link(*ngIf="fieldName === 'Subject'", [attr.id]="cleanId(fieldName)", (click)="trackSubjectLink(value)", [routerLink]="['/search', 'artsubject:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 //- Other fields (culture, material, work type, description...etc)

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -185,7 +185,9 @@
               .label {{ fieldName }}
               div(*ngFor="let value of assets[0].formattedMetadata[fieldName]; let i=index")
                 a.value.col-link(*ngIf="fieldName === 'Creator'", [attr.id]="cleanId(fieldName)", (click)="trackCreatorLink(value)", [routerLink]="['/search', 'artcreator:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
-                a.value.col-link(*ngIf="fieldName === 'Collection'", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(value))", [routerLink]="setCollectionLink(assets[0], value)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
+                ng-container(*ngIf="fieldName === 'Collection'")
+                  a.value.col-link(*ngFor="let col of assets[0].collections",[attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(value))", [routerLink]="setCollectionLink(assets[0], value)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
+                  br
                 a.value.col-link(*ngIf="fieldName === 'Subject'", [attr.id]="cleanId(fieldName)", (click)="trackSubjectLink(value)", [routerLink]="['/search', 'artsubject:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 .value(*ngIf="fieldName !== 'Collection' && fieldName !== 'Subject' && fieldName !== 'Creator'", [attr.id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
           .meta-block(*ngIf="assets[0].formattedMetadata.Rights && assets[0].formattedMetadata.Rights.length > 0")

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -188,9 +188,10 @@
                 a.value.col-link(*ngIf="fieldName === 'Creator'", [attr.id]="cleanId(fieldName)", (click)="trackCreatorLink(value)", [routerLink]="['/search', 'artcreator:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 //- Collections
                 ng-container(*ngIf="fieldName === 'Collection'")
-                  a.value.col-link(*ngFor="let col of assets[0].collections", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(value))", [routerLink]="setCollectionLink(assets[0], value, col)", [innerHTML]="cleanFieldValue(col.name) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
+                  a.value.col-link(*ngFor="let col of collectionLinks[0]", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(col.displayName))", [routerLink]="col.route", [innerHTML]="cleanFieldValue(col.displayName) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
                 //- Subject
                 a.value.col-link(*ngIf="fieldName === 'Subject'", [attr.id]="cleanId(fieldName)", (click)="trackSubjectLink(value)", [routerLink]="['/search', 'artsubject:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
+                //- Other fields (culture, material, work type, description...etc)
                 .value(*ngIf="fieldName !== 'Collection' && fieldName !== 'Subject' && fieldName !== 'Creator'", [attr.id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
           //- Rights
           .meta-block(*ngIf="assets[0].formattedMetadata.Rights && assets[0].formattedMetadata.Rights.length > 0")

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -188,7 +188,7 @@
                 a.value.col-link(*ngIf="fieldName === 'Creator'", [attr.id]="cleanId(fieldName)", (click)="trackCreatorLink(value)", [routerLink]="['/search', 'artcreator:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 //- Collections
                 ng-container(*ngIf="fieldName === 'Collection'")
-                  a.value.col-link(*ngFor="let col of collectionLinks[0]", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(col.displayName))", [routerLink]="col.route", [innerHTML]="cleanFieldValue(col.displayName) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
+                  a.value.col-link(*ngFor="let col of collectionLinks", [attr.id]="cleanId(fieldName)", (click)="trackCollectionLink(cleanFieldValue(col.displayName))", [routerLink]="col.route", [innerHTML]="cleanFieldValue(col.displayName) | linkify", [attr.aria-labelledby]="cleanId(fieldName)", style="display:block;")
                 //- Subject
                 a.value.col-link(*ngIf="fieldName === 'Subject'", [attr.id]="cleanId(fieldName)", (click)="trackSubjectLink(value)", [routerLink]="['/search', 'artsubject:(' + value + ')']", [innerHTML]="value", [attr.aria-labelledby]="cleanId(fieldName)")
                 //- Other fields (culture, material, work type, description...etc)

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -774,39 +774,44 @@ export class AssetPage implements OnInit, OnDestroy {
     }
 
     /**
-     * Sets collection id for the Collection href
-     * A collection may be private, institutional, or public.
-     * If both institional(2) and public(5), we set the link to the public collection id.
-     */
+    * setCollectionLink
+    * Sets collection id for the Collection href
+    * A collection may be private, institutional, or public.
+    * this is called in a loop over the collections array from the template,
+    * @param asset
+    * @param value - the current collection name in the iteration over the asset's collections
+    * @return router link array value
+    */
     setCollectionLink(asset: Asset, value: string): any[] {
-        let link = []
         asset.publicDownload = this.setPublicDownload()
+        // console.log(asset.collections)
+        let link = []
 
-        // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN, check the id in the collections array instead
+        // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN,
+        // check the id in the collections array instead
         if (String(asset.collectionId) === '103' || String(asset.collections[0].id) === '103') {
-            link = ['/category', String(asset.categoryId)]
-            return link
+            return ['/category', String(asset.categoryId)]
         }
         else {
-            for (let col of this.collections) {
-                // Collection links for Public & Personal Collections, type 5 or 6
-                if(col.name === value) {
-                  switch (col.type) {
-                        case '6':
-                            link = ['/pcollection', col.id]
-                            break
-                        case '5':
-                            link = ['/collection', col.id]
-                            break
-                        default: // Other types will override link if link has not been set
-                            if (link.length === 0) {
-                              link = ['/collection', col.id]
-                            }
-                            break
-                    }
-                    return link
-                }
-            }
+          for (let col of asset.collections) {
+
+            //if(col.name === value) {
+              // Collection links for Public & Personal Collections, type 5 or 6
+              if (col.type === '5' || col.type === '6') {
+                link = col.type === '5' ? ['/collection', col.id] : ['/pcollection', col.id]
+              }
+              // Collection links for institutional, type 2 - only if not also public, type 5
+              else if (col.type === '2' && !asset.publicDownload) {
+                link = ['/collection', col.id]
+              }
+              // Collection types where we don't need a special condition
+              else {
+                link = ['/collection', col.id]
+              }
+            //}
+            return link
+          }
+
         }
     }
 

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -22,7 +22,7 @@ import {
     DomUtilityService,
     ScriptService
 } from '_services'
-import { CollectionTypeHandler, CollectionTypeInfo, CollectionLink } from 'datatypes'
+import { CollectionTypeHandler, CollectionTypeInfo } from 'datatypes'
 import { LocalPCService, LocalPCAsset } from '../_local-pc-asset.service'
 import { APP_CONST } from '../app.constants'
 import { AppConfig } from '../app.service'

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -780,36 +780,33 @@ export class AssetPage implements OnInit, OnDestroy {
     * this is called in a loop over the collections array from the template,
     * @param asset
     * @param value - the current collection name in the iteration over the asset's collections
+    * @param col - the current collection object in the iteration over the asset's collections
     * @return router link array value
     */
     setCollectionLink(asset: Asset, value: string, col): any[] {
-        asset.publicDownload = this.setPublicDownload()
-        // console.log(asset.collections)
-        let link = []
+      asset.publicDownload = this.setPublicDownload()
 
-        // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN,
-        // check the id in the collections array instead
-        if (String(asset.collectionId) === '103' || String(asset.collections[0].id) === '103') {
-            link = ['/category', String(asset.categoryId)]
-        }
-        else {
-
-            if(col.name === value) {
-              // Collection links for Public & Personal Collections, type 5 or 6
-              if (col.type === '5' || col.type === '6') {
-                link = col.type === '5' ? ['/collection', col.id] : ['/pcollection', col.id]
-              }
-              // Collection links for institutional, type 2 - only if not also public, type 5
-              else if (col.type === '2' && !asset.publicDownload) {
-                link = ['/collection', col.id]
-              }
-              // Collection types where we don't need a special condition
-              else {
-                link = ['/collection', col.id]
-              }
-            }
+      // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN,
+      // check the id in the collections array instead
+      if (String(asset.collectionId) === '103' || String(asset.collections[0].id) === '103') {
+        return ['/category', String(asset.categoryId)]
+      }
+      else {
+        if(col.name === value) {
+          // Collection links for Public & Personal Collections, type 5 or 6
+          if (col.type === '5' || col.type === '6') {
+            return col.type === '5' ? ['/collection', col.id] : ['/pcollection', col.id]
           }
-          return link
+          // Collection links for institutional, type 2 - only if not also public, type 5
+          else if (col.type === '2' && !asset.publicDownload) {
+            return ['/collection', col.id]
+          }
+          // Collection types where we don't need a special condition
+          else {
+            return ['/collection', col.id]
+          }
+        }
+      }
     }
 
     /**

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -702,7 +702,7 @@ export class AssetPage implements OnInit, OnDestroy {
     trackSubjectLink(subjectName: string): void {
         this.angulartics.eventTrack.next({ properties: { event: 'metadata_subject_link', category: 'metadata', label: subjectName } });
     }
-    
+
     // Track metadata creator link click
     trackCreatorLink(creatorName: string): void {
         this.angulartics.eventTrack.next({ properties: { event: 'metadata_creator_link', category: 'metadata', label: creatorName } });
@@ -789,19 +789,20 @@ export class AssetPage implements OnInit, OnDestroy {
         }
         else {
             for (let col of this.collections) {
-                // Make collection links for only Public & Personal Collections
-                if(col.name === value && (col.type === '5' || col.type === '6')) {
-                    switch (col.type) {
+                // Collection links for Public & Personal Collections, type 5 or 6
+                if(col.name === value) {
+                  switch (col.type) {
                         case '6':
                             link = ['/pcollection', col.id]
                             break
                         case '5':
                             link = ['/collection', col.id]
                             break
-                        default:
-                            link = ['/collection', col.id]
+                        default: // Other types will override link if link has not been set
+                            if (link.length === 0) {
+                              link = ['/collection', col.id]
+                            }
                             break
-
                     }
                     return link
                 }

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -407,8 +407,6 @@ export class AssetPage implements OnInit, OnDestroy {
                         this.assetIndex = this.currentAssetIndex();
                         this.assetNumber = this._assets.currentLoadedParams.page ? this.assetIndex + 1 + ((this._assets.currentLoadedParams.page - 1) * this._assets.currentLoadedParams.size) : this.assetIndex + 1;
                     }
-
-
                 }
             })
         );
@@ -585,8 +583,6 @@ export class AssetPage implements OnInit, OnDestroy {
                 this.assets[0].formattedMetadata.License[i] = resLicenseVal ? resLicenseVal : licenseField
             }
         }
-
-
     }
 
     /**

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -782,7 +782,7 @@ export class AssetPage implements OnInit, OnDestroy {
     * @param value - the current collection name in the iteration over the asset's collections
     * @return router link array value
     */
-    setCollectionLink(asset: Asset, value: string): any[] {
+    setCollectionLink(asset: Asset, value: string, col): any[] {
         asset.publicDownload = this.setPublicDownload()
         // console.log(asset.collections)
         let link = []
@@ -790,12 +790,11 @@ export class AssetPage implements OnInit, OnDestroy {
         // 103 Collection Id routes to /category/<categoryId>, some of the collections have collectionId of NaN,
         // check the id in the collections array instead
         if (String(asset.collectionId) === '103' || String(asset.collections[0].id) === '103') {
-            return ['/category', String(asset.categoryId)]
+            link = ['/category', String(asset.categoryId)]
         }
         else {
-          for (let col of asset.collections) {
 
-            //if(col.name === value) {
+            if(col.name === value) {
               // Collection links for Public & Personal Collections, type 5 or 6
               if (col.type === '5' || col.type === '6') {
                 link = col.type === '5' ? ['/collection', col.id] : ['/pcollection', col.id]
@@ -808,11 +807,9 @@ export class AssetPage implements OnInit, OnDestroy {
               else {
                 link = ['/collection', col.id]
               }
-            //}
-            return link
+            }
           }
-
-        }
+          return link
     }
 
     /**

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -784,7 +784,8 @@ export class AssetPage implements OnInit, OnDestroy {
         }
         else {
             for (let col of this.collections) {
-                if(col.name === value) {
+                // Make collection links for only Public & Personal Collections
+                if(col.name === value && (col.type === '5' || col.type === '6')) {
                     switch (col.type) {
                         case '6':
                             link = ['/pcollection', col.id]

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -792,10 +792,9 @@ export class AssetPage implements OnInit, OnDestroy {
       }
 
       let links: CollectionLink[]
-      let justOne: boolean = collections.length === 1
 
       // Single collection type cases, and routes
-      if (justOne) {
+      if (collections.length === 1) {
         let col = collections[0]
 
         if (col.type === '1' && col.id === '103') {
@@ -808,7 +807,6 @@ export class AssetPage implements OnInit, OnDestroy {
           links = [({ displayName: col.name, route: ['/collection', col.id] })]
         }
       }
-
       // Collections contains type 5 Public, and 2
       else if (typeFilter('2') && typeFilter('5')) {
         links = collections.map(c => {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild, HostListener, ElementRef, PLATFORM_ID, Inject } from '@angular/core'
-import { ActivatedRoute, Params, Router, Route } from '@angular/router'
+import { ActivatedRoute, Params, Router } from '@angular/router'
 import { Meta } from '@angular/platform-browser'
 import { Subscription } from 'rxjs'
 import { map, take } from 'rxjs/operators'

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -22,7 +22,7 @@ import {
     DomUtilityService,
     ScriptService
 } from '_services'
-import { CollectionTypeHandler, CollectionTypeInfo } from 'datatypes'
+import { CollectionTypeHandler, CollectionTypeInfo, CollectionLink } from 'datatypes'
 import { LocalPCService, LocalPCAsset } from '../_local-pc-asset.service'
 import { APP_CONST } from '../app.constants'
 import { AppConfig } from '../app.service'

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -561,13 +561,12 @@ export class AssetPage implements OnInit, OnDestroy {
             }
             // Assign collections array for this asset. Provided in metadata
             this.collections = asset.collections
+            // Procure array of collection links to loop over in the template
+            this.collectionLinks = this.mapCollectionLinks(asset, this.collections)
             // set publicDownload bool
             asset.publicDownload = this.setPublicDownload()
 
             this.updateMetadataFromLocal(this._localPC.getAsset(parseInt(this.assets[0].SSID)))
-
-            // Procure array of router links to loop over in the template
-            this.collectionLinks = this.mapCollectionLinks(asset, this.collections)
         }
         // Set download link
         this.setDownloadFull()
@@ -782,51 +781,49 @@ export class AssetPage implements OnInit, OnDestroy {
 
     /**
     * mapCollectionLinks
-    * @param asset
-    * @param collections - the current collection object in the iteration over the asset's collections
+    * @param asset - only used here to get asset.categoryId
+    * @param collections - this.collections
     * @return CollectionLink[]
     */
     mapCollectionLinks(asset: Asset, collections: any[]): CollectionLink[] {
 
-      function typeFilter(type: string) {
-        return collections.filter(c => { return c.type === type })[0].length
+      function typeFilter(type: string): boolean {
+        return collections.filter(c => { return c.type === type })[0].length > 0
       }
 
-      let links = []
+      let links: CollectionLink[]
       let justOne: boolean = collections.length === 1
 
+      // Single collection type cases, and routes
       if (justOne) {
         let col = collections[0]
 
         if (col.type === '1' && col.id === '103') {
-          links.push({ displayName: col.name, route: ['/category', asset.categoryId] })
+          links = [({ displayName: col.name, route: ['/category', asset.categoryId] })]
         }
         else if(col.type === '6') {
-          links.push({ displayName: col.name, route: ['/pcollection', col.id] })
+          links = [({ displayName: col.name, route: ['/pcollection', col.id] })]
         }
         else {
-          links.push({ displayName: col.name, route: ['/collection', col.id] })
+          links = [({ displayName: col.name, route: ['/collection', col.id] })]
         }
       }
 
-      // If collections contains type 5 Public, and 2
+      // Collections contains type 5 Public, and 2
       else if (typeFilter('2') && typeFilter('5')) {
-
-        let cols = collections.map(c => {
+        links = collections.map(c => {
           if (c.type === '2' || c.type === '5') {
             return { displayName: c.name, route: ['/collection', c.id] }
           }
         })
-        links.push(cols)
       }
-      // other wise, just map all multiple collections to the links array, which is multiple tpye 2s
+      // Otherwise, map all multiple collections to the links array, which can be multiple type 2 institutional colllections
       else {
-        let cols = collections.map(c => {
-            return { displayName: c.name, route: ['/collection', c.id] }
+        links = collections.map(c => {
+          return { displayName: c.name, route: ['/collection', c.id] }
         })
-        links.push(cols)
       }
-      return links.map(link => { return link })
+      return links
     }
 
     /**

--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -1,6 +1,7 @@
 // Project Dependencies
 import { AssetData, MetadataField, FileProperty, CollectionValue } from './asset.service'
 import { ImageZoomParams } from './image-group.interface';
+import { CollectionLink } from 'datatypes'
 
 export class Asset {
     id: string
@@ -21,6 +22,7 @@ export class Asset {
     qualities: string[] // IIIF quality available: https://iiif.io/api/image/2.1/#quality
     formats: string[] = ['jpg'] // IIIF formats available: https://iiif.io/api/image/2.1/#format
     collectionType: number
+    collectionLinks: CollectionLink[]
     contributinginstitutionid: number
     personalCollectionOwner: number
     // Not reliably available
@@ -105,7 +107,7 @@ export class Asset {
                 let maxSize
                 if (data.download_size && data.download_size.length > 0) {
                     let sizeValues = data.download_size.split(',')
-                    maxWidth = parseInt(sizeValues[0]) 
+                    maxWidth = parseInt(sizeValues[0])
                     maxHeight = parseInt(sizeValues[1])
                 }
                 // Check if valid sizes, otherwise use defaults (larger than 3000 may stall)

--- a/src/app/shared/datatypes/collection-type-handler.ts
+++ b/src/app/shared/datatypes/collection-type-handler.ts
@@ -66,3 +66,12 @@ export interface CollectionTypeInfo {
   badgeText: string
   type: number
 }
+
+/**
+ * CollectionLink type
+ * Used in AssetPage component array of collectionLinks
+ */
+export interface CollectionLink {
+  displayName: string
+  route: any
+}

--- a/src/sass/modules/_metadata.scss
+++ b/src/sass/modules/_metadata.scss
@@ -28,5 +28,6 @@
     &.col-link, a{
         text-decoration: underline !important;
         color: #0039c6 !important;
+        display: block;
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,133 +1,133 @@
-// {
-//   "rulesDirectory": [
-//     "node_modules/codelyzer"
-//   ],
-//   "rules": {
-//     "member-access": false,
-//     "member-ordering": [
-//       true,
-//       "public-before-private",
-//       "static-before-instance",
-//       "variables-before-functions"
-//     ],
-//     "no-any": false,
-//     "no-inferrable-types": false,
-//     "no-internal-module": true,
-//     "no-var-requires": false,
-//     "typedef": false,
-//     "typedef-whitespace": [
-//       true,
-//       {
-//         "call-signature": "nospace",
-//         "index-signature": "nospace",
-//         "parameter": "nospace",
-//         "property-declaration": "nospace",
-//         "variable-declaration": "nospace"
-//       },
-//       {
-//         "call-signature": "space",
-//         "index-signature": "space",
-//         "parameter": "space",
-//         "property-declaration": "space",
-//         "variable-declaration": "space"
-//       }
-//     ],
+{
+  "rulesDirectory": [
+    "node_modules/codelyzer"
+  ],
+  "rules": {
+    "member-access": false,
+    "member-ordering": [
+      true,
+      "public-before-private",
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-any": false,
+    "no-inferrable-types": false,
+    "no-internal-module": true,
+    "no-var-requires": false,
+    "typedef": false,
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      },
+      {
+        "call-signature": "space",
+        "index-signature": "space",
+        "parameter": "space",
+        "property-declaration": "space",
+        "variable-declaration": "space"
+      }
+    ],
 
-//     "ban": false,
-//     "curly": false,
-//     "forin": true,
-//     "label-position": true,
-//     "label-undefined": true,
-//     "no-arg": true,
-//     "no-bitwise": true,
-//     "no-conditional-assignment": true,
-//     "no-console": [
-//       true,
-//       "debug",
-//       "info",
-//       "time",
-//       "timeEnd",
-//       "trace"
-//     ],
-//     "no-construct": true,
-//     "no-debugger": true,
-//     "no-duplicate-key": true,
-//     "no-duplicate-variable": true,
-//     "no-empty": false,
-//     "no-eval": true,
-//     "no-null-keyword": false,
-//     "no-shadowed-variable": true,
-//     "no-string-literal": false,
-//     "no-switch-case-fall-through": true,
-//     "no-unreachable": true,
-//     "no-unused-expression": true,
-//     "no-unused-variable": false,
-//     "no-use-before-declare": true,
-//     "no-var-keyword": true,
-//     "radix": true,
-//     "switch-default": true,
-//     "triple-equals": [
-//       true,
-//       "allow-null-check"
-//     ],
-//     "use-strict": [
-//       true,
-//       "check-module"
-//     ],
+    "ban": false,
+    "curly": false,
+    "forin": true,
+    "label-position": true,
+    "label-undefined": true,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": false,
+    "no-eval": true,
+    "no-null-keyword": false,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-switch-case-fall-through": true,
+    "no-unreachable": true,
+    "no-unused-expression": true,
+    "no-unused-variable": false,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "radix": true,
+    "switch-default": true,
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "use-strict": [
+      true,
+      "check-module"
+    ],
 
-//     "eofline": true,
-//     "indent": [
-//       true,
-//       "spaces"
-//     ],
-//     "max-line-length": [
-//       true,
-//       100
-//     ],
-//     "no-require-imports": false,
-//     "no-trailing-whitespace": true,
-//     "object-literal-sort-keys": false,
-//     "trailing-comma": [
-//       true,
-//       {
-//         "multiline": false,
-//         "singleline": "never"
-//       }
-//     ],
+    "eofline": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "max-line-length": [
+      true,
+      100
+    ],
+    "no-require-imports": false,
+    "no-trailing-whitespace": true,
+    "object-literal-sort-keys": false,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": false,
+        "singleline": "never"
+      }
+    ],
 
-//     "align": false,
-//     "class-name": true,
-//     "comment-format": [
-//       true,
-//       "check-space"
-//     ],
-//     "interface-name": false,
-//     "jsdoc-format": true,
-//     "no-consecutive-blank-lines": false,
-//     "no-constructor-vars": false,
-//     "one-line": [
-//       false,
-//       "check-open-brace",
-//       "check-catch",
-//       "check-else",
-//       "check-finally",
-//       "check-whitespace"
-//     ],
-//     "semicolon": [false, "never"],
-//     "variable-name": [
-//       true,
-//       "check-format",
-//       "allow-leading-underscore",
-//       "ban-keywords"
-//     ],
-//     "whitespace": [
-//       true,
-//       "check-branch",
-//       "check-decl",
-//       "check-operator",
-//       "check-separator",
-//       "check-type"
-//     ],
-//     "import-destructuring-spacing": true
-//   }
-// }
+    "align": false,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "interface-name": false,
+    "jsdoc-format": true,
+    "no-consecutive-blank-lines": false,
+    "no-constructor-vars": false,
+    "one-line": [
+      false,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-finally",
+      "check-whitespace"
+    ],
+    "semicolon": [false, "never"],
+    "variable-name": [
+      true,
+      "check-format",
+      "allow-leading-underscore",
+      "ban-keywords"
+    ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "import-destructuring-spacing": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,133 +1,133 @@
-{
-  "rulesDirectory": [
-    "node_modules/codelyzer"
-  ],
-  "rules": {
-    "member-access": false,
-    "member-ordering": [
-      true,
-      "public-before-private",
-      "static-before-instance",
-      "variables-before-functions"
-    ],
-    "no-any": false,
-    "no-inferrable-types": false,
-    "no-internal-module": true,
-    "no-var-requires": false,
-    "typedef": false,
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      },
-      {
-        "call-signature": "space",
-        "index-signature": "space",
-        "parameter": "space",
-        "property-declaration": "space",
-        "variable-declaration": "space"
-      }
-    ],
+// {
+//   "rulesDirectory": [
+//     "node_modules/codelyzer"
+//   ],
+//   "rules": {
+//     "member-access": false,
+//     "member-ordering": [
+//       true,
+//       "public-before-private",
+//       "static-before-instance",
+//       "variables-before-functions"
+//     ],
+//     "no-any": false,
+//     "no-inferrable-types": false,
+//     "no-internal-module": true,
+//     "no-var-requires": false,
+//     "typedef": false,
+//     "typedef-whitespace": [
+//       true,
+//       {
+//         "call-signature": "nospace",
+//         "index-signature": "nospace",
+//         "parameter": "nospace",
+//         "property-declaration": "nospace",
+//         "variable-declaration": "nospace"
+//       },
+//       {
+//         "call-signature": "space",
+//         "index-signature": "space",
+//         "parameter": "space",
+//         "property-declaration": "space",
+//         "variable-declaration": "space"
+//       }
+//     ],
 
-    "ban": false,
-    "curly": false,
-    "forin": true,
-    "label-position": true,
-    "label-undefined": true,
-    "no-arg": true,
-    "no-bitwise": true,
-    "no-conditional-assignment": true,
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-key": true,
-    "no-duplicate-variable": true,
-    "no-empty": false,
-    "no-eval": true,
-    "no-null-keyword": false,
-    "no-shadowed-variable": true,
-    "no-string-literal": false,
-    "no-switch-case-fall-through": true,
-    "no-unreachable": true,
-    "no-unused-expression": true,
-    "no-unused-variable": false,
-    "no-use-before-declare": true,
-    "no-var-keyword": true,
-    "radix": true,
-    "switch-default": true,
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "use-strict": [
-      true,
-      "check-module"
-    ],
+//     "ban": false,
+//     "curly": false,
+//     "forin": true,
+//     "label-position": true,
+//     "label-undefined": true,
+//     "no-arg": true,
+//     "no-bitwise": true,
+//     "no-conditional-assignment": true,
+//     "no-console": [
+//       true,
+//       "debug",
+//       "info",
+//       "time",
+//       "timeEnd",
+//       "trace"
+//     ],
+//     "no-construct": true,
+//     "no-debugger": true,
+//     "no-duplicate-key": true,
+//     "no-duplicate-variable": true,
+//     "no-empty": false,
+//     "no-eval": true,
+//     "no-null-keyword": false,
+//     "no-shadowed-variable": true,
+//     "no-string-literal": false,
+//     "no-switch-case-fall-through": true,
+//     "no-unreachable": true,
+//     "no-unused-expression": true,
+//     "no-unused-variable": false,
+//     "no-use-before-declare": true,
+//     "no-var-keyword": true,
+//     "radix": true,
+//     "switch-default": true,
+//     "triple-equals": [
+//       true,
+//       "allow-null-check"
+//     ],
+//     "use-strict": [
+//       true,
+//       "check-module"
+//     ],
 
-    "eofline": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "max-line-length": [
-      true,
-      100
-    ],
-    "no-require-imports": false,
-    "no-trailing-whitespace": true,
-    "object-literal-sort-keys": false,
-    "trailing-comma": [
-      true,
-      {
-        "multiline": false,
-        "singleline": "never"
-      }
-    ],
+//     "eofline": true,
+//     "indent": [
+//       true,
+//       "spaces"
+//     ],
+//     "max-line-length": [
+//       true,
+//       100
+//     ],
+//     "no-require-imports": false,
+//     "no-trailing-whitespace": true,
+//     "object-literal-sort-keys": false,
+//     "trailing-comma": [
+//       true,
+//       {
+//         "multiline": false,
+//         "singleline": "never"
+//       }
+//     ],
 
-    "align": false,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
-    "interface-name": false,
-    "jsdoc-format": true,
-    "no-consecutive-blank-lines": false,
-    "no-constructor-vars": false,
-    "one-line": [
-      false,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-finally",
-      "check-whitespace"
-    ],
-    "semicolon": [false, "never"],
-    "variable-name": [
-      true,
-      "check-format",
-      "allow-leading-underscore",
-      "ban-keywords"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "import-destructuring-spacing": true
-  }
-}
+//     "align": false,
+//     "class-name": true,
+//     "comment-format": [
+//       true,
+//       "check-space"
+//     ],
+//     "interface-name": false,
+//     "jsdoc-format": true,
+//     "no-consecutive-blank-lines": false,
+//     "no-constructor-vars": false,
+//     "one-line": [
+//       false,
+//       "check-open-brace",
+//       "check-catch",
+//       "check-else",
+//       "check-finally",
+//       "check-whitespace"
+//     ],
+//     "semicolon": [false, "never"],
+//     "variable-name": [
+//       true,
+//       "check-format",
+//       "allow-leading-underscore",
+//       "ban-keywords"
+//     ],
+//     "whitespace": [
+//       true,
+//       "check-branch",
+//       "check-decl",
+//       "check-operator",
+//       "check-separator",
+//       "check-type"
+//     ],
+//     "import-destructuring-spacing": true
+//   }
+// }


### PR DESCRIPTION
This PR includes logic for display of collection links, based on multiple types. on the asset page.
- Adds `collectionsLinks` member to `Asset` type, which is an array of `CollectionLink` types.
- Simplifies metadata loop for collection links by looping over `asset.collectionLinks`
- `mapCollectionLinks` called in asset page component, defines asset.collectionLinks