### PR TITLE
PLATO-463: Artstor logging adjustments for view/download item events

### DIFF
--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -902,6 +902,20 @@ export class AssetPage implements OnInit, OnDestroy {
     return false
   }
 
+  private getReasonForAuth() {
+    if(this.showAccessDeniedModal) {
+      return "not_authorized"
+    } else {
+      if(this.assetGroupId) {
+        return "image_group"
+      } else if(this.encryptedAccess) {
+        return "encrypted_access"
+      } else {
+        return "license"
+      }
+    }
+  }
+
   /**
    * trackEvent
    * send captain's log event for the current asset
@@ -910,24 +924,25 @@ export class AssetPage implements OnInit, OnDestroy {
    */
   private trackEvent(eventType: string): void {
     const hasAccess = !this.showAccessDeniedModal
-    const reasonForAuth = this.showAccessDeniedModal ? "not_authorized" : "license"
     const authorizedAsset = this.assets[0]
     const assetId = authorizedAsset ? authorizedAsset.id : this.assetIds[0]
     const doi = authorizedAsset ? authorizedAsset.doi : null
     const abSegments = this._search.ab_segments.get(assetId)
 
-    this._log.log({
-      eventType: eventType,
-      referring_requestid: this._search.latestSearchRequestId,
-      ab_segments: abSegments ? [abSegments] : [],
-      item_id: assetId,
-      ...doi && {doi: [doi]},
-      additional_fields: {
-        has_access: hasAccess,
-        reason_for_authorization: [reasonForAuth],
-        fullUrl: this._router.url
-      }
-    })
+    if(this.isBrowser) {
+      this._log.log({
+        eventType: eventType,
+        referring_requestid: this._search.latestSearchRequestId,
+        ab_segments: abSegments ? [abSegments] : [],
+        item_id: assetId,
+        ...doi && {doi: [doi]},
+        additional_fields: {
+          has_access: hasAccess,
+          reason_for_authorization: [this.getReasonForAuth()],
+          fullUrl: this._router.url
+        }
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
Resolves PLATO-463

Changes:

- Data platform requested that we be a little more granular with our `reason_for_authorization` field. This will help for account for the edge cases that allow a user to view an image even though they don't technically have the entitlements to do so.

- We learned that the asset page is server side rendered if it is hit with the `/public` or `/object` urls. https://github.com/ithaka/aiw-ui/blob/884259db16fc0eb967f7ac819e81286c5c4cc078/server/server.ts#L101 This running node server was actually emitting a captains log in an attempt to pre-render the page. This log was incomplete and overall not C5 worthy. A log would then again be fired on the front end when the javascript would run in the actual browser. The log generated at this stage is well formed. So here we are just omitting the ssr log.