### PR TITLE
PLATO-423: Log the current url for asset related actions

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -911,10 +911,10 @@ export class AssetPage implements OnInit, OnDestroy {
   private trackEvent(eventType: string): void {
     const hasAccess = !this.showAccessDeniedModal
     const reasonForAuth = this.showAccessDeniedModal ? "not_authorized" : "license"
-    const assetId = this.assetIds[0]
-    const abSegments = this._search.ab_segments.get(assetId)
     const authorizedAsset = this.assets[0]
+    const assetId = authorizedAsset ? authorizedAsset.id : this.assetIds[0]
     const doi = authorizedAsset ? authorizedAsset.doi : null
+    const abSegments = this._search.ab_segments.get(assetId)
 
     this._log.log({
       eventType: eventType,

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -925,6 +925,7 @@ export class AssetPage implements OnInit, OnDestroy {
       additional_fields: {
         has_access: hasAccess,
         reason_for_authorization: [reasonForAuth],
+        fullUrl: this._router.url
       }
     })
   }


### PR DESCRIPTION
While recently debugging some artstor logging issues, we came across some interesting url parameters that affect can affect the way access is evaluated when viewing/downloading an asset. It would have been super helpful to have seen this url reflected in the logs in order to help draw conclusions. 

This PR just adds the full url to the asset related logging (viewing/downloading). Let me know if there are any concerns with this!