### PR TITLE
PLATO-165: Recently created groups not showing up in the save dialog box

### DIFF
--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -325,9 +325,9 @@ export class GroupService {
      * @param igId The image group id to make global
      * @returns Observable resolved with { success: boolean, message: string }
      */
-    public updateIgPublic(igId: string, makePublic: boolean) {
+    public updateIgPublic(igId: string) {
         let reqUrl = [this.groupV1, igId, 'admin', 'public'].join('/')
-        let body = { public: makePublic }
+        let body = { public: true }
 
         return this.http.put(
             reqUrl,

--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -27,8 +27,8 @@
                       | It looks like you have not created a group yet! Please try creating a group first.
                   .no-result-row(*ngIf="error.recentGroups")
                     .alert.alert-warning
-                      b Error
-                      | There is an error loading your recent groups.
+                      b Error:
+                      | Unable to load groups at this time. Please try again later.
                   .row.no-gutters(*ngFor="let recentGroup of recentGroups", [ngClass]="{ 'selectedGroup' : recentGroup.selected }", [attr.id]="recentGroup.id", (click)="selectGroup(recentGroup, 'recent');groupSelectKeyDown($event, recentGroup.selected)", (keydown.enter)="selectGroup(recentGroup, 'recent')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(recentGroup, 'recent')", (keydown)="groupSelectKeyDown($event, recentGroup.selected)", tabindex="10", [attr.aria-label]="recentGroup.name + ', ' + (recentGroup.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (recentGroup.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper
@@ -47,8 +47,8 @@
                     b.no-result-msg Sorry, we couldn’t find any groups related to your search. Please try a different search.
                   .no-result-row(*ngIf="error.allGroups")
                     .alert.alert-warning
-                      b Error
-                      | There is an error loading your groups.
+                      b Error:
+                      | Unable to load groups at this time. Please try again later.
                   .row.no-gutters(*ngFor="let group of allGroups", [ngClass]="{ 'selectedGroup' : group.selected }", [attr.id]="group.id", (click)="selectGroup(group, 'all');groupSelectKeyDown($event, group.selected)", (keydown.enter)="selectGroup(group, 'all')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(group, 'all')", (keydown)="groupSelectKeyDown($event, group.selected)", tabindex="10", [attr.aria-label]="group.name + ', ' + (group.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (group.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper

--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -25,6 +25,10 @@
                     .alert.alert-warning
                       b No Groups Found
                       | It looks like you have not created a group yet! Please try creating a group first.
+                  .no-result-row(*ngIf="error.recentGroups")
+                    .alert.alert-warning
+                      b Error
+                      | There is an error loading your recent groups.
                   .row.no-gutters(*ngFor="let recentGroup of recentGroups", [ngClass]="{ 'selectedGroup' : recentGroup.selected }", [attr.id]="recentGroup.id", (click)="selectGroup(recentGroup, 'recent');groupSelectKeyDown($event, recentGroup.selected)", (keydown.enter)="selectGroup(recentGroup, 'recent')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(recentGroup, 'recent')", (keydown)="groupSelectKeyDown($event, recentGroup.selected)", tabindex="10", [attr.aria-label]="recentGroup.name + ', ' + (recentGroup.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (recentGroup.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper
@@ -41,6 +45,10 @@
                     label(tabindex="10") All My Groups
                   .no-result-row(*ngIf="groupSearchTerm && totalGroups === 0")
                     b.no-result-msg Sorry, we couldn’t find any groups related to your search. Please try a different search.
+                  .no-result-row(*ngIf="error.allGroups")
+                    .alert.alert-warning
+                      b Error
+                      | There is an error loading your groups.
                   .row.no-gutters(*ngFor="let group of allGroups", [ngClass]="{ 'selectedGroup' : group.selected }", [attr.id]="group.id", (click)="selectGroup(group, 'all');groupSelectKeyDown($event, group.selected)", (keydown.enter)="selectGroup(group, 'all')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(group, 'all')", (keydown)="groupSelectKeyDown($event, group.selected)", tabindex="10", [attr.aria-label]="group.name + ', ' + (group.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (group.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -51,6 +51,10 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
     recentGroups: false,
     allGroups: false
   }
+  public error: any = {
+    recentGroups: false,
+    allGroups: false
+  }
 
   public detailViewBounds: ImageZoomParams = {}
   public selectedGroup: any = {}
@@ -341,6 +345,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.error.recentGroups = true
             this.loading.recentGroups = false
           })
         } else {
@@ -392,6 +397,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.error.allGroups = true
             this.loading.allGroups = false
           })
         } else { // Incase the result has 0 groups

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -341,6 +341,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.loading.recentGroups = false
           })
         } else {
           this.loading.recentGroups = false
@@ -391,6 +392,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.loading.allGroups = false
           })
         } else { // Incase the result has 0 groups
           this.loading.allGroups = false

--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -259,8 +259,8 @@ export class NewIgModal implements OnInit, AfterViewInit {
           }
         )).subscribe()
       // if an Artstor user, make sure the public property is set correctly
-      if (this.isArtstorUser) {
-        this.changeGlobalSetting(group, formValue.artstorPermissions == 'global')
+      if (this.isArtstorUser && formValue.artstorPermissions === 'global') {
+        this.changeGlobalSetting(group)
       }
     }
     else {
@@ -282,8 +282,8 @@ export class NewIgModal implements OnInit, AfterViewInit {
           this._assets.clearSelectMode.next(true)
 
           // if an Artstor user, make sure the public property is set correctly
-          if (this.isArtstorUser) {
-            this.changeGlobalSetting(this.newGroup, formValue.artstorPermissions == 'global')
+          if (this.isArtstorUser && formValue.artstorPermissions === 'global') {
+            this.changeGlobalSetting(this.newGroup)
           }
 
           if (this.copyIG && this.ig && this.ig.id) {
@@ -402,9 +402,9 @@ export class NewIgModal implements OnInit, AfterViewInit {
    * @param group the image group which needs the public property changed
    * @param isPublic the value to set the public property to
    */
-  private changeGlobalSetting(group: ImageGroup, isPublic: boolean): void {
+  private changeGlobalSetting(group: ImageGroup): void {
 
-    this._group.updateIgPublic(group.id, isPublic).pipe(
+    this._group.updateIgPublic(group.id).pipe(
       take(1),
       map(res => {
         // not really sure what to do here?

--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -400,7 +400,6 @@ export class NewIgModal implements OnInit, AfterViewInit {
   /**
    * Updates a group's public property. Should only be called for artstor users.
    * @param group the image group which needs the public property changed
-   * @param isPublic the value to set the public property to
    */
   private changeGlobalSetting(group: ImageGroup): void {
 


### PR DESCRIPTION
 - Cannot reproduce on my machine
 - If looking further, the only place where we don't set `loading.recentGroups` back to false (this is why the three dots show) is when the item service and group service fails. So the problem is very likely to be cause by service failure.
 - Add an error message to notify users when the service fails