### PR TITLE
SRCHX-392: Geographic filters in advanced search is using efq values

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -124,7 +124,7 @@ export class AssetSearchService {
     // Loop through applied filters
     for (let i = 0; i < filterOptions.filters.length; i++) {
       let currentFilter = filterOptions.filters[i]
-
+      institutionalTypeFilter = false;
       // for these values, do nothing
       if (['collTypes', 'page', 'size', 'sort', 'startDate', 'endDate'].indexOf(currentFilter.filterGroup) > -1) {
 
@@ -139,11 +139,12 @@ export class AssetSearchService {
       } else {
         for (let j = 0; j < currentFilter.filterValue.length; j++) {
           let filterValue = currentFilter.filterValue[j]
+          institutionalTypeFilter = false;
           /**
            * In case of Inst. colType filter, also use the contributing inst. ID to filter
            */
           if ((currentFilter.filterGroup === 'collectiontypes') && (filterValue === 2 || filterValue === 4)) {
-            institutionalTypeFilter = true
+            institutionalTypeFilter = true;
             filterOptions.filterArray.push('contributinginstitutionid:\"' + this._auth.getUser().institutionId.toString() + '\"')
           }
 

--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -150,6 +150,9 @@ export class AssetFilters {
               } catch (err) { // param is not an array
                 parsedParam = routeParams[paramName]
               }
+              if(paramName === 'geography') {
+                parsedParam = parsedParam.split(',')
+              }
               this._filters.apply(paramName, parsedParam);
             }
         }

--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -150,6 +150,7 @@ export class AssetFilters {
               } catch (err) { // param is not an array
                 parsedParam = routeParams[paramName]
               }
+              // Check if there are multiple selected Geo facets.
               if(paramName === 'geography') {
                 parsedParam = parsedParam.split(',')
               }

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -233,11 +233,11 @@ export class SearchModal implements OnInit, AfterViewInit {
     // Construct OR query between filters within the same filter group
     // filters across multiple filter groups will be AND-ed
     // example orQuery: paints AND artclassification_str:"Photographs" OR artclassification_str:"Paintings" OR artclassification_str:"Prints" OR artclassification_str:"photographs" AND year:[-4000 TO 1980]
-    let orQuery: string = ''
+    let orQuery: string = advQuery
     // Do not apply "* AND", Solr will treat the wildcard as a character in that case
-    if (advQuery !== '*') {
-      orQuery = advQuery
-    }
+    // if (advQuery !== '*') {
+      // orQuery = advQuery
+    // }
     // Build Solr query string from filters
     for(let key in filterParams) {
       if(key !== 'startDate' && key !== 'endDate' && key !== 'geography') {
@@ -303,7 +303,7 @@ export class SearchModal implements OnInit, AfterViewInit {
     }
     let geography: string = routeParams['geography']
     if (geography) {
-      appliedFiltersObj['geography'] = geography.startsWith('[') ? JSON.parse(geography) : geography
+      appliedFiltersObj['geography'] = geography.startsWith('[') ? JSON.parse(geography) : geography.split(',')
     }
 
     // Process advance search query string

--- a/src/app/modals/search-modal/search-modal.component.ts
+++ b/src/app/modals/search-modal/search-modal.component.ts
@@ -223,7 +223,7 @@ export class SearchModal implements OnInit, AfterViewInit {
     if (currentParams['featureFlag']) {
       queryParams['featureFlag'] = currentParams['featureFlag']
     }
-    
+
     // Build Solr query string from filters
     let orQuery: string = this.buildSolrQuery(advQuery, filterParams)
 
@@ -242,7 +242,7 @@ export class SearchModal implements OnInit, AfterViewInit {
         queryParams['geography'].push(efq)
       }
     }
-    
+
     // Track in angulartics
     this.angulartics.eventTrack.next({ properties: { event: 'advSearch', category: 'search', label: advQuery } })
     // Open search page with new query
@@ -275,7 +275,7 @@ export class SearchModal implements OnInit, AfterViewInit {
    */
   public buildSolrQuery(advQuery, filterParams) {
     let orQuery: string = advQuery
-    
+
     for(let key in filterParams) {
       if(key !== 'startDate' && key !== 'endDate' && key !== 'geography') {
         if (orQuery.length > 0) {
@@ -311,6 +311,7 @@ export class SearchModal implements OnInit, AfterViewInit {
   /**
    * Update advanceQueries, advanceSearchDate and selected filters based on applied filters from URL
    */
+  // TODO This function needs to be smaller
   private loadAppliedFiltersFromURL(): void{
     let routeParams = this.route.snapshot.params
     // Setup selected filters object to show applied filters for edit
@@ -321,10 +322,7 @@ export class SearchModal implements OnInit, AfterViewInit {
       this.loadingFilters = false
       return
     }
-    let geography: string = routeParams['geography']
-    if (geography) {
-      appliedFiltersObj['geography'] = geography.startsWith('[') ? JSON.parse(geography) : geography.split(',')
-    }
+    this.createGeographyFilterListFromParam(routeParams, appliedFiltersObj);
 
     // Process advance search query string
     query = query.replace(/\(|\)/g, '')
@@ -384,12 +382,7 @@ export class SearchModal implements OnInit, AfterViewInit {
         case 'geography': {
           let filterGroup = this.availableFilters.find( filterGroup => filterGroup.name === key )
           if (filterGroup) {
-            let geography = routeParams[key]
-            let selections = typeof geography === 'string' ? [ geography ] : geography
-            for (let efq of selections) {
-              let updtFilterObj = filterGroup.values.find(filterObj => filterObj.efq === efq)
-              this.checkFilter(updtFilterObj, filterGroup, efq, true)
-            }
+            this.loadGeographyFilters(routeParams, key, filterGroup);
           }
           break
         }
@@ -420,9 +413,25 @@ export class SearchModal implements OnInit, AfterViewInit {
     this.loadingFilters = false
   }
 
+  private createGeographyFilterListFromParam(routeParams, appliedFiltersObj) {
+    let geography: string = routeParams['geography']
+    if (geography) {
+      appliedFiltersObj['geography'] = geography.startsWith('[') ? JSON.parse(geography) : geography.split(',')
+    }
+  }
+
+  private loadGeographyFilters(routeParams, key, filterGroup) {
+    let geography = routeParams[key]
+    let selections = typeof geography === 'string' ? [geography] : geography
+    for (let efq of selections) {
+      let updtFilterObj = filterGroup.values.find(filterObj => filterObj.efq === efq)
+      this.checkFilter(updtFilterObj, filterGroup, efq, true)
+    }
+  }
+
   /**
    * clean out wrapping parenthesis for OR queries
-   * @param query Query string from route params 
+   * @param query Query string from route params
    * @param appliedFiltersObj Applied filters object
    */
   private processAdvSrchQueryString(query, appliedFiltersObj) {
@@ -446,7 +455,7 @@ export class SearchModal implements OnInit, AfterViewInit {
         }
       }
     }
-    
+
     return appliedFiltersObj
   }
 

--- a/src/app/modals/search-modal/search-query.ts
+++ b/src/app/modals/search-modal/search-query.ts
@@ -113,10 +113,18 @@ export class SearchQueryUtil {
 
     // Put filters into an object with field name as key
     for (let filter of appliedFilters) {
-      if (filterParams[filter.group]) {
-        filterParams[filter.group].push(filter.value)
+      if (filter.group === 'geography') {
+        if (filterParams[filter.group]) {
+          filterParams[filter.group].push(filter.efq)
+        } else {
+          filterParams[filter.group] = [filter.efq]
+        }
       } else {
-        filterParams[filter.group] = [filter.value]
+        if (filterParams[filter.group]) {
+          filterParams[filter.group].push(filter.value)
+        } else {
+          filterParams[filter.group] = [filter.value]
+        }
       }
     }
 

--- a/src/app/modals/search-modal/search-query.ts
+++ b/src/app/modals/search-modal/search-query.ts
@@ -113,18 +113,11 @@ export class SearchQueryUtil {
 
     // Put filters into an object with field name as key
     for (let filter of appliedFilters) {
-      if (filter.group === 'geography') {
-        if (filterParams[filter.group]) {
-          filterParams[filter.group].push(filter.efq)
-        } else {
-          filterParams[filter.group] = [filter.efq]
-        }
+      let filterValue = filter.group === 'geography' ? filter.efq : filter.value
+      if (filterParams[filter.group]) {
+        filterParams[filter.group].push(filterValue)
       } else {
-        if (filterParams[filter.group]) {
-          filterParams[filter.group].push(filter.value)
-        } else {
-          filterParams[filter.group] = [filter.value]
-        }
+        filterParams[filter.group] = [filterValue]
       }
     }
 


### PR DESCRIPTION
Geographic queries will use the efq (encoded filter query) values from the search service. These values will be selected in the search results page.

The `SearchModal.loadAppliedFiltersFromURL()` method will parse the geography portion of the url to select the proper tree nodes.

This work has not been comprehensively tested. I only have one day left on this project (contract expires) and there are a lot of devs out of the office now so you folks will need to take this over the finish line.