### PR TITLE
PALS-106: Login Page: Error Messages Aren't Announced via Screen Reader

### DIFF
--- a/src/app/login-form/login-form.component.pug
+++ b/src/app/login-form/login-form.component.pug
@@ -8,8 +8,8 @@ form((ngSubmit)="login(user)")
       span([innerHtml]="'LOGIN.REG_LOGIN.PASSWORD_LABEL' | translate")
       input#inputLoginPassword.form-control([(ngModel)]="user.password" name="password" type="password" placeholder="Password" aria-label="Artstor password, required" tabindex="1")
     #errorMsg.form-text.text-danger(
-      *ngIf="errorMsg",
-      [innerHtml]="errorMsg | translate"
+      [innerHtml]="errorMsg | translate",
+      aria-live="assertive"
     )
     p.form-text.text-danger(*ngIf="forcePwdRst", [innerHtml]="'LOGIN.REG_LOGIN.FORCE_PW_RESET_MSG' | translate")
   p.notranslate([innerHtml]=" copyBase + 'LOGIN.TERMS' | translate ")

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -44,7 +44,7 @@
               [fieldTabindex]="1",
               aria-live="polite",
             )
-            .login-errorMsg(*ngIf="instErrorMsg") {{ instErrorMsg | translate }}
+            .login-errorMsg(aria-live="assertive") {{ instErrorMsg | translate }}
           .form-group
             p.notranslate([innerHtml]="'LOGIN.TERMS' | translate")
             p.small {{ 'LOGIN.INSTITUTION_LOGIN.LIST_INFO' | translate }}


### PR DESCRIPTION
https://jira.jstor.org/browse/PALS-106

Apply aria-live attributes to Login error messages so screen readers announce them.