### PR TITLE
PLATO-147: Display subject fields with newlines as default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/shared/filter-link.pipe.ts
+++ b/src/app/shared/filter-link.pipe.ts
@@ -5,10 +5,12 @@ export class FilterLinkPipe implements PipeTransform {
     transform(value: any, filterKey: string): any {
         let values: string[] = []
         let restoreChar: string = ''
+        let breakChar: string = '<br/>'
         // Semicolons - handle splitting
         values = value.split(/;\s/g)
         if (values.length > 1) {
             restoreChar = ';'
+            breakChar = '<span>&ensp;</span>'
         } else {
             // Pipes - handle splitting
             values = value.split(/\|/g)
@@ -17,7 +19,7 @@ export class FilterLinkPipe implements PipeTransform {
         let linkHtml = ''
         values.forEach((value, index) => {
             if (index == (values.length - 1)) restoreChar = ''
-            linkHtml += `<a href="/#/search/${filterKey}:(${value})">${value}</a>${restoreChar}<span>&ensp;</span>`
+            linkHtml += `<a href="/#/search/${filterKey}:(${value})">${value}</a>${restoreChar}${breakChar}`
         })
         return linkHtml
     }


### PR DESCRIPTION
 - Upon receiving an array of subject content, use newlines as the default way to separate them because forum users expect pipe separated content should be displayed in newlines