### PR TITLE
AIR-2375

### DIFF
--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -74,6 +74,11 @@ export class Asset {
             if (data.link) {
                 data.fieldValue = data.link
             }
+
+            // If license value is `ADL Terms and Conditions` then replace it with bolierplate text
+            if (data.fieldName === 'License' && data.fieldValue === 'ADL Terms and Conditions') {
+                data.fieldValue = 'Use of this image is in accordance with the <a href="https://www.artstor.org/artstor-terms/" target="_blank">Artstor Terms & Conditions</a>'
+            }
             // Split by semicolons without removing semicolon
             let values = data.fieldValue.split(/;./g)
             // if the field exists, add to it (make sure the field value exists)
@@ -82,6 +87,11 @@ export class Asset {
             } else if(values[0]) { // otherwise make a new field (make sure the field vaue exists)
                 formattedData[data.fieldName] = values
             }
+        }
+
+        // If the asset doesn't have a license field then display bilerplate for license field.
+        if(!formattedData['License']) {
+            formattedData['License'] = ['Use of this image is in accordance with the <a href="https://www.artstor.org/artstor-terms/" target="_blank">Artstor Terms & Conditions</a>']
         }
         return formattedData
     }


### PR DESCRIPTION
The boilerplate text "Use of this image is in accordance with the Artstor Terms & Conditions" should always be displayed in the following two cases:
1. No license is defined at all, and there is not a License field returned in the metadata response at all.
2. Or the license is ADL Terms and Conditions