### PR TITLE
PLATO-355: Fix Sentry error reporting on PROD for Artstor

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -143,8 +143,9 @@ import { version } from '../../package.json'
  * Sentry.io client-side reporter
  * > Reports to "artstor-ui" project
  */
+let dsn = environment.SENTRY_ENV === 'dev' ? null : 'https://9ef1f98534914bf6826e202370d1f627@sentry.io/209953'
 Sentry.init({
-  dsn: 'https://9ef1f98534914bf6826e202370d1f627@sentry.io/209953',
+  dsn: dsn,
   release: 'artstor-ui@' + version,
   environment: environment.SENTRY_ENV
 });
@@ -152,7 +153,12 @@ Sentry.init({
 export class SentryErrorHandler implements ErrorHandler {
   constructor() {}
   handleError(error) {
-    const eventId = Sentry.captureException(error.originalError || error);
+    if (environment.SENTRY_ENV !== 'dev') {
+      const eventId = Sentry.captureException(error.originalError || error);
+    }
+    else {
+      console.error(error)
+    }
     // For additional debugging
     // console.log("Sentry ID: " + eventId)
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { DatePipe, isPlatformBrowser } from '@angular/common'
  * Platform and Environment providers/directives/pipes
  */
 import { ENV_PROVIDERS } from './environment';
+import { environment } from "environments/environment"
 import { ROUTES } from './app.routes';
 
 // UI modules
@@ -144,7 +145,8 @@ import { version } from '../../package.json'
  */
 Sentry.init({
   dsn: 'https://9ef1f98534914bf6826e202370d1f627@sentry.io/209953',
-  release: 'artstor-ui@' + version
+  release: 'artstor-ui@' + version,
+  environment: environment.SENTRY_ENV
 });
 @Injectable()
 export class SentryErrorHandler implements ErrorHandler {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -7,5 +7,6 @@ export const environment = {
   SSR_API_URL: 'https://library.artstor.org',
   FORUM_URL: 'http://new.forum.jstor.org',
   STOR_URL: '//stor.artstor.org/stor',
-  GAPI_TEST: ['', '', [''], '']
+  GAPI_TEST: ['', '', [''], ''],
+  SENTRY_ENV: 'prod'
 };

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -7,5 +7,6 @@ export const environment = {
   SSR_API_URL: 'https://stage.artstor.org',
   FORUM_URL: 'http://new.forum.jstor.org',
   STOR_URL: '//stor.stage.artstor.org/stor',
-  GAPI_TEST: ['', '', [''], '']
+  GAPI_TEST: ['', '', [''], ''],
+  SENTRY_ENV: 'test'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,7 +14,7 @@ export const environment = {
     ['https://slides.googleapis.com/$discovery/rest?version=v1'],
     'https://www.googleapis.com/auth/presentations'
   ],
-  SENTRY_ENV: 'test'
+  SENTRY_ENV: 'dev'
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,7 +13,8 @@ export const environment = {
     "AIzaSyDHAAKMjGUxxQbZCeHJDCpAeLmQ2A7HqOI",
     ['https://slides.googleapis.com/$discovery/rest?version=v1'],
     'https://www.googleapis.com/auth/presentations'
-  ]
+  ],
+  SENTRY_ENV: 'test'
 };
 
 /*


### PR DESCRIPTION
According to Sentry's doc, we can set up environment through init: https://docs.sentry.io/enriching-error-data/environments/?platform=browser