### PR TITLE
PLATO-223: Image Groups Modals Have Keyboard Trap

### DIFF
--- a/src/app/asset-page/agree-modal/agree-modal.component.pug
+++ b/src/app/asset-page/agree-modal/agree-modal.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog(role="document")
     .modal-content
       .modal-header
-        h4.modal-title Terms and Conditions of Use
+        h4.modal-title(#agreeModalTitle, tabindex="0") Terms and Conditions of Use
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .notranslate.modal-body
@@ -14,4 +14,4 @@
           a.link(href="http://support.artstor.org/?article=embedded-metadata", name="Embedded metadata viewing help", target="_blank") click here.
       .modal-footer
         button.btn.btn-secondary(type="button", (click)="closeModal.emit()") I reject
-        a.btn.btn-primary((click)="agree()", [href]="downloadUrl", target="_blank") I accept
+        a.btn.btn-primary((click)="agree()", [href]="downloadUrl", target="_blank", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") I accept

--- a/src/app/asset-page/agree-modal/agree-modal.component.ts
+++ b/src/app/asset-page/agree-modal/agree-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, Input, EventEmitter, ElementRef, ViewChild } from '@angular/core';
+import { Component, AfterViewInit, Output, Input, EventEmitter, ElementRef, ViewChild } from '@angular/core';
 
 // Project Dependencies
 import { AuthService, DomUtilityService } from '_services'
@@ -9,7 +9,7 @@ import { Asset } from './../asset'
   templateUrl: 'agree-modal.component.pug',
   styleUrls: [ './agree-modal.component.scss' ]
 })
-export class AgreeModalComponent implements OnInit {
+export class AgreeModalComponent implements AfterViewInit {
 
   /** Causes modal to be hidden */
   @Output()
@@ -30,20 +30,21 @@ export class AgreeModalComponent implements OnInit {
   @Input()
   isMSAgent: boolean
 
-  @ViewChild("modal", {read: ElementRef}) modalElement: ElementRef;
+  @ViewChild("agreeModalTitle", {read: ElementRef}) modalTitleElement: ElementRef;
 
   constructor(
     private _auth: AuthService,
     private _dom: DomUtilityService
   ) { }
 
-  ngOnInit() {
-    // Set focus to the modal to make the links in the modal first thing to tab for accessibility
-    // TO-DO: Only reference document client-side
-    // let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('modal');
-    // htmlelement.focus()
-    if (this.modalElement && this.modalElement.nativeElement){
-      this.modalElement.nativeElement.focus()
+  ngAfterViewInit() {
+    this.startModalFocus()
+  }
+
+  // Set initial focus on the modal Title h4
+  public startModalFocus() {
+    if (this.modalTitleElement && this.modalTitleElement.nativeElement){
+      this.modalTitleElement.nativeElement.focus()
     }
   }
 

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog(role="dialog", (keydown.esc)="hideModal($event)")
     .modal-content
       .modal-header
-        h4.modal-title#term-condition-title(tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
+        h4.modal-title(#termConditionTitle, tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
         button.close#term-condition-close((click)="hideModal($event)", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog(role="dialog", (keydown.esc)="hideModal($event)")
     .modal-content
       .modal-header
-        h4.modal-title(#termConditionTitle, tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
+        h4.modal-title(#termsAndConditionsTitle, tabindex="0", (keydown.shift.tab)="hideModal($event)") {{ 'IMAGE_GROUP_PAGE.TERMS_AND_CONDITIONS.TITLE' | translate }}
         button.close#term-condition-close((click)="hideModal($event)", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
@@ -26,7 +26,7 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   @Input()
   public exportType: string;
 
-  @ViewChild("termConditionTitle", {read: ElementRef}) termConditionTitleElement: ElementRef;
+  @ViewChild("termsAndConditionsTitle", {read: ElementRef}) termsAndConditionsTitleElement: ElementRef;
 
   public isLoading: boolean = false;
   public zipLoading: boolean = false;
@@ -56,8 +56,8 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   
   // Set initial focus on the modal Title h4
   public startModalFocus() {
-    if (this.termConditionTitleElement && this.termConditionTitleElement.nativeElement){
-      this.termConditionTitleElement.nativeElement.focus()
+    if (this.termsAndConditionsTitleElement && this.termsAndConditionsTitleElement.nativeElement){
+      this.termsAndConditionsTitleElement.nativeElement.focus()
     }
   }
 

--- a/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
+++ b/src/app/image-group-page/terms-and-conditions/terms-and-conditions.component.ts
@@ -26,7 +26,7 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   @Input()
   public exportType: string;
 
-  @ViewChild("ig-download-title", {read: ElementRef}) downloadTitleElement: ElementRef;
+  @ViewChild("termConditionTitle", {read: ElementRef}) termConditionTitleElement: ElementRef;
 
   public isLoading: boolean = false;
   public zipLoading: boolean = false;
@@ -53,13 +53,11 @@ export class TermsAndConditionsComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.startModalFocus()
   }
+  
   // Set initial focus on the modal Title h4
   public startModalFocus() {
-    let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('term-condition-title');
-    htmlelement.focus()
-
-    if (this.downloadTitleElement && this.downloadTitleElement.nativeElement){
-      this.downloadTitleElement.nativeElement.focus()
+    if (this.termConditionTitleElement && this.termConditionTitleElement.nativeElement){
+      this.termConditionTitleElement.nativeElement.focus()
     }
   }
 

--- a/src/app/modals/generate-citation/generate-citation.component.pug
+++ b/src/app/modals/generate-citation/generate-citation.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog.modal-lg(role="dialog", (keydown.esc)="closeModal.emit()")
     .modal-content
       .modal-header
-        h4#generate-citation-title.modal-title(tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'GENERATE_CITATION_MODAL.MAIN_HEADING' | translate }}
+        h4.modal-title(#generateCitationTitle, tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'GENERATE_CITATION_MODAL.MAIN_HEADING' | translate }}
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body

--- a/src/app/modals/generate-citation/generate-citation.component.ts
+++ b/src/app/modals/generate-citation/generate-citation.component.ts
@@ -17,7 +17,7 @@ export class GenerateCitation implements OnInit, AfterViewInit {
 
   @Input() private asset: Asset /** the asset in question */
 
-  @ViewChild("modal", {read: ElementRef}) modalElement: ElementRef;
+  @ViewChild("generateCitationTitle", {read: ElementRef}) generateCitationTitleElement: ElementRef;
 
   // Prefer saving links to HTTPS
   private reqProtocol = 'https://'
@@ -38,11 +38,6 @@ export class GenerateCitation implements OnInit, AfterViewInit {
   ) { }
 
   ngOnInit() {
-    // Set focus to the modal to make the links in the modal first thing to tab for accessibility
-    if (this.modalElement && this.modalElement.nativeElement){
-      this.modalElement.nativeElement.focus()
-    }
-
     this.generateCitations(this.asset)
     this._log.log({
       eventType: 'artstor_citation',
@@ -56,8 +51,12 @@ export class GenerateCitation implements OnInit, AfterViewInit {
 
   // Set initial focus on the modal Title h1
   public startModalFocus() {
-    let modalStartFocus: HTMLElement = <HTMLElement>this._dom.byId('generate-citation-title')
-    modalStartFocus.focus()
+    // let modalStartFocus: HTMLElement = <HTMLElement>this._dom.byId('generate-citation-title')
+    // modalStartFocus.focus()
+
+    if (this.generateCitationTitleElement && this.generateCitationTitleElement.nativeElement){
+      this.generateCitationTitleElement.nativeElement.focus()
+    }
   }
 
   /**

--- a/src/app/modals/generate-citation/generate-citation.component.ts
+++ b/src/app/modals/generate-citation/generate-citation.component.ts
@@ -51,9 +51,6 @@ export class GenerateCitation implements OnInit, AfterViewInit {
 
   // Set initial focus on the modal Title h1
   public startModalFocus() {
-    // let modalStartFocus: HTMLElement = <HTMLElement>this._dom.byId('generate-citation-title')
-    // modalStartFocus.focus()
-
     if (this.generateCitationTitleElement && this.generateCitationTitleElement.nativeElement){
       this.generateCitationTitleElement.nativeElement.focus()
     }

--- a/src/app/modals/new-ig-modal/new-ig-modal.component.pug
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.pug
@@ -7,7 +7,7 @@
         #modalHeader,
         tabindex="1",
         (keydown.tab)="focusElement(firstField, $event)",
-        (keydown.shit.tab)="focusElement(confirmButton, $event)"
+        (keydown.shift.tab)="focusElement(confirmButton, $event)"
       )
         h4.modal-title(*ngIf="!copyIG && !editIG") {{ 'NEW_GROUP_MODAL.CREATE_TITLE' | translate }}
         h4.modal-title(*ngIf="copyIG") {{ 'NEW_GROUP_MODAL.COPY_TITLE' | translate }}

--- a/src/app/modals/share-ig-link/share-ig-link.component.pug
+++ b/src/app/modals/share-ig-link/share-ig-link.component.pug
@@ -3,7 +3,7 @@
     // modal content: Is deleted, now what?
     .modal-content
       .modal-header
-        h4.modal-title#share-ig-link-title(tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'SHARE_IG_LINK_MODAL.MAIN_HEADING' | translate }}
+        h4.modal-title(#shareIgLinkTitle, tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'SHARE_IG_LINK_MODAL.MAIN_HEADING' | translate }}
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close", tabindex="0")
           span(aria-hidden="true") &times;
       .modal-body

--- a/src/app/modals/share-ig-link/share-ig-link.component.ts
+++ b/src/app/modals/share-ig-link/share-ig-link.component.ts
@@ -26,7 +26,7 @@ export class ShareIgLinkModal implements OnInit, AfterViewInit {
 
   @Input() private ig: ImageGroup /** the image group in question */
 
-  @ViewChild("share-ig-link-title", {read: ElementRef}) shareLinkTitleElement: ElementRef
+  @ViewChild("shareIgLinkTitle") shareLinkTitleElement: ElementRef;
 
   constructor(
     private _group: GroupService,

--- a/src/app/modals/share-link-modal/share-link-modal.component.pug
+++ b/src/app/modals/share-link-modal/share-link-modal.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog.modal-lg
     .modal-content
       .modal-header
-        h1#share-img-link-title(tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'SHARE_IMG_LINK_MODAL.MAIN_HEADING' | translate }}
+        h1(#shareImgLinkTitle, tabindex="0", (keydown.shift.tab)="closeModal.emit()") {{ 'SHARE_IMG_LINK_MODAL.MAIN_HEADING' | translate }}
         button.close(type="button", (click)="closeModal.emit()", data-dismiss="modal", aria-label="Close", tabindex="0")
           span(aria-hidden="true") &times;
       .modal-body(*ngIf="asset")

--- a/src/app/modals/share-link-modal/share-link-modal.component.ts
+++ b/src/app/modals/share-link-modal/share-link-modal.component.ts
@@ -14,7 +14,7 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
 
   @Input() public asset: any;
   @Output() public closeModal: EventEmitter<any> = new EventEmitter();
-  @ViewChild("share-ig-link-title", {read: ElementRef}) shareLinkTitleElement: ElementRef;
+  @ViewChild("shareImgLinkTitle", {read: ElementRef}) shareLinkTitleElement: ElementRef;
   private shareLink: string = '';
   private genImgMode: string = 'half';
 


### PR DESCRIPTION
Resolve PLATO-223

- Prevent keyboard trap for "Generate image link" and "Generate group link" modals
- Also realize same behavior on other modals