### PR TITLE
AIR-2381: Fix Creative Common License icons/links

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -850,8 +850,9 @@ export class AssetPage implements OnInit, OnDestroy {
     }
 
   /**
-   * Returns the Creative Commons license text if the provided license text is for Creative Commons.
-   * Otherwise returns false.
+   * Returns the license text if the provided string matches one that is for Creative Commons.
+   * Otherwise returns false. The comparison made on provided string is case-insensitive and
+   * ignores non-alphanumeric characters.
    * @param {string} licenseText
    */
     public isCreativeCommonsLicense(licenseText: string): any {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -849,21 +849,26 @@ export class AssetPage implements OnInit, OnDestroy {
       return false
     }
 
-    public isCreativeCommonsLicense(license_text: string): any {
-        // Handle extra spaces and differences in punctuation in License fields
-        // by doing uppercase comparison of alphanumeric chars only
-        let reg = /[^a-zA-Z0-9]/
+  /**
+   * Returns the Creative Commons license text if the provided string is for Creative Commons.
+   * Otherwise returns false.
+   * @param {string} licenseText
+   */
+    public isCreativeCommonsLicense(licenseText: string): any {
+        const licenseToUse = licenses.find((currentLicense) => {
+          const candidateLicenseName = currentLicense.name.replace(/\W/g, '').toUpperCase(),
+                actualLicenseName = licenseText.replace(/\W/g, '').toUpperCase()
 
-        for (let i = 0; i < licenses.length; i++) {
-            if ((licenses[i].name.split(reg).join('').toUpperCase() === license_text.split(reg).join('').toUpperCase()) || (licenses[i].html === license_text)) {
-                this.licenseText = licenses[i].name
-                this.licenseLink = licenses[i].link
-                this.licenseImg = licenses[i].img
+          return candidateLicenseName === actualLicenseName || currentLicense.html === licenseText
+        })
 
-                return this.licenseText
-            }
+        if (licenseToUse) {
+          this.licenseText = licenseToUse.name
+          this.licenseLink = licenseToUse.link
+          this.licenseImg = licenseToUse.img
         }
-        return
+
+        return this.licenseText ? this.licenseText : false
     }
 
     private handleSkipAsset(): void {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -850,7 +850,7 @@ export class AssetPage implements OnInit, OnDestroy {
     }
 
   /**
-   * Returns the Creative Commons license text if the provided string is for Creative Commons.
+   * Returns the Creative Commons license text if the provided license text is for Creative Commons.
    * Otherwise returns false.
    * @param {string} licenseText
    */

--- a/src/app/asset-page/licenses.ts
+++ b/src/app/asset-page/licenses.ts
@@ -27,7 +27,7 @@ export const licenses = [
       link: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
       img: 'https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png'
     },
-    { name: 'Public Domain',
+    { name: 'Creative Commons: Public Domain Mark',
       link: 'https://creativecommons.org/share-your-work/public-domain/',
       img: 'https://licensebuttons.net/p/88x31.png',
       html: '<a href="https://creativecommons.org/publicdomain/zero/1.0/" title="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication">Public Domain</a></div>'

--- a/src/app/asset-page/licenses.ts
+++ b/src/app/asset-page/licenses.ts
@@ -3,27 +3,27 @@
  */
 
 export const licenses = [
-    { name: 'Attribution',
+    { name: 'Creative Commons: Attribution',
       link: 'https://creativecommons.org/licenses/by/4.0/',
       img: 'https://licensebuttons.net/l/by/4.0/88x31.png'
     },
-    { name: 'Attribution-ShareAlike',
+    { name: 'Creative Commons: Attribution-ShareAlike',
       link: 'https://creativecommons.org/licenses/by-sa/4.0/',
       img: 'https://licensebuttons.net/l/by-sa/4.0/88x31.png'
     },
-    { name: 'Attribution-NoDerivs',
+    { name: 'Creative Commons: Attribution-NoDerivs',
       link: 'https://creativecommons.org/licenses/by-nd/4.0/',
       img: 'https://licensebuttons.net/l/by-nd/4.0/88x31.png'
     },
-    { name: 'Attribution-NonCommercial',
+    { name: 'Creative Commons: Attribution-NonCommercial',
       link: 'https://creativecommons.org/licenses/by-nc/4.0/',
       img: 'https://licensebuttons.net/l/by-nc/4.0/88x31.png'
     },
-    { name: 'Attribution-NonCommercial-ShareAlike',
+    { name: 'Creative Commons: Attribution-NonCommercial-ShareAlike',
       link: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
       img: 'https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png'
     },
-    { name: 'Attribution-NonCommercial-NoDerivs',
+    { name: 'Creative Commons: Attribution-NonCommercial-NoDerivs',
       link: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
       img: 'https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png'
     },
@@ -33,6 +33,3 @@ export const licenses = [
       html: '<a href="https://creativecommons.org/publicdomain/zero/1.0/" title="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication">Public Domain</a></div>'
     }
 ]
-  
-  
-  


### PR DESCRIPTION
Since implementing the CC icons/links under AIR-2270, the controlled list of license names for Creative Commons have slightly changed in Forum. This has caused an issue on the front end since we are no longer matching on our expected string.

Here are some examples:
https://stage.artstor.org/#/asset/1002989035
https://stage.artstor.org/#/asset/1003307364

Here is an example of what we should expect the `License` metadata field to look like when it is for CC:
![image](https://user-images.githubusercontent.com/3267412/63118156-4fa30380-bf6b-11e9-9662-42fb64289563.png)

