### PR TITLE
SRCHX-428: Correct search results when using contributinginstitution facet

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -148,9 +148,11 @@ export class AssetSearchService {
           }
 
           // Push filter queries into the array
-          let filterValueArray = filterValue.toString().trim().split('|')
-          for (let filterVal of filterValueArray) {
-            filterOptions.filterArray.push(currentFilter.filterGroup + ':\"' + filterVal + '\"')
+          if (!institutionalTypeFilter) {
+            let filterValueArray = filterValue.toString().trim().split('|')
+            for (let filterVal of filterValueArray) {
+              filterOptions.filterArray.push(currentFilter.filterGroup + ':\"' + filterVal + '\"')
+            }
           }
         }
       }
@@ -357,6 +359,7 @@ export class AssetSearchService {
     }
 
     this.applyFilters(query, institutionalTypeFilter, options, sortIndex, filterOptions)
+    console.log("something here for pausing");
 
     return this._http.post<RawSearchResponse>(
       this._auth.getSearchUrl(),

--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -140,7 +140,7 @@ export class AssetSearchService {
         for (let j = 0; j < currentFilter.filterValue.length; j++) {
           let filterValue = currentFilter.filterValue[j]
           /**
-           * In case of Inst. colType filter, also use the contributing inst. ID to filter
+           * In case of Inst. colType filter, ONLY use the contributing inst. ID to filter
            */
           if ((currentFilter.filterGroup === 'collectiontypes') && (filterValue === 2 || filterValue === 4)) {
             institutionalTypeFilter = true
@@ -174,6 +174,7 @@ export class AssetSearchService {
       filterOptions.filterArray.push('collections:"' + colId + '"');
     }
 
+    //HERE?
     if (options.collections) {
       let colsArray = options.collections.toString().trim().split(',');
       for (let col of colsArray) { // Push each collection id seperately in the filterArray
@@ -359,7 +360,6 @@ export class AssetSearchService {
     }
 
     this.applyFilters(query, institutionalTypeFilter, options, sortIndex, filterOptions)
-    console.log("something here for pausing");
 
     return this._http.post<RawSearchResponse>(
       this._auth.getSearchUrl(),

--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -174,7 +174,6 @@ export class AssetSearchService {
       filterOptions.filterArray.push('collections:"' + colId + '"');
     }
 
-    //HERE?
     if (options.collections) {
       let colsArray = options.collections.toString().trim().split(',');
       for (let col of colsArray) { // Push each collection id seperately in the filterArray


### PR DESCRIPTION
The count when using contributing institution facet does not match the search results when being used. In order to correct this we are removing the `collectiontypes:2` from the filter queries since it causes the query to be incorrect. Therefore, when a facet for a university is selected, the only filter query that gets added to the submitted query is `contributinginstitutionid:10050`. 

Before: 
```{
  "limit": 48,
  "start": 0,
  "query": "parc de la Villette",
  "hier_facet_fields2": [
    {
      "field": "hierarchies",
      "hierarchy": "artstor-geography",
      "look_ahead": 2,
      "look_behind": -10,
      "d_look_ahead": 1
    }
  ],
  "facet_fields": [
    {
      "name": "artclassification_str",
      "mincount": 1,
      "limit": 20
    },
    {
      "name": "donatinginstitutionids",
      "mincount": 1,
      "limit": 400
    },
    {
      "name": "collectiontypes",
      "mincount": 1,
      "limit": 15
    }
  ],
  "content_set_flags": [
    "art"
  ],
  "filter_queries": [
    "contributinginstitutionid:\"10050\"",
    "collectiontypes:\"2\""
  ],
  "sortorder": "asc"
}
```


After:
```
{
  "limit": 48,
  "start": 0,
  "query": "parc de la Villette",
  "hier_facet_fields2": [
    {
      "field": "hierarchies",
      "hierarchy": "artstor-geography",
      "look_ahead": 2,
      "look_behind": -10,
      "d_look_ahead": 1
    }
  ],
  "facet_fields": [
    {
      "name": "artclassification_str",
      "mincount": 1,
      "limit": 20
    },
    {
      "name": "donatinginstitutionids",
      "mincount": 1,
      "limit": 400
    },
    {
      "name": "collectiontypes",
      "mincount": 1,
      "limit": 15
    }
  ],
  "content_set_flags": [
    "art"
  ],
  "filter_queries": [
    "contributinginstitutionid:\"10050\""
  ],
  "sortorder": "asc"
}
```