### PR TITLE
PLATO-126: Verify License field on PROD: Support "None" and "ADL" options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -221,11 +221,11 @@
           .meta-block(*ngIf="assets[0].formattedMetadata.License && assets[0].formattedMetadata.License.length > 0")
             .label#License License
             .license(*ngFor="let license of assets[0].formattedMetadata.License")
-              a(*ngIf="licenseText === license", [attr.href]="licenseLink", aria-label="Learn about this license statement on creativecommons.org", target="_blank")
+              a([attr.href]="licenseLink", aria-label="Learn about this license statement on creativecommons.org", target="_blank")
                 img.license-icon([attr.src]="licenseImg", [attr.alt]="license", title="License")
                 | &nbsp;
                 span.value.license-text([innerHTML]="cleanFieldValue(license) | lowercase | linkify", title="License")
-              .value(*ngIf="licenseText !== license", [innerHTML]="cleanFieldValue(license) | linkify")
+            .value([innerHTML]="cleanFieldValue('Use of this image is in accordance with the <a href=`https://www.artstor.org/artstor-terms/` target=`_blank` >Artstor Terms & Conditions</a>') | linkify")
           //- File Properties
           .row-hdr.pt-3(*ngIf="assets[0].filePropertiesArray.length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.FILE_PROPS' | translate}}
           //- File Name

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -221,10 +221,10 @@
           .meta-block(*ngIf="assets[0].formattedMetadata.License && assets[0].formattedMetadata.License.length > 0")
             .label#License License
             .license(*ngFor="let license of assets[0].formattedMetadata.License")
-              a([attr.href]="licenseLink", aria-label="Learn about this license statement on creativecommons.org", target="_blank")
-                img.license-icon([attr.src]="licenseImg", [attr.alt]="license", title="License")
+              a(*ngIf="license", [attr.href]="license.licenseLink", aria-label="Learn about this license statement on creativecommons.org", target="_blank")
+                img.license-icon([attr.src]="license.licenseImg", [attr.alt]="license.licenseText", title="License")
                 | &nbsp;
-                span.value.license-text([innerHTML]="cleanFieldValue(license) | lowercase | linkify", title="License")
+                span.value.license-text([innerHTML]="cleanFieldValue(license.licenseText) | lowercase | linkify", title="License")
             .value([innerHTML]="cleanFieldValue('Use of this image is in accordance with the <a href=`https://www.artstor.org/artstor-terms/` target=`_blank` >Artstor Terms & Conditions</a>') | linkify")
           //- File Properties
           .row-hdr.pt-3(*ngIf="assets[0].filePropertiesArray.length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.FILE_PROPS' | translate}}

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -67,10 +67,6 @@ export class AssetPage implements OnInit, OnDestroy {
     public rightsLink: string = ''
     public rightsImg: string = ''
 
-    // License Statements values
-    public licenseLink: string = ''
-    public licenseImg: string = ''
-
     // Toast Variables
     public showToast: boolean = false
     public toastType: string = ''
@@ -578,8 +574,7 @@ export class AssetPage implements OnInit, OnDestroy {
             // Loop over License fields and set license statement values via isCreativeCommonsLicense
             for (let i = 0; i < this.assets[0].formattedMetadata.License.length; i++) {
                 let licenseField = this.assets[0].formattedMetadata.License[i]
-                let resLicenseVal = this.isCreativeCommonsLicense(licenseField)
-                this.assets[0].formattedMetadata.License[i] = resLicenseVal ? resLicenseVal : licenseField
+                this.assets[0].formattedMetadata.License[i] = this.isCreativeCommonsLicense(licenseField)
             }
         }
     }
@@ -863,11 +858,14 @@ export class AssetPage implements OnInit, OnDestroy {
         })
 
         if (licenseToUse) {
-          this.licenseLink = licenseToUse.link
-          this.licenseImg = licenseToUse.img
+            return {
+                licenseText: licenseToUse.name,
+                licenseLink: licenseToUse.link,
+                licenseImg: licenseToUse.img
+            }
         }
 
-        return licenseToUse && licenseToUse.name ? licenseToUse.name : false
+        return false
     }
 
     private handleSkipAsset(): void {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -68,7 +68,6 @@ export class AssetPage implements OnInit, OnDestroy {
     public rightsImg: string = ''
 
     // License Statements values
-    public licenseText: string = ''
     public licenseLink: string = ''
     public licenseImg: string = ''
 
@@ -864,12 +863,11 @@ export class AssetPage implements OnInit, OnDestroy {
         })
 
         if (licenseToUse) {
-          this.licenseText = licenseToUse.name
           this.licenseLink = licenseToUse.link
           this.licenseImg = licenseToUse.img
         }
 
-        return this.licenseText ? this.licenseText : false
+        return licenseToUse && licenseToUse.name ? licenseToUse.name : false
     }
 
     private handleSkipAsset(): void {


### PR DESCRIPTION
 - Boilerplate needs to be exist for all conditions, so remove the licenseText variable and hardcode the boilerplate into the template