### PR TITLE
PLATO-218: Image Viewer Keyboard Instructions Availability

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -50,7 +50,8 @@
             (multiViewPageViaThumbnail)="multiViewPageViaThumbnail()",
             (assetDrawer)="toggleAssetDrawer(!showAssetDrawer)",
             [legacyFlag]="false",
-            [openLibraryFlag]="fromOpenLibrary"
+            [openLibraryFlag]="fromOpenLibrary",
+            aria-label="Use the arrow keys to move the image, press 0 to center the image, and the plus and minus keys to zoom in and out."
           )
       //- Related results from JSTOR
       .pl-3(*ngIf="jstorResults.length > 0 && relatedResFlag")


### PR DESCRIPTION
Add aria label to viewer to announce keyboard instructions, use the same wording as Jstor