### PR TITLE
Update dependency to use our forked repo of openseadragon

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "ngx-device-detector": "^1.3.3",
     "ngx-infinite-scroll": "^7.0.1",
     "ngx-tag-autocomplete": "2.0.4",
-    "openseadragon": "^2.4.0",
+    "openseadragon": "git://github.com/ithaka/openseadragon.git#master",
     "popper.js": "^1.14.4",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,9 +6890,9 @@ opener@~1.4.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
-openseadragon@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.0.tgz#d0b28b37a953602c82432a0dbd8a3779dadf756f"
+"openseadragon@git://github.com/ithaka/openseadragon.git#master":
+  version "2.4.1"
+  resolved "git://github.com/ithaka/openseadragon.git#a39d20bd70cee75845fb4716f4bd3e19d417590c"
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
We discovered an issue with OpenSeadragon that prevented reference strip thumbnails from loading due to missing headers. The fix was only a couple lines in the OpenSeadragon source. However, since the original OpenSeadragon project is seldom released, we decided to fork the repo so we can be more in control.

Check out the fix here in our forked repo: https://github.com/ithaka/openseadragon/pull/1

This PR simply points our dependency at this forked repo. This includes the ajax header fix above, however it also includes all changes made to the original OpenSeadragon project since `v2.4.0` (our current version). Testing manually, things still seem to be working, but let me know if you have any concerns.  See: https://github.com/openseadragon/openseadragon/releases
