### PR TITLE
AIR-2436: Fix tabbing on the image group help window

### DIFF
--- a/src/app/shared/tour/tour.component.pug
+++ b/src/app/shared/tour/tour.component.pug
@@ -1,4 +1,12 @@
-a.contextual-help(title="How do I use image groups?", (click)="openTourModal()", (keyup.enter)="openTourModal()", target="_blank", tabindex="3", aria-label="Learn more about how to use image groups with our tour.") ?
+a.contextual-help(
+  #openTourLink
+  title="How do I use image groups?",
+  (click)="openTourModal()",
+  (keyup.enter)="openTourModal()",
+  target="_blank",
+  tabindex="3",
+  aria-label="Learn more about how to use image groups with our tour."
+) ?
 .modal(tabindex="-1", [class.show]="startModalShow", (keydown.esc)="closeTourModal()")
   .modal-dialog(role="document")
     .modal-content

--- a/src/app/shared/tour/tour.component.pug
+++ b/src/app/shared/tour/tour.component.pug
@@ -1,13 +1,30 @@
-a.contextual-help(title="How do I use image groups?", (click)="startModalShow=true", (keyup.enter)="startModalShow=true", target="_blank", tabindex="3", aria-label="Learn more about how to use image groups with our tour.") ?
-.modal(tabindex="-1", [class.show]="startModalShow")
-    .modal-dialog(role="document")
-        .modal-content
-            .modal-header
-                h4.modal-title We've made some updates to groups!
-                button.close(type="button", (click)="closeTourModal()", aria-label="Close")
-                    span(aria-hidden="true") &times;
-            .modal-body
-                p We've made a few adjustments to give you a better experience with your groups. Take the tour to learn more about the changes. 
-            .modal-footer
-                button.btn.btn-secondary(tabindex="4", (click)="closeTourModal()") NOT NOW
-                button.btn.btn-primary(tabindex="3", (click)="$event.stopPropagation();startTour()") TAKE THE TOUR
+a.contextual-help(title="How do I use image groups?", (click)="openTourModal()", (keyup.enter)="openTourModal()", target="_blank", tabindex="3", aria-label="Learn more about how to use image groups with our tour.") ?
+.modal(tabindex="-1", [class.show]="startModalShow", (keydown.esc)="closeTourModal()")
+  .modal-dialog(role="document")
+    .modal-content
+      .modal-header
+        h4.modal-title We've made some updates to groups!
+        button.close(
+          #closeTourButton
+          type="button",
+          (click)="closeTourModal()",
+          (keydown.tab)="focusElement(startTourButton, $event)",
+          (keydown.shift.tab)="focusElement(notNowButton, $event)"
+          aria-label="Close"
+        )
+          span(aria-hidden="true") &times;
+      .modal-body
+        p We've made a few adjustments to give you a better experience with your groups. Take the tour to learn more about the changes.
+      .modal-footer
+        button.btn.btn-secondary(
+          #notNowButton
+          (click)="closeTourModal()",
+          (keydown.tab) = "focusElement(closeTourButton, $event)",
+          (keydown.shift.tab)="focusElement(startTourButton, $event)"
+        ) NOT NOW
+        button.btn.btn-primary(
+          #startTourButton,
+          (click)="$event.stopPropagation();startTour()",
+          (keydown.tab)="focusElement(notNowButton, $event)",
+          (keydown.shift.tab)="focusElement(closeTourButton, $event)"
+        ) TAKE THE TOUR

--- a/src/app/shared/tour/tour.component.ts
+++ b/src/app/shared/tour/tour.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, PLATFORM_ID, Inject  } from '@angular/core'
+import { Component, Input, OnInit, PLATFORM_ID, Inject, ViewChild, ElementRef } from '@angular/core'
 // TO-DO: Import driver only on the clientside
 // Maybe use their CDN? https://github.com/kamranahmedse/driver.js
 import * as Driver from '../../../../node_modules/driver.js/dist/driver.min.js'
@@ -20,6 +20,8 @@ import {  } from '../../shared'
     public startModalShow: boolean = false
 
     @Input() public steps: TourStep[]
+
+    @ViewChild("startTourButton", { read: ElementRef }) startTourButton: ElementRef
 
     private driver: any
     private isBrowser
@@ -128,6 +130,29 @@ import {  } from '../../shared'
      */
     public closeTourModal(): void {
       this.startModalShow = false
+    }
+
+    /**
+     * Opens the tour models and places focus on the start button.
+     */
+    public openTourModal(): void {
+        this.startModalShow = true;
+        setTimeout(() => {
+          this.focusElement(this.startTourButton.nativeElement)
+        }, 0)
+      }
+
+    /**
+     * Force focus upon a key event
+     * @param event keydown/click event
+     * @param element element to focus
+     */
+    public focusElement(element, event?: Event) {
+      if (event) {
+        event.stopPropagation()
+        event.preventDefault()
+      }
+      element.focus()
     }
 
     /**

--- a/src/app/shared/tour/tour.component.ts
+++ b/src/app/shared/tour/tour.component.ts
@@ -22,8 +22,10 @@ import {  } from '../../shared'
     @Input() public steps: TourStep[]
 
     @ViewChild("startTourButton", { read: ElementRef }) startTourButton: ElementRef
+    @ViewChild("openTourLink", { read: ElementRef }) openTourLink: ElementRef
 
-    private driver: any
+
+  private driver: any
     private isBrowser
 
     constructor(
@@ -130,6 +132,7 @@ import {  } from '../../shared'
      */
     public closeTourModal(): void {
       this.startModalShow = false
+      this.openTourLink.nativeElement.focus()
     }
 
     /**


### PR DESCRIPTION
The `We've made some updates to groups!` modal has been enhanced to ensure tabbing to its different elements remains scoped to only the modal (not leaking out to the rest of the page). The approach taken in this PR is similar to that of the the `pwd-reset-component`.

Other Changes:
- Pressing escape at anytime will close the modal and give the original link element focus again.