### PR TITLE
PLATO-371: Update openseadragon dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ngx-device-detector": "^1.3.3",
     "ngx-infinite-scroll": "^7.0.1",
     "ngx-tag-autocomplete": "2.0.4",
-    "openseadragon": "git://github.com/ithaka/openseadragon.git#master",
+    "openseadragon": "git://github.com/ithaka/openseadragon.git#f92bfe545ca095e517a73cbe43b4e92d5a186203",
     "popper.js": "^1.14.4",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6899,9 +6899,9 @@ opener@~1.4.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
-"openseadragon@git://github.com/ithaka/openseadragon.git#master":
+"openseadragon@git://github.com/ithaka/openseadragon.git#f92bfe545ca095e517a73cbe43b4e92d5a186203":
   version "2.4.1"
-  resolved "git://github.com/ithaka/openseadragon.git#a39d20bd70cee75845fb4716f4bd3e19d417590c"
+  resolved "git://github.com/ithaka/openseadragon.git#f92bfe545ca095e517a73cbe43b4e92d5a186203"
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Using the latest forked version of openseadragon that uses the IIIF 2.0 standard for getting full size images. 