### PR TITLE
AIR-2470: Prevent chat widget from displaying on wrong pages

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -198,9 +198,9 @@ export class AppComponent {
             this._script.loadScript('zendesk')
               .then( data => {
                 if (data['status'] !== "server_rendered") {
-                  zE(() => {
-                    $zopim(() => {
-                      $zopim.livechat.setOnConnected(() => {
+                  window['zE'](() => {
+                    window['$zopim'](() => {
+                      window['$zopim'].livechat.setOnConnected(() => {
                         // Sometimes the user navigates away from a page containing the chat widget
                         // but it hasn't loaded yet. Need to check once more after it loads to ensure
                         // we still should display it.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -197,7 +197,6 @@ export class AppComponent {
           if (this.shouldShowChat(window.location.href) && this._app.config.showZendeskWidget) {
             this._script.loadScript('zendesk')
               .then( data => {
-                if (data['status'] !== "server_rendered") {
                   window['zE'](() => {
                     window['$zopim'](() => {
                       window['$zopim'].livechat.setOnConnected(() => {
@@ -212,7 +211,6 @@ export class AppComponent {
                       })
                     })
                   });
-                }
               })
               .catch( error => console.error(error) )
           } else {
@@ -246,8 +244,8 @@ export class AppComponent {
     let zendeskElements = this._dom.bySelectorAll('.zopim')
 
     if (zendeskElements && zendeskElements.length > 1) {
-      zendeskElements[0]['style']['display'] = 'none'
-      zendeskElements[1]['style']['display'] = 'none'
+      zendeskElements[0]['style']['display'] = 'none' // ChatWidgetButton
+      zendeskElements[1]['style']['display'] = 'none' // ChatWidgetWindow
     }
   }
 
@@ -255,7 +253,7 @@ export class AppComponent {
     let zendeskElements = this._dom.bySelectorAll('.zopim')
 
     if (zendeskElements && zendeskElements.length > 1) {
-      zendeskElements[0]['style']['display'] = 'block'
+      zendeskElements[0]['style']['display'] = 'block' // ChatWidgetButton
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -153,7 +153,6 @@ export class AppComponent {
       else if (event instanceof NavigationEnd) {
         if (isPlatformBrowser(this.platformId)) {
           let event_url_array = event.url.split('/')
-          let zendeskElements = this._dom.bySelectorAll('.zopim')
           let path = event.urlAfterRedirects
           // Properties of "pageGTM" need to match vars set in Google Tag Manager
           let pageGTMVars = {
@@ -195,21 +194,27 @@ export class AppComponent {
           }
 
           // On navigation end, load the zendesk chat widget if user lands on login page else hide the widget
-          if (this.showChatWidget(window.location.href) && this._app.config.showZendeskWidget) {
+          if (this.shouldShowChat(window.location.href) && this._app.config.showZendeskWidget) {
             this._script.loadScript('zendesk')
-              .then( data => {
-                if (data['status'] === 'loaded'){
-                } else if (data['status'] === 'already_loaded'){ // if the widget script has already been loaded then just show the widget
-                  zendeskElements[0]['style']['display'] = 'block'
-                }
-              })
+              .then( () => {
+                zE(() => {
+                  $zopim(() => {
+                    $zopim.livechat.setOnConnected(() => {
+                      // Sometimes the user navigates away from a page containing the chat widget
+                      // but it hasn't loaded yet. Need to check once more after it loads to ensure
+                      // we still should display it.
+                      if (this.shouldShowChat(window.location.href)) {
+                        this.showZendeskChat()
+                      } else {
+                        this.hideZendeskChat()
+                      }
+                    })
+                  })
+                });
+                })
               .catch( error => console.error(error) )
           } else {
-            // If Zendesk chat is loaded, hide it
-            if (zendeskElements && zendeskElements.length > 1) {
-              zendeskElements[0]['style']['display'] = 'none'
-              zendeskElements[1]['style']['display'] = 'none'
-            }
+            this.hideZendeskChat()
           }
         }
       }
@@ -232,6 +237,23 @@ export class AppComponent {
             this.statusPageClient = StatusPage( this._auth.getEnv() === 'test' ? STATUS_PAGE_CMP_ID_STAGE : STATUS_PAGE_CMP_ID_PROD, { environment: this._auth.getEnv() } )
             this.subscribeToStatus()
           })
+    }
+  }
+
+  private hideZendeskChat() {
+    let zendeskElements = this._dom.bySelectorAll('.zopim')
+
+    if (zendeskElements && zendeskElements.length > 1) {
+      zendeskElements[0]['style']['display'] = 'none'
+      zendeskElements[1]['style']['display'] = 'none'
+    }
+  }
+
+  private showZendeskChat() {
+    let zendeskElements = this._dom.bySelectorAll('.zopim')
+
+    if (zendeskElements && zendeskElements.length > 1) {
+      zendeskElements[0]['style']['display'] = 'block'
     }
   }
 
@@ -308,10 +330,10 @@ export class AppComponent {
   }
 
   // Show the chat widget on: 'login', 'browse/library', or 'browse/groups/public'
-  private showChatWidget(eventUrl: string): boolean {
+  private shouldShowChat(eventUrl: string): boolean {
       if (eventUrl.indexOf('browse/library') > -1 ||
           eventUrl.indexOf('browse/groups/public') > -1 ||
-          eventUrl.indexOf('login') > -1) {
+          eventUrl.indexOf('/login') > -1) {
            return true
         }
       else {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -196,22 +196,24 @@ export class AppComponent {
           // On navigation end, load the zendesk chat widget if user lands on login page else hide the widget
           if (this.shouldShowChat(window.location.href) && this._app.config.showZendeskWidget) {
             this._script.loadScript('zendesk')
-              .then( () => {
-                zE(() => {
-                  $zopim(() => {
-                    $zopim.livechat.setOnConnected(() => {
-                      // Sometimes the user navigates away from a page containing the chat widget
-                      // but it hasn't loaded yet. Need to check once more after it loads to ensure
-                      // we still should display it.
-                      if (this.shouldShowChat(window.location.href)) {
-                        this.showZendeskChat()
-                      } else {
-                        this.hideZendeskChat()
-                      }
+              .then( data => {
+                if (data['status'] !== "server_rendered") {
+                  zE(() => {
+                    $zopim(() => {
+                      $zopim.livechat.setOnConnected(() => {
+                        // Sometimes the user navigates away from a page containing the chat widget
+                        // but it hasn't loaded yet. Need to check once more after it loads to ensure
+                        // we still should display it.
+                        if (this.shouldShowChat(window.location.href)) {
+                          this.showZendeskChat()
+                        } else {
+                          this.hideZendeskChat()
+                        }
+                      })
                     })
-                  })
-                });
-                })
+                  });
+                }
+              })
               .catch( error => console.error(error) )
           } else {
             this.hideZendeskChat()

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -341,8 +341,3 @@ body body{
     left: calc(50% - 0.4rem);
   }
 }
-
-// Hide Zendesk Chat until it is ready to be displayed
-.zopim {
-  display: none;
-}

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -341,3 +341,8 @@ body body{
     left: calc(50% - 0.4rem);
   }
 }
+
+// Hide Zendesk Chat until it is ready to be displayed
+.zopim {
+  display: none;
+}


### PR DESCRIPTION
The zendesk chat widget sometimes takes a second to load. This race condition can sometimes cause the widget to end up on a page it is not supposed to. Consider the steps to reproduce:

1. User visits login page (the widget should be displayed here)
2. We start fetching the zendesk chat widget script
3. The user quickly navigates away from the login page (assume it a page the widget should NOT appear)
4. The zendesk chat widget is finally ready to be displayed, so it happily displays even though it is for the wrong page.

**Solution:**
Leverage the zendesk chat api to determine when the widget is actually done loading. That way we can further determine if the current url is one it should be displaying on. Reference: https://api.zopim.com/files/meshim/widget/controllers/LiveChatAPI-js.html

Open to any other suggestions anyone may have!