### PR TITLE
AIR-2478: Update privacy policy links

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -445,7 +445,7 @@
       "TEACHING_IDEAS": "<a href=\"https://www.artstor.org/teach/\" class=\"link\" target=\"_blank\">Teach with Artstor</a>",
       "STAY_INFORMED": "<a href=\"https://www.artstor.org/newsletter/\" class=\"link\" target=\"_blank\">Newsletters</a>",
       "TERMS": "<a href=\"https://www.artstor.org/artstor-terms\" class=\"link\" target=\"_blank\">Terms and Conditions</a>",
-      "PRIVACY": "<a href=\"http://www.artstor.org/privacy-policy\" class=\"link\" target=\"_blank\">Privacy Policy</a>",
+      "PRIVACY": "<a href=\"https://www.ithaka.org/privacypolicy\" class=\"link\" target=\"_blank\">Privacy Policy</a>",
       "COOKIE_POLICY": "<a href=\"http://www.ithaka.org/cookies\" class=\"link\" target=\"_blank\">Cookie Policy</a>",
       "COPYRIGHT": "<a href=\"http://www.artstor.org/copyright\" class=\"link\" target=\"_blank\">Copyright Concerns</a>",
       "SUPPORT": "<a href=\"http://support.artstor.org\" class=\"link\" target=\"_blank\">Support</a>",
@@ -455,7 +455,7 @@
       "SAHARA_CONTRIBUTE_STAGE": "<a href=\"http://test.forum.jstor.org/\" class=\"link\" target=\"_blank\">Contribute to SAHARA using JSTOR Forum</a>",
       "SAHARA_CONTRIBUTE_PROD": "<a href=\"http://new.forum.jstor.org/\" class=\"link\" target=\"_blank\">Contribute to SAHARA using JSTOR Forum</a>",
       "SAHARA_TERMS": "<a href=\"http://artstor.org/sahara-terms\" class=\"link\" target=\"_blank\">Terms</a>",
-      "SAHARA_PRIVACY": "<a href=\"http://artstor.org/privacy-policy\" class=\"link\" target=\"_blank\">Privacy</a>"
+      "SAHARA_PRIVACY": "<a href=\"https://www.ithaka.org/privacypolicy\" class=\"link\" target=\"_blank\">Privacy</a>"
     },
     "DISCLAIMER" : "Artstor is a part of <a href=\"https://www.ithaka.org/\" class=\"link\" target=\"_blank\">ITHAKA</a>, a not-for-profit organization helping the academic community use digital technologies to preserve the scholarly record and to advance research and teaching in sustainable ways.",
     "RIGHTS" : "All Rights Reserved. JSTOR®, ITHAKA®, and Artstor® are registered trademarks of ITHAKA."


### PR DESCRIPTION
Updates the privacy policy link in the footer to point to `https://www.ithaka.org/privacypolicy`