### PR TITLE
PLATO 312: Fix tooltip popping up behind results

### DIFF
--- a/src/app/collection-badge/collection-badge.component.pug
+++ b/src/app/collection-badge/collection-badge.component.pug
@@ -1,6 +1,7 @@
 .collection-badge.my-1(
   [ngbTooltip]="tipContent",
   ngbTooltip,
+  container="body",
   triggers="focusin:focusout mouseenter:mouseleave",
   placement="right",
   aria-haspopup="true",


### PR DESCRIPTION
PLATO-312

## Description
Make tooltips fully visible in results instead of hiding behind adjacent images.

## Checks
Have you written any necessary unit tests?
☐ Yes
☐ Not yet
☑︎ Not applicable
Have you added or updated any necessary integration tests?
☐ Yes
☐ Not yet
☑︎ Not applicable
Browsers tested on:
☑︎ Chrome
   ☐ Mobile
☐ Safari
   ☐ Mobile
☐ Firefox
   ☐ Mobile
☐ Edge
☐ IE11
☐ Not applicable