### PR TITLE
PLATO-391: Pass doi as array

### DIFF
--- a/src/app/_services/log.service.ts
+++ b/src/app/_services/log.service.ts
@@ -42,6 +42,7 @@ interface LogResponse {
 interface LogMessage {
   eventType: string
   item_id?: string
+  doi?: string[]
   referring_requestid?: string
   additional_fields?: any
   ab_segments?: any

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -924,10 +924,10 @@ export class AssetPage implements OnInit, OnDestroy {
       referring_requestid: this._search.latestSearchRequestId,
       ab_segments: abSegments ? [abSegments] : [],
       item_id: assetId,
+      ...doi && {doi: [doi]},
       additional_fields: {
         has_access: hasAccess,
         reason_for_authorization: [reasonForAuth],
-        ...doi && {doi: doi}
       }
     })
   }


### PR DESCRIPTION
The artstor-log-service expects an array of dois, also moved it as a top level key after coordinating with blueprint team