### PR TITLE
PLATO-354: Fix bug that prevent image download when navigating directly to an image url

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -38,7 +38,7 @@ export class AssetSearchService {
   ]
 
   public latestSearchRequestId: string
-  public ab_segments: any
+  public ab_segments: any = new Map()
 
   // Used for simplify the code when versioning search
   private contentQueryKey: string
@@ -382,7 +382,6 @@ export class AssetSearchService {
         })
 
         // Build a mapping between the artstorid and ab_segment for logging
-        this.ab_segments = new Map()
         res.results.forEach((result) => { this.ab_segments.set(result['artstorid'], result['ab_segment'])})
 
         // create the cleaned response to pass to caller


### PR DESCRIPTION
Resolves PLATO-354

Steps to reproduce:

- Navigate directly to asset: https://library.artstor.org/#/asset/ABROOKLYNIG_10312350495;prevRouteTS=1573050245273;iap=true
- Try download the image. Also notice the share url is blank

Issue is that when you navigate directly to an asset we don't have the ab segments data and this line blows up because `abSegments` is `undefined`: https://github.com/ithaka/aiw-ui/blob/684ab92ca47a5380c9dff82632850951f6d1343c/src/app/asset-page/asset-page.component.ts#L516
