### PR TITLE
PLATO-165-192: Refactor logic that retrieves image groups for 'Add To Group' modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -403,6 +403,10 @@ export class AssetService {
             let options = { withCredentials: true };
 
             let loadBatch = (i) => {
+                if(itemIds.length === 0) {
+                  resolve([])
+                }
+
                 let countEnd = i + maxCount
                 let objectIdTerm: string = igId ? '&object_ids=' : '&object_id=' // the group version of the call takes object_ids instead of object_id
 
@@ -714,7 +718,7 @@ export class AssetService {
             } else {
                 dateObj = {
                     modified : false,
-                    earliest : {                   
+                    earliest : {
                         era : 'BCE'
                     },
                     latest : {

--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -325,9 +325,9 @@ export class GroupService {
      * @param igId The image group id to make global
      * @returns Observable resolved with { success: boolean, message: string }
      */
-    public updateIgPublic(igId: string, makePublic: boolean) {
+    public updateIgPublic(igId: string) {
         let reqUrl = [this.groupV1, igId, 'admin', 'public'].join('/')
-        let body = { public: makePublic }
+        let body = { public: true }
 
         return this.http.put(
             reqUrl,

--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -25,6 +25,10 @@
                     .alert.alert-warning
                       b No Groups Found
                       | It looks like you have not created a group yet! Please try creating a group first.
+                  .no-result-row(*ngIf="error.recentGroups")
+                    .alert.alert-warning
+                      b Error
+                      | There is an error loading your recent groups.
                   .row.no-gutters(*ngFor="let recentGroup of recentGroups", [ngClass]="{ 'selectedGroup' : recentGroup.selected }", [attr.id]="recentGroup.id", (click)="selectGroup(recentGroup, 'recent');groupSelectKeyDown($event, recentGroup.selected)", (keydown.enter)="selectGroup(recentGroup, 'recent')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(recentGroup, 'recent')", (keydown)="groupSelectKeyDown($event, recentGroup.selected)", tabindex="10", [attr.aria-label]="recentGroup.name + ', ' + (recentGroup.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (recentGroup.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper
@@ -41,6 +45,10 @@
                     label(tabindex="10") All My Groups
                   .no-result-row(*ngIf="groupSearchTerm && totalGroups === 0")
                     b.no-result-msg Sorry, we couldn’t find any groups related to your search. Please try a different search.
+                  .no-result-row(*ngIf="error.allGroups")
+                    .alert.alert-warning
+                      b Error
+                      | There is an error loading your groups.
                   .row.no-gutters(*ngFor="let group of allGroups", [ngClass]="{ 'selectedGroup' : group.selected }", [attr.id]="group.id", (click)="selectGroup(group, 'all');groupSelectKeyDown($event, group.selected)", (keydown.enter)="selectGroup(group, 'all')", (keydown.space)="$event.stopPropagation(); $event.preventDefault(); selectGroup(group, 'all')", (keydown)="groupSelectKeyDown($event, group.selected)", tabindex="10", [attr.aria-label]="group.name + ', ' + (group.selected ? 'selected' : 'unselected') + ', press enter or spacebar to ' + (group.selected ? 'unselect' : 'select') + ' this group'")
                     .col-3
                       .ig-thmbnail-wrapper

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -352,7 +352,6 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
         this.recentGroups = groups
       },
       (error) => {
-        console.error('Error loading recent image groups', error)
         this.error.recentGroups = true
       }
     ).add(() => {
@@ -373,7 +372,6 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
         }
       },
       (error) => {
-        console.error('Error loading all image groups', error)
         this.error.allGroups = true
       }
     ).add(() => {

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -51,6 +51,10 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
     recentGroups: false,
     allGroups: false
   }
+  public error: any = {
+    recentGroups: false,
+    allGroups: false
+  }
 
   public detailViewBounds: ImageZoomParams = {}
   public selectedGroup: any = {}
@@ -341,6 +345,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.error.recentGroups = true
             this.loading.recentGroups = false
           })
         } else {
@@ -392,6 +397,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.error.allGroups = true
             this.loading.allGroups = false
           })
         } else { // Incase the result has 0 groups

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -341,6 +341,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.loading.recentGroups = false
           })
         } else {
           this.loading.recentGroups = false
@@ -391,6 +392,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
           })
           .catch( error => {
             console.error(error)
+            this.loading.allGroups = false
           })
         } else { // Incase the result has 0 groups
           this.loading.allGroups = false

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -314,7 +314,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private injectThumbnails(groups) {
-    let itemIds = groups.filter(group => group.items.length > 0).map(group => group.items[0])
+    const itemIds = groups.filter(group => group.items.length > 0).map(group => group.items[0])
 
       return this._assets.getAllThumbnails({ itemIds })
         .then( thumbnails => {
@@ -325,7 +325,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
         })
         .then(thumbnailMap => {
           return groups.map(group => {
-            let groupClone: any = {...group}
+            const groupClone: any = {...group}
 
             if(groupClone.items.length > 0) {
               let firstItemId: string = group.items[0],

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, AfterViewInit, OnDestroy, Input, Output, EventEmitter, ElementRef, ViewChild } from '@angular/core'
 import { NgForm } from '@angular/forms'
-import { BehaviorSubject, Observable, Subscription, from } from 'rxjs'
+import { Subscription, from } from 'rxjs'
 import { map, take, mergeMap } from 'rxjs/operators'
-import { CompleterService, CompleterData } from 'ng2-completer'
+import { CompleterService } from 'ng2-completer'
 import { Angulartics2 } from 'angulartics2'
 import { Router } from '@angular/router'
 
@@ -10,7 +10,6 @@ import { Router } from '@angular/router'
 import { AssetService, GroupService, AuthService, DomUtilityService, ThumbnailService, LogService } from '_services'
 import { ImageGroup, ImageZoomParams, Asset } from 'datatypes'
 import { ToastService } from 'app/_services'
-import { group } from "@angular/animations";
 import { GroupList } from "shared";
 
 @Component({

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -345,6 +345,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
 
   private loadRecentGroups(): void {
     this.loading.recentGroups = true
+    this.error.recentGroups = false
 
     this.loadGroups(
       3,
@@ -366,6 +367,8 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
 
   private loadMyGroups() {
     this.loading.allGroups = true
+    this.error.allGroups = false
+
     let timeStamp = this.allGroupSearchTS
 
     this.loadGroups(
@@ -399,8 +402,8 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
         )
       ).subscribe(
       (groups) => onSuccess(groups),
-      (error) => onFailure(error),
-      () => onComplete())
+      (error) => onFailure(error)
+    ).add(() => onComplete())
   }
 
   private selectGroup(selectedGroup: any, type: string): void{

--- a/src/app/modals/new-ig-modal/new-ig-modal.component.ts
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.ts
@@ -259,8 +259,8 @@ export class NewIgModal implements OnInit, AfterViewInit {
           }
         )).subscribe()
       // if an Artstor user, make sure the public property is set correctly
-      if (this.isArtstorUser) {
-        this.changeGlobalSetting(group, formValue.artstorPermissions == 'global')
+      if (this.isArtstorUser && formValue.artstorPermissions === 'global') {
+        this.changeGlobalSetting(group)
       }
     }
     else {
@@ -282,8 +282,8 @@ export class NewIgModal implements OnInit, AfterViewInit {
           this._assets.clearSelectMode.next(true)
 
           // if an Artstor user, make sure the public property is set correctly
-          if (this.isArtstorUser) {
-            this.changeGlobalSetting(this.newGroup, formValue.artstorPermissions == 'global')
+          if (this.isArtstorUser && formValue.artstorPermissions === 'global') {
+            this.changeGlobalSetting(this.newGroup)
           }
 
           if (this.copyIG && this.ig && this.ig.id) {
@@ -402,9 +402,9 @@ export class NewIgModal implements OnInit, AfterViewInit {
    * @param group the image group which needs the public property changed
    * @param isPublic the value to set the public property to
    */
-  private changeGlobalSetting(group: ImageGroup, isPublic: boolean): void {
+  private changeGlobalSetting(group: ImageGroup): void {
 
-    this._group.updateIgPublic(group.id, isPublic).pipe(
+    this._group.updateIgPublic(group.id).pipe(
       take(1),
       map(res => {
         // not really sure what to do here?


### PR DESCRIPTION
Resolves [PLATO-192](https://jira.jstor.org/browse/PLATO-192)

In PLATO-165 we introduced some logic to the 'Add to Group' modal that increased the complexity. We are taking an opportunity here to consolidate that logic to reduce the risk of edge cases while slightly boosting performance.

The diff here in github is kinda narly and unhelpful. Might recommend pulling down the code because a couple functions have been written from scratch.