### PR TITLE
SRCHX-138: Allow only one date filter on advanced search

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -183,10 +183,14 @@ export class AssetSearchService {
 
     if (filterOptions.dateFacet.modified) {
       filterOptions.earliestDate = filterOptions.dateFacet.earliest.date;
-      filterOptions.earliestDate = (filterOptions.dateFacet.earliest.era == 'BCE') ? (parseInt(filterOptions.earliestDate) * -1).toString() : filterOptions.earliestDate.toString();
+      if (!isNaN(filterOptions.earliestDate)) {
+        filterOptions.earliestDate = (filterOptions.dateFacet.earliest.era == 'BCE') ? (parseInt(filterOptions.earliestDate) * -1).toString() : filterOptions.earliestDate.toString();
+      }
 
       filterOptions.latestDate = filterOptions.dateFacet.latest.date;
-      filterOptions.latestDate = (filterOptions.dateFacet.latest.era == 'BCE') ? (parseInt(filterOptions.latestDate) * -1).toString() : filterOptions.latestDate.toString();
+      if (!isNaN(filterOptions.latestDate)) {
+        filterOptions.latestDate = (filterOptions.dateFacet.latest.era == 'BCE') ? (parseInt(filterOptions.latestDate) * -1).toString() : filterOptions.latestDate.toString();
+      }
 
       query[this.filterQueryKey].push('year:[' + filterOptions.earliestDate + ' TO ' + filterOptions.latestDate + ']')
     }

--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -183,13 +183,13 @@ export class AssetSearchService {
 
     if (filterOptions.dateFacet.modified) {
       filterOptions.earliestDate = filterOptions.dateFacet.earliest.date;
-      if (!isNaN(filterOptions.earliestDate)) {
-        filterOptions.earliestDate = (filterOptions.dateFacet.earliest.era == 'BCE') ? (parseInt(filterOptions.earliestDate) * -1).toString() : filterOptions.earliestDate.toString();
+      if (Number.isInteger(filterOptions.earliestDate)) {
+        filterOptions.earliestDate = (filterOptions.dateFacet.earliest.era == 'BCE') ? (parseInt(filterOptions.earliestDate) * -1).toString() : filterOptions.earliestDate.toString()
       }
 
       filterOptions.latestDate = filterOptions.dateFacet.latest.date;
-      if (!isNaN(filterOptions.latestDate)) {
-        filterOptions.latestDate = (filterOptions.dateFacet.latest.era == 'BCE') ? (parseInt(filterOptions.latestDate) * -1).toString() : filterOptions.latestDate.toString();
+      if (Number.isInteger(filterOptions.latestDate)) {
+        filterOptions.latestDate = (filterOptions.dateFacet.latest.era == 'BCE') ? (parseInt(filterOptions.latestDate) * -1).toString() : filterOptions.latestDate.toString()
       }
 
       query[this.filterQueryKey].push('year:[' + filterOptions.earliestDate + ' TO ' + filterOptions.latestDate + ']')

--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -701,7 +701,7 @@ export class AssetService {
                 }
             });
 
-            if (params['startDate'] && params['endDate']){
+            if (params['startDate'] || params['endDate']){
                 dateObj = {
                     modified : true,
                     earliest : {

--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -705,12 +705,12 @@ export class AssetService {
                 dateObj = {
                     modified : true,
                     earliest : {
-                        date : Math.abs(params['startDate']),
-                        era : params['startDate'] < 0 ? 'BCE' : 'CE'
+                        date : isNaN(params['startDate']) ? params['startDate'] : Math.abs(params['startDate']),
+                        era : isNaN(params['startDate']) ? 'BCE' : (params['startDate'] < 0 ? 'BCE' : 'CE')
                     },
                     latest : {
-                        date : Math.abs(params['endDate']),
-                        era : params['endDate'] < 0 ? 'BCE' : 'CE'
+                        date : isNaN(params['endDate']) ? params['endDate'] : Math.abs(params['endDate']),
+                        era :  isNaN(params['endDate']) ? 'CE' : (params['endDate'] < 0 ? 'BCE' : 'CE')
                     }
                 }
                 this._filters.setAvailable('dateObj', dateObj);

--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -270,12 +270,19 @@ export class AssetFilters {
     }
 
     if (this.availableFilters.dateObj && this.availableFilters.dateObj.modified == true && this.filterDate) {
-      params['startDate'] = this.availableFilters.dateObj.earliest.date * (this.availableFilters.dateObj.earliest.era == 'BCE' ? -1 : 1);
-      params['endDate'] = this.availableFilters.dateObj.latest.date * (this.availableFilters.dateObj.latest.era == 'BCE' ? -1 : 1);
-    
-      // Make sure the params are not NaN before setting route parameter
-      params['startDate'] = isNaN(params['startDate']) ? 0 : params['startDate']
-      params['endDate'] = isNaN(params['endDate']) ? 0 : params['endDate']
+      if (this.availableFilters.dateObj.earliest.date == null || this.availableFilters.dateObj.earliest.date == '*') {
+        params['startDate'] = '*'
+      } else {
+        params['startDate'] = this.availableFilters.dateObj.earliest.date * (this.availableFilters.dateObj.earliest.era == 'BCE' ? -1 : 1);
+        params['startDate'] = isNaN(params['startDate']) ? 0 : params['startDate']
+      }
+
+      if (this.availableFilters.dateObj.latest.date == null || this.availableFilters.dateObj.latest.date == '*') {
+        params['endDate'] = '*'
+      } else {
+        params['endDate'] = this.availableFilters.dateObj.latest.date * (this.availableFilters.dateObj.latest.era == 'BCE' ? -1 : 1);
+        params['endDate'] = isNaN(params['endDate']) ? 0 : params['endDate']
+      }
     }
 
     for (let filter of this.appliedFilters) {

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -260,8 +260,10 @@ export class SearchModal implements OnInit, AfterViewInit {
       }
     }
     // Apply date filter
-    if(filterParams["startDate"] && filterParams["endDate"]) {
+    if(filterParams["startDate"]) {
       queryParams["startDate"] = filterParams["startDate"]
+    }
+    if(filterParams["endDate"]) {
       queryParams["endDate"] = filterParams["endDate"]
     }
     // Track in angulartics
@@ -306,7 +308,7 @@ export class SearchModal implements OnInit, AfterViewInit {
       } else {
         termOperator = ' AND '
       }
-      
+
       for(let orQuerySegment of orQuerySegments) {
         if( orQuerySegment.indexOf(':') > -1 ) { // Its a filter query
           let key = orQuerySegment.split(':')[0]

--- a/src/app/modals/search-modal/search-query.ts
+++ b/src/app/modals/search-modal/search-query.ts
@@ -95,18 +95,20 @@ export class SearchQueryUtil {
   public generateFilters(appliedFilters: any, dateFilter: any): any {
     let filterParams = {}
 
-    if (dateFilter['startDate']) {
-      // Pass BCE dates as negative numbers
-      filterParams['startDate'] = dateFilter['startDate'] * (dateFilter['startEra'] == 'BCE' ? -1 : 1)
-    } else {
-      filterParams['startDate'] = '*'
-    }
+    if (dateFilter['startDate'] || dateFilter['endDate']) {
+      if (dateFilter['startDate']) {
+        // Pass BCE dates as negative numbers
+        filterParams['startDate'] = dateFilter['startDate'] * (dateFilter['startEra'] == 'BCE' ? -1 : 1)
+      } else {
+        filterParams['startDate'] = '*'
+      }
 
-    if (dateFilter['endDate']) {
-      // Pass BCE dates as negative numbers
-      filterParams['endDate'] = dateFilter['endDate'] * (dateFilter['endEra'] == 'BCE' ? -1 : 1)
-    } else {
-      filterParams['endDate'] = '*'
+      if (dateFilter['endDate']) {
+        // Pass BCE dates as negative numbers
+        filterParams['endDate'] = dateFilter['endDate'] * (dateFilter['endEra'] == 'BCE' ? -1 : 1)
+      } else {
+        filterParams['endDate'] = '*'
+      }
     }
 
     // Put filters into an object with field name as key

--- a/src/app/modals/search-modal/search-query.ts
+++ b/src/app/modals/search-modal/search-query.ts
@@ -95,9 +95,13 @@ export class SearchQueryUtil {
   public generateFilters(appliedFilters: any, dateFilter: any): any {
     let filterParams = {}
 
-    if (dateFilter['startDate'] && dateFilter['endDate']) {
+    if (dateFilter['startDate']) {
       // Pass BCE dates as negative numbers
       filterParams['startDate'] = dateFilter['startDate'] * (dateFilter['startEra'] == 'BCE' ? -1 : 1)
+    }
+
+    if (dateFilter['endDate']) {
+      // Pass BCE dates as negative numbers
       filterParams['endDate'] = dateFilter['endDate'] * (dateFilter['endEra'] == 'BCE' ? -1 : 1)
     }
 

--- a/src/app/modals/search-modal/search-query.ts
+++ b/src/app/modals/search-modal/search-query.ts
@@ -98,11 +98,15 @@ export class SearchQueryUtil {
     if (dateFilter['startDate']) {
       // Pass BCE dates as negative numbers
       filterParams['startDate'] = dateFilter['startDate'] * (dateFilter['startEra'] == 'BCE' ? -1 : 1)
+    } else {
+      filterParams['startDate'] = '*'
     }
 
     if (dateFilter['endDate']) {
       // Pass BCE dates as negative numbers
       filterParams['endDate'] = dateFilter['endDate'] * (dateFilter['endEra'] == 'BCE' ? -1 : 1)
+    } else {
+      filterParams['endDate'] = '*'
     }
 
     // Put filters into an object with field name as key


### PR DESCRIPTION
Allows users to filter in advanced search by only 1 date filter, whether start or end.

Implements same functionality as side bar in browse page. 