### PR TITLE
PLATO-221-225: Image Viewer Controls Keyboard Access

### DIFF
--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -83,19 +83,26 @@ export class ToolboxService {
      * @note Should fire immediately within a user-event binding (click, key)
      */
     public requestFullScreen(): void {
-        let el = document.getElementById("artstor-viewer");
-        // Supports most browsers and their versions.
-        var requestMethod = el.requestFullscreen || el['webkitRequestFullscreen'] || el['mozRequestFullscreen'] || el['msRequestFullscreen'];
-        if (requestMethod) { // Native full screen.
-            requestMethod.call(el);
-        } else if (window['ActiveXObject'] && typeof window['ActiveXObject'] !== "undefined") { // Older IE.
-            var wscript = new ActiveXObject("WScript.Shell");
-            if (wscript !== null) {
-                wscript.SendKeys("{F11}");
+        // Set timeout so that the artstor-viewer element will be available by the time we request fullscreen from image group
+        setTimeout(() => {
+            let el = document.getElementById("artstor-viewer");
+            // Supports most browsers and their versions.
+            var requestMethod = el.requestFullscreen || el['webkitRequestFullscreen'] || el['mozRequestFullscreen'] || el['msRequestFullscreen'];
+            if (requestMethod) { // Native full screen.
+                requestMethod.call(el);
+            } else if (window['ActiveXObject'] && typeof window['ActiveXObject'] !== "undefined") { // Older IE.
+                var wscript = new ActiveXObject("WScript.Shell");
+                if (wscript !== null) {
+                    wscript.SendKeys("{F11}");
+                }
             }
-        }
-        let ZoomInElement: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
-        ZoomInElement.focus();
+            let ZoomInElement: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
+            if (ZoomInElement) {
+                ZoomInElement.focus();
+            }
+        }, 0);
+        
+        
     }
 
     /**

--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -83,26 +83,21 @@ export class ToolboxService {
      * @note Should fire immediately within a user-event binding (click, key)
      */
     public requestFullScreen(): void {
-        // Set timeout so that the artstor-viewer element will be available by the time we request fullscreen from image group
-        setTimeout(() => {
-            let el = document.getElementById("artstor-viewer");
-            // Supports most browsers and their versions.
-            var requestMethod = el.requestFullscreen || el['webkitRequestFullscreen'] || el['mozRequestFullscreen'] || el['msRequestFullscreen'];
-            if (requestMethod) { // Native full screen.
-                requestMethod.call(el);
-            } else if (window['ActiveXObject'] && typeof window['ActiveXObject'] !== "undefined") { // Older IE.
-                var wscript = new ActiveXObject("WScript.Shell");
-                if (wscript !== null) {
-                    wscript.SendKeys("{F11}");
-                }
+        let el = document.getElementById("main");
+        // Supports most browsers and their versions.
+        var requestMethod = el.requestFullscreen || el['webkitRequestFullscreen'] || el['mozRequestFullscreen'] || el['msRequestFullscreen'];
+        if (requestMethod) { // Native full screen.
+            requestMethod.call(el);
+        } else if (window['ActiveXObject'] && typeof window['ActiveXObject'] !== "undefined") { // Older IE.
+            var wscript = new ActiveXObject("WScript.Shell");
+            if (wscript !== null) {
+                wscript.SendKeys("{F11}");
             }
-            let ZoomInElement: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
-            if (ZoomInElement) {
-                ZoomInElement.focus();
-            }
-        }, 0);
-        
-        
+        }
+        let ZoomInElement: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
+        if (ZoomInElement) {
+            ZoomInElement.focus();
+        }
     }
 
     /**

--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -94,10 +94,15 @@ export class ToolboxService {
                 wscript.SendKeys("{F11}");
             }
         }
-        let ZoomInElement: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
-        if (ZoomInElement) {
-            ZoomInElement.focus();
-        }
+        this.setFocusToCanvas();
+    }
+
+    /**
+     * Set focus to the main canvas in the viewer
+     */
+    private setFocusToCanvas(): void {
+        let canvasElement: HTMLElement = <HTMLElement>document.getElementsByClassName('openseadragon-canvas')[0];
+        canvasElement && canvasElement.focus();
     }
 
     /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,7 +37,7 @@ const STATUS_PAGE_CMP_ID_PROD: string = 'cmy3vpk5tq18'
         <button id="button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
       </div>
       <nav-bar tabindex="-1"></nav-bar>
-      <main>
+      <main id="main">
         <router-outlet></router-outlet>
       </main>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -304,24 +304,12 @@ export class AppComponent {
 
   private removeSkipToMainContent() {
     let skipToMainContentButton = document.getElementById("skip-main-content-button")
-    skipToMainContentButton.remove()
+    skipToMainContentButton.tabIndex = -1
   }
 
   private addSkipToMainContent() {
-    let skipToMainContentDiv = document.getElementById("skip-main-content-div")
-    // <button id="skip-main-content-button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
-    let skipToMainContentButton = document.createElement("button")
-    skipToMainContentButton.innerHTML = "Skip to main content"
+    let skipToMainContentButton = document.getElementById("skip-main-content-button")
     skipToMainContentButton.tabIndex = 1
-    skipToMainContentButton.id = "skip-main-content-button"
-    skipToMainContentButton.setAttribute("class", "sr-only sr-only-focusable")
-    skipToMainContentButton.onclick = this.findMainContent
-    skipToMainContentButton.onkeyup = (event) => {
-      if (event.keyCode === 13) {
-        this.findMainContent()
-      }
-    }
-    skipToMainContentDiv.appendChild(skipToMainContentButton);
   }
 
   private hideZendeskChat() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,8 +33,8 @@ const STATUS_PAGE_CMP_ID_PROD: string = 'cmy3vpk5tq18'
   template: `
     <ang-sky-banner *ngIf="showSkyBanner" [textValue]="skyBannerCopy" (closeBanner)="closeBanner()"></ang-sky-banner>
     <div>
-      <div id="skip" tabindex="-1">
-        <button id="button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
+      <div id="skip-main-content-div" tabindex="-1">
+        <button id="skip-main-content-button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
       </div>
       <nav-bar tabindex="-1"></nav-bar>
       <main id="main">
@@ -52,6 +52,8 @@ export class AppComponent {
   public showSkyBanner: boolean = false
   public skyBannerCopy: string = ''
   public test: any = {}
+
+  private isFullscreen: boolean = false
 
   public statusPageClient: any
   /**
@@ -141,7 +143,7 @@ export class AppComponent {
 
         if (isPlatformBrowser(this.platformId)) {
           // focus on the wrapper of the "skip to main content link" everytime new page is loaded
-          let mainEl = <HTMLElement>(this._dom.byId('skip'))
+          let mainEl = <HTMLElement>(this._dom.byId('skip-main-content-div'))
           if (!(event.url.indexOf('browse') > -1) && !(event.url.indexOf('search') > -1) && !(event.url.indexOf('asset') > -1)) // Don't set focus to skip to main content on browse pages so that we can easily go between browse levels
             mainEl.focus()
         }
@@ -273,6 +275,53 @@ export class AppComponent {
     }
 
     this.initPerimeterX();
+
+    document.addEventListener("fullscreenchange", () => {
+      this.toggleSkipToMainContent()
+    }, false);
+  
+    document.addEventListener("mozfullscreenchange", () => {
+      this.toggleSkipToMainContent()
+    }, false);
+  
+    document.addEventListener("webkitfullscreenchange",() => {
+      this.toggleSkipToMainContent()
+    }, false);
+  
+    document.addEventListener("msfullscreenchange", () => {
+      this.toggleSkipToMainContent()
+    }, false);
+  }
+
+  private toggleSkipToMainContent() {
+    if (this.isFullscreen) {
+        this.addSkipToMainContent()
+    } else {
+      this.removeSkipToMainContent()
+    }
+    this.isFullscreen = !this.isFullscreen
+  }
+
+  private removeSkipToMainContent() {
+    let skipToMainContentButton = document.getElementById("skip-main-content-button")
+    skipToMainContentButton.remove()
+  }
+
+  private addSkipToMainContent() {
+    let skipToMainContentDiv = document.getElementById("skip-main-content-div")
+    // <button id="skip-main-content-button" (click)="findMainContent()" (keyup.enter)="findMainContent()" tabindex="1" class="sr-only sr-only-focusable"> Skip to main content </button>
+    let skipToMainContentButton = document.createElement("button")
+    skipToMainContentButton.innerHTML = "Skip to main content"
+    skipToMainContentButton.tabIndex = 1
+    skipToMainContentButton.id = "skip-main-content-button"
+    skipToMainContentButton.setAttribute("class", "sr-only sr-only-focusable")
+    skipToMainContentButton.onclick = this.findMainContent
+    skipToMainContentButton.onkeyup = (event) => {
+      if (event.keyCode === 13) {
+        this.findMainContent()
+      }
+    }
+    skipToMainContentDiv.appendChild(skipToMainContentButton);
   }
 
   private hideZendeskChat() {

--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -119,6 +119,7 @@
               ang-thumbnail(
                 [thumbnail]="asset", 
                 [reorderMode]="false", 
+                [compareMode]="false",
                 [editMode]="editMode", 
                 [largeThmbView]="largeThmbView"
               )
@@ -144,6 +145,7 @@
                     [itemIndex]="i",
                     [arrowReorderMode]="arrowReorderMode",
                     [reorderMode]="true",
+                    [compareMode]="false",
                     [editMode]="editMode",
                     [largeThmbView]="largeThmbView",
                     (click)="arrowReorderMode = false",

--- a/src/app/asset-grid/thumbnail/thumbnail.component.ts
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.ts
@@ -44,6 +44,9 @@ export class ThumbnailComponent implements OnInit, OnChanges {
   @Input()
   public editMode: boolean
 
+  @Input()
+  private compareMode: boolean
+
   public src: SafeUrl
   // Keeps the track of multiViewItems count associated with the current asset
   public multiviewItemCount: number = 0
@@ -95,14 +98,16 @@ export class ThumbnailComponent implements OnInit, OnChanges {
     // Prevent the parent anchor tag from firing
     event.preventDefault()
     event.stopPropagation()
-
-    if (urlParams[0] === '/associated') {
-      this.angulartics.eventTrack.next({ properties: { event: 'view associated images', label: this.thumbnail.id } })
+    // Don't navigate to other page in compare mode
+    if (!this.compareMode) {
+      if (urlParams[0] === '/associated') {
+        this.angulartics.eventTrack.next({ properties: { event: 'view associated images', label: this.thumbnail.id } })
+      }
+      if (urlParams[0] === '/cluster') {
+        this.angulartics.eventTrack.next({ properties: { event: 'view cluster', label: this.thumbnail.id } })
+      }
+      this.router.navigate(urlParams)
     }
-    if (urlParams[0] === '/cluster') {
-      this.angulartics.eventTrack.next({ properties: { event: 'view cluster', label: this.thumbnail.id } })
-    }
-    this.router.navigate(urlParams)
   }
 
   /**

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -49,7 +49,8 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
         <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -21,20 +21,31 @@
     <div class="pdf-viewer-container" *ngIf="state == 6">
         <pdf-viewer [src]="pdfViewerOpts" [original-size]="false" [render-text]="true" [autoresize]="true" [show-all]="false" [page]="pdfCurrentPage" [zoom]="pdfZoomValue" (after-load-complete)="onPdfLoad($event)" (error)="onPdfError($event)"></pdf-viewer>
         <div class="asset-viewer__edge-arrows">
-            <button class="btn btn--icon btn--prev" [class.disabled]="pdfCurrentPage === 1" (click)="pdfPrevPage()"><i class="icon icon-prev--white"></i></button>
-            <button class="btn btn--icon btn--next" [class.disabled]="pdfCurrentPage === pdfTotalPages" (click)="pdfNextPage()"><i class="icon icon-next--white"></i></button>
+            <button class="btn btn--icon btn--prev" [class.aiw-hidden]="pdfCurrentPage === 1" (click)="pdfPrevPage()" tabindex="0"><i class="icon icon-prev--white"></i></button>
+            <button class="btn btn--icon btn--next" [class.aiw-hidden]="pdfCurrentPage === pdfTotalPages" (click)="pdfNextPage()" tabindex="0"><i class="icon icon-next--white"></i></button>
         </div>
         <div class="page-info">Page <b>{{ pdfCurrentPage }}</b> / <b>{{ pdfTotalPages }}</b></div>
     </div>
     <!--Viewer Buttons-->
     <div *ngIf="!thumbnailMode">
-      <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
-        <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
-        <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
-        <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
-        <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
-      </div>
+        <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
+            <div class="vertical-center-wrap">
+                <i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber > 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+                <div class="title" [innerHtml]="asset.title"></div>
+                <i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber < assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()" (keydown.tab)="setFocusToCtrBtns()"></i>
+                <div class="meta-block small">
+                    <div class="creator" [innerHtml]="asset.creator"></div>
+                    <div class="date" [innerHtml]="asset.date"></div>
+                </div>
+            </div>
+        </div>
+        <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}" tabindex="-1">
+            <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
+            <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
+            <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" (keydown.tab)="setFocusToCompare()" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
+            <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
+            <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
+        </div>
 
         <ng-template #zoomInTooltip><div>Zoom in</div></ng-template>
         <ng-template #zoomOutTooltip><div>Zoom out</div></ng-template>
@@ -48,24 +59,14 @@
         <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><</button><span class="btn-divider"></span><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}">></button>
         </div> -->
         <!-- Edge pagination arrow style -->
-        <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
+        <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}" tabindex="-1">
             <button [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button>
-            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
         <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
         <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
         </div>
-        <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-            <div class="vertical-center-wrap">
-                <i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber > 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
-                <div class="title" [innerHtml]="asset.title"></div>
-                <i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber < assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
-                <div class="meta-block small">
-                    <div class="creator" [innerHtml]="asset.creator"></div>
-                    <div class="date" [innerHtml]="asset.date"></div>
-                </div>
-            </div>
-        </div>
+        
     </div>
 </div>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -60,8 +60,7 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}" tabindex="-1">
-            <button *ngIf="multiViewPage != multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}"><i class="icon icon-prev--white"></i></button>
-            <button *ngIf="multiViewPage == multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-prev--white"></i></button>
+            <button *ngIf="multiViewPage == multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}" (keydown.tab)="multiViewPage == multiViewCount ? setFocusToThumbs() : null"><i class="icon icon-prev--white"></i></button>
             <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId }}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -57,13 +57,15 @@
         <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
         </div>
         <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" (click)="prevPage.emit()"></i>
-            <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" (click)="nextPage.emit()"></i>
-            <div class="meta-block small">
-            <div class="creator" [innerHtml]="asset.creator"></div>
-            <div class="date" [innerHtml]="asset.date"></div>
+            <div class="vertical-center-wrap">
+                <i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber > 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+                <div class="title" [innerHtml]="asset.title"></div>
+                <i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber < assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
+                <div class="meta-block small">
+                    <div class="creator" [innerHtml]="asset.creator"></div>
+                    <div class="date" [innerHtml]="asset.date"></div>
+                </div>
             </div>
-        </div>
         </div>
     </div>
 </div>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -60,8 +60,9 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}" tabindex="-1">
-            <button [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button>
-            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-next--white"></i></button>
+            <button *ngIf="multiViewPage != multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}"><i class="icon icon-prev--white"></i></button>
+            <button *ngIf="multiViewPage == multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-prev--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId }}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
         <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -60,7 +60,7 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}" tabindex="-1">
-            <button *ngIf="multiViewPage == multiViewCount" [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}" (keydown.tab)="multiViewPage == multiViewCount ? setFocusToThumbs() : null"><i class="icon icon-prev--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}" (keydown.tab)="multiViewPage == multiViewCount ? setFocusToThumbs() : null"><i class="icon icon-prev--white"></i></button>
             <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId }}" (keydown.tab)="setFocusToThumbs()"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -69,6 +69,11 @@ $desktop: 992px;*/
             background-color: $color-gray-3 !important;
         }
 
+        &:focus {
+            outline: auto 2px Highlight !important;
+            outline: -webkit-focus-ring-color auto 5px !important;
+        }
+
         .icon {
             width: 24px !important;
             height: 24px !important;
@@ -145,6 +150,11 @@ $desktop: 992px;*/
 .asset-viewer__edge-arrows .btn:active,
 .asset-viewer__edge-arrows .btn:focus {
     background: rgba(66,66,66,1.0);
+}
+
+.asset-viewer__edge-arrows .btn:focus {
+    outline: auto 2px Highlight !important;
+    outline: -webkit-focus-ring-color auto 5px !important;
 }
 
 .asset-viewer__edge-arrows .btn--prev {

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,9 +407,18 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
-            // Get all canvas elements, first one is the big viewer canvas, second one is the navigator
+            // Get all canvas elements, first one is the main canvas, second one is the navigator
             // The canvas in the reference strip starts as the third one in the collection
             let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+
+            // Set focus to the zoom in button after the main canvas
+            canvasElements.item(0).addEventListener("keydown", (event: KeyboardEvent) => {
+                if (event.keyCode === 9) {
+                    let ZoomInElement: HTMLElement = <HTMLElement>document.getElementById(`imageButtons-${this.osdViewerId}`)
+                    ZoomInElement.focus()
+                }
+            })
+
             // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
             for (let i = 2; i < canvasElements.length; i++) {
                 canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
@@ -631,6 +640,25 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             this.state = viewState.thumbnailFallback
         }
     };
+
+    private setFocusToCompare(): void {
+        let compareBtnElement: HTMLElement = <HTMLElement>document.getElementById("fullscreen-btn-group")
+        compareBtnElement && compareBtnElement.focus()
+    }
+
+    private setFocusToThumbs(): void {
+        let referenceStripThumbs = document.getElementsByClassName("openseadragon-container")
+        if (referenceStripThumbs.length > 2) {
+            let firstThumbEl: HTMLElement = <HTMLElement>(referenceStripThumbs.item(2))
+            firstThumbEl.tabIndex = -1
+            firstThumbEl.focus()
+        }
+    }
+
+    private setFocusToCtrBtns(): void {
+        let controlBtnElement: HTMLElement = <HTMLElement>document.getElementById("quiz-caption-cntnr")
+        controlBtnElement && controlBtnElement.focus()
+    }
 
     // Keep: We will want to dynamically load the Kaltura player
     // private getAndLoadKalturaId(data): void {

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -406,6 +406,20 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             this.osdViewer.destroy();
         });
 
+        this.osdViewer.addOnceHandler("tile-drawn", () => {
+            // Get all canvas elements, first one is the big viewer canvas, second one is the navigator
+            // The canvas in the reference strip starts as the third one in the collection
+            let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+            // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
+            for (let i = 2; i < canvasElements.length; i++) {
+                canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
+                    if (event.keyCode === 13) {
+                        this.osdViewer.goToPage(i-2)
+                    }
+                })
+            }
+        })
+
         this.osdViewer.addHandler('pan', (value: any) => {
             // Save viewport pan for downloading the view
             this.asset.viewportDimensions.center = value.center

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -2,7 +2,7 @@
 .container-fluid.asset-page(*ngIf="assetIds[0]", [class.fullscreen]="isFullscreen")
   .row
     //- View prev/next asset
-    .title-nav-cntnr.col-md-12([class.hidden]="isFullscreen")
+    .title-nav-cntnr.col-md-12(*ngIf="!isFullscreen")
       .row
         .col-2
           span#previousPageLink.back-results(*ngIf="prevRouteParams.length > 0", (keyup.enter)="backToResults()", (click)="backToResults()", tabindex="1", aria-label="Back to results", role="link")
@@ -121,7 +121,7 @@
             pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 
     //- Asset Metadata Column
-    .col-md-4(*ngIf="assets[0]",[class.hidden]="isFullscreen")
+    .col-md-4(*ngIf="assets[0] && !isFullscreen")
       .py-3
         //- If the user has not accepted the agreement, show modal when clicked, otherwise download immediately
         .btn-row

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -116,7 +116,7 @@
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
         div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
           .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
-        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)")
+        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [compareMode]="true", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)", (keydown.enter)="toggleAsset(asset)")
         .text-center.pt-2
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -18,6 +18,7 @@
               span.font-weight-normal &nbsp;of&nbsp;
               span#assetPageCount.font-weight-bold {{ totalAssetCount - restrictedAssetsCount }}
               i.icon.icon-direction.icon-right(title="Next in results", (click)="showNextAsset()", (keyup.enter)="showNextAsset()", [class.disabled]="assetNumber >= totalAssetCount - restrictedAssetsCount", [attr.tabindex]="assetNumber >= totalAssetCount - restrictedAssetsCount ? -1 : 1", aria-label="Next item, press enter to go to next result item. You can also use left and right arrow keys to navigate between result items.", role="button")
+    
     //- for accessibility so that page has title
     h1.sr-only([innerHTML]="getTitleAndResults()")
     //- Asset Viewer Row
@@ -50,7 +51,7 @@
             (multiViewPageViaThumbnail)="multiViewPageViaThumbnail()",
             (assetDrawer)="toggleAssetDrawer(!showAssetDrawer)",
             [legacyFlag]="false",
-            [openLibraryFlag]="fromOpenLibrary"
+            [openLibraryFlag]="fromOpenLibrary",
             aria-label="Use the arrow keys to move the image, press 0 to center the image, and the plus and minus keys to zoom in and out."
           )
         //- Related results from JSTOR
@@ -72,7 +73,7 @@
             br
             div(*ngIf="selectedJstorResult.doi") Stable URL: {{ 'http://www.jstor.org/stable/' + selectedJstorResult.doi }}
 
-        .col-md-12.quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]")
+        .col-md-12.quiz-caption-cntnr#quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]", tabindex="-1")
           ang-promo-tooltip(*ngIf="user.isLoggedIn && !quizModeTTDismissed && studyMode", [options]="quizModeTooltipOpts", (close)="closeQuizModeTooltip()")
           .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", tabindex="0", (click)="showAssetCaption = !showAssetCaption", (keydown.enter)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
             span.caption-btn
@@ -83,23 +84,26 @@
           .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", tabindex="0", (tap)="toggleQuizShuffle()", (keydown.enter)="toggleQuizShuffle()", title="Toggle Asset Suffle")
             span.shuffle-btn
             | SHUFFLE {{ quizShuffle ? 'ON' : 'OFF' }}
-          .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", tabindex="0", (tap)="toggleQuizMode()", (keydown.enter)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
+          .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", tabindex="0", (tap)="toggleQuizMode()", (keydown.enter)="toggleQuizMode()", (keydown.tab)="setFocusToCanvas()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
             span.quiz-btn
             | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
 
     //- Fullscreen viewer control button
-    .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-      button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
+    .fullscreen-btns.button-group#fullscreen-btn-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer", tabindex="-1")
+      button.btn.btn-light(*ngIf="!quizMode && !showAssetDrawer", (click)="toggleAssetDrawer(!showAssetDrawer)")
           | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
           i.icon.icon-compare
       button.btn.btn-light(
-          type="button",
-          (click)="exitPresentationMode()",
-          aria-label="Close",
-          title="Exit Fullscreen"
-        )
+        *ngIf="!showAssetDrawer"
+        type="button",
+        (click)="exitPresentationMode()",
+        (keydown.tab)="setFocusToArrow()"
+        aria-label="Close",
+        title="Exit Fullscreen"
+      )
         | Exit
         .icon.icon-exit-fullscreen
+
     //- Asset Drawer
     .asset-drawer(*ngIf="showAssetDrawer && isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
       .col-sm-12
@@ -116,24 +120,17 @@
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
         div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
           .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
-        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [compareMode]="true", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)", (keydown.enter)="toggleAsset(asset)")
+        ang-thumbnail.card.card--asset(
+          *ngFor="let asset of prevAssetResults.thumbnails",
+          [thumbnail]="asset",
+          [compareMode]="true",
+          [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }",
+          (click)="toggleAsset(asset)",
+          (keydown.enter)="toggleAsset(asset)"
+        )
         .text-center.pt-2
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 
-    .col-md-12.quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]")
-      ang-promo-tooltip(*ngIf="user.isLoggedIn && !quizModeTTDismissed && studyMode", [options]="quizModeTooltipOpts", (close)="closeQuizModeTooltip()")
-      .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", (click)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
-        span.caption-btn
-        | {{ showAssetCaption ? 'HIDE CAPTION' : 'SHOW CAPTION' }}
-      .quiz-browse-cntnr(*ngIf="quizMode")
-        i.icon.icon-direction.icon-left([class.disabled]="!quizShuffle && assetNumber <= 1 ? true : false", title="Previous in results", (tap)="showPrevAsset()")
-        i.icon.icon-direction.icon-right([class.disabled]="!quizShuffle && assetNumber >= totalAssetCount - restrictedAssetsCount ? true: false", title="Next in results", (tap)="showNextAsset()")
-      .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", (tap)="toggleQuizShuffle()", title="Toggle Asset Suffle")
-        span.shuffle-btn
-        | SHUFFLE {{ quizShuffle ? 'ON' : 'OFF' }}
-      .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", (tap)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
-        span.quiz-btn
-        | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
     //- Asset Metadata Column
     .col-md-4(*ngIf="assets[0] && !isFullscreen")
       .py-3

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -101,7 +101,7 @@
           | Exit
           .icon.icon-exit-fullscreen
       //- Asset Drawer
-      .asset-drawer(*ngIf="isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
+      .asset-drawer(*ngIf="showAssetDrawer && isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
         .col-sm-12
           h3.asset-drawer__header((click)="toggleAssetDrawer(!showAssetDrawer)")
             button.asset-drawer__close.pr-1(

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -87,53 +87,53 @@
             span.quiz-btn
             | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
 
-      //- Fullscreen viewer control button
-      .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-        button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
-            | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
-            i.icon.icon-compare
-        button.btn.btn-light(
+    //- Fullscreen viewer control button
+    .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
+      button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
+          | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
+          i.icon.icon-compare
+      button.btn.btn-light(
+          type="button",
+          (click)="exitPresentationMode()",
+          aria-label="Close",
+          title="Exit Fullscreen"
+        )
+        | Exit
+        .icon.icon-exit-fullscreen
+    //- Asset Drawer
+    .asset-drawer(*ngIf="showAssetDrawer && isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
+      .col-sm-12
+        h3.asset-drawer__header((click)="toggleAssetDrawer(!showAssetDrawer)")
+          button.asset-drawer__close.pr-1(
+            *ngIf="isFullscreen",
             type="button",
-            (click)="exitPresentationMode()",
             aria-label="Close",
-            title="Exit Fullscreen"
+            style="float:left;"
           )
-          | Exit
-          .icon.icon-exit-fullscreen
-      //- Asset Drawer
-      .asset-drawer(*ngIf="showAssetDrawer && isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
-        .col-sm-12
-          h3.asset-drawer__header((click)="toggleAssetDrawer(!showAssetDrawer)")
-            button.asset-drawer__close.pr-1(
-              *ngIf="isFullscreen",
-              type="button",
-              aria-label="Close",
-              style="float:left;"
-            )
-              .icon.icon-right
-            | COMPARE
-          .text-center
-            pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
-          div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
-            .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
-          ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)")
-          .text-center.pt-2
-            pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
+            .icon.icon-right
+          | COMPARE
+        .text-center
+          pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
+        div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
+          .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
+        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)")
+        .text-center.pt-2
+          pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 
-      .col-md-12.quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]")
-        ang-promo-tooltip(*ngIf="user.isLoggedIn && !quizModeTTDismissed && studyMode", [options]="quizModeTooltipOpts", (close)="closeQuizModeTooltip()")
-        .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", (click)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
-          span.caption-btn
-          | {{ showAssetCaption ? 'HIDE CAPTION' : 'SHOW CAPTION' }}
-        .quiz-browse-cntnr(*ngIf="quizMode")
-          i.icon.icon-direction.icon-left([class.disabled]="!quizShuffle && assetNumber <= 1 ? true : false", title="Previous in results", (tap)="showPrevAsset()")
-          i.icon.icon-direction.icon-right([class.disabled]="!quizShuffle && assetNumber >= totalAssetCount - restrictedAssetsCount ? true: false", title="Next in results", (tap)="showNextAsset()")
-        .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", (tap)="toggleQuizShuffle()", title="Toggle Asset Suffle")
-          span.shuffle-btn
-          | SHUFFLE {{ quizShuffle ? 'ON' : 'OFF' }}
-        .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", (tap)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
-          span.quiz-btn
-          | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
+    .col-md-12.quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]")
+      ang-promo-tooltip(*ngIf="user.isLoggedIn && !quizModeTTDismissed && studyMode", [options]="quizModeTooltipOpts", (close)="closeQuizModeTooltip()")
+      .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", (click)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
+        span.caption-btn
+        | {{ showAssetCaption ? 'HIDE CAPTION' : 'SHOW CAPTION' }}
+      .quiz-browse-cntnr(*ngIf="quizMode")
+        i.icon.icon-direction.icon-left([class.disabled]="!quizShuffle && assetNumber <= 1 ? true : false", title="Previous in results", (tap)="showPrevAsset()")
+        i.icon.icon-direction.icon-right([class.disabled]="!quizShuffle && assetNumber >= totalAssetCount - restrictedAssetsCount ? true: false", title="Next in results", (tap)="showNextAsset()")
+      .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", (tap)="toggleQuizShuffle()", title="Toggle Asset Suffle")
+        span.shuffle-btn
+        | SHUFFLE {{ quizShuffle ? 'ON' : 'OFF' }}
+      .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", (tap)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
+        span.quiz-btn
+        | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
     //- Asset Metadata Column
     .col-md-4(*ngIf="assets[0] && !isFullscreen")
       .py-3
@@ -332,37 +332,6 @@
                 button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
                 button.btn.btn-primary(type="submit", [class.loading]="isProcessing", tabindex="6") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
-    .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-      button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
-          | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
-          i.icon.icon-compare
-      button.btn.btn-light(
-          type="button",
-          (click)="exitPresentationMode()",
-          aria-label="Close",
-          title="Exit Fullscreen"
-        )
-        | Exit
-        .icon.icon-exit-fullscreen
-    //- Asset Drawer
-    .asset-drawer(*ngIf="isFullscreen", [class.slideOut]="showAssetDrawer && isFullscreen")
-      .col-sm-12
-        h3.asset-drawer__header((click)="toggleAssetDrawer(!showAssetDrawer)")
-          button.asset-drawer__close.pr-1(
-            *ngIf="isFullscreen",
-            type="button",
-            aria-label="Close",
-            style="float:left;"
-          )
-            .icon.icon-right
-          | COMPARE
-        .text-center
-          pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
-        div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
-          .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
-        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)")
-        .text-center.pt-2
-          pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 ang-agree-modal(
   *ngIf="showAgreeModal",
   (closeModal)="showAgreeModal = false",

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1893,7 +1893,6 @@ export class AssetPage implements OnInit, OnDestroy {
 
   private setFocusToArrow(): void {
     let edgeArrowElement: HTMLElement = <HTMLElement>document.getElementsByClassName("asset-viewer__edge-arrows")[0]
-    console.log(edgeArrowElement)
     edgeArrowElement.focus()
   }
 

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -1891,6 +1891,19 @@ export class AssetPage implements OnInit, OnDestroy {
     return index
   }
 
+  private setFocusToArrow(): void {
+    let edgeArrowElement: HTMLElement = <HTMLElement>document.getElementsByClassName("asset-viewer__edge-arrows")[0]
+    console.log(edgeArrowElement)
+    edgeArrowElement.focus()
+  }
+
+  private setFocusToCanvas(): void {
+    let referenceStripThumbs = document.getElementsByClassName("openseadragon-container")
+    let firstThumbEl: HTMLElement = <HTMLElement>(referenceStripThumbs.item(0))
+    firstThumbEl.tabIndex = -1
+    firstThumbEl.focus()
+  }
+
   public updatePrimaryAssetZoom(): void {
     this.assets[0].zoom = this.indexZoomMap[0]
   }

--- a/src/app/shared/footer/footer.component.pug
+++ b/src/app/shared/footer/footer.component.pug
@@ -1,4 +1,4 @@
-.container-fluid
+.container-fluid(*ngIf="!isFullscreen")
   .footer.row
     .container
       .row

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -91,21 +91,25 @@ export class Footer {
 
 
     document.addEventListener("fullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("mozfullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("webkitfullscreenchange",() => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("msfullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
 
+  }
+
+  private toggleFullscreen(): void {
+    this.isFullscreen = !this.isFullscreen
   }
 
   private logout(): void {

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -25,6 +25,7 @@ export class Footer {
   private subscriptions: Subscription[] = []
   private user: any = {}
   private browseSec: { [key: string]: boolean } = {}
+  private isFullscreen: boolean = false
 
   // TypeScript public modifiers
   constructor(
@@ -87,6 +88,23 @@ export class Footer {
         }
       }, 1000)
     }
+
+
+    document.addEventListener("fullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("mozfullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("webkitfullscreenchange",() => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("msfullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
 
   }
 

--- a/src/app/shared/nav/nav.component.pug
+++ b/src/app/shared/nav/nav.component.pug
@@ -1,4 +1,4 @@
-header.navbar.navbar-light
+header.navbar.navbar-light(*ngIf="!isFullscreen")
   .container(style="padding:0px;")
     .row.fit
       .col-8

--- a/src/app/shared/nav/nav.component.ts
+++ b/src/app/shared/nav/nav.component.ts
@@ -165,20 +165,25 @@ export class Nav implements OnInit, OnDestroy {
     this.hideLoginTooltip = !!this._storage.getSession('hideLoginTooltip');
 
     document.addEventListener("fullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("mozfullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("webkitfullscreenchange",() => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
   
     document.addEventListener("msfullscreenchange", () => {
-      this.isFullscreen = !this.isFullscreen
+      this.toggleFullscreen();
     }, false);
+
+  }
+
+  private toggleFullscreen(): void {
+    this.isFullscreen = !this.isFullscreen
   }
 
   ngOnDestroy() {

--- a/src/app/shared/nav/nav.component.ts
+++ b/src/app/shared/nav/nav.component.ts
@@ -34,6 +34,7 @@ export class Nav implements OnInit, OnDestroy {
   private appConfig: any
 
   private ipAuthed: boolean = false
+  private isFullscreen: boolean = false
 
   // Flag display (dev)
   public showAppliedFlags: boolean = false
@@ -162,6 +163,22 @@ export class Nav implements OnInit, OnDestroy {
     );
 
     this.hideLoginTooltip = !!this._storage.getSession('hideLoginTooltip');
+
+    document.addEventListener("fullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("mozfullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("webkitfullscreenchange",() => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
+  
+    document.addEventListener("msfullscreenchange", () => {
+      this.isFullscreen = !this.isFullscreen
+    }, false);
   }
 
   ngOnDestroy() {

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -132,7 +132,7 @@ $iconBtnSize: $btnHeight;
      background: rgba(255, 255, 255, 0.98);
      color: #333;
 
-     &:hover, &:active {
+     &:hover, &:active, &:focus {
          background: $btnLinkHoverBg;
      }
 

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -14,45 +14,45 @@ $btnHeight: 30px;
 $iconBtnSize: $btnHeight;
 
 .btn, a.btn {
-     @extend %Graphik-Bold-Web;
-     color: #fff;
-     font-size: 12px;
-     padding: 0 24px;
-     text-transform: uppercase;
-     letter-spacing: 0.5px;
-     border-bottom: none;
-     cursor: pointer;
-     height: $btnHeight;
-     line-height: $btnHeight;
+    @extend %Graphik-Bold-Web;
+    color: #fff;
+    font-size: 12px;
+    padding: 0 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: none;
+    cursor: pointer;
+    height: $btnHeight;
+    line-height: $btnHeight;
 
-     &:hover, &:focus, &:active {
+    &:hover, &:focus, &:active {
         color: #fff;
         border-bottom: none;
-     }
+    }
 
-     &.disabled, &:disabled {
-         pointer-events: none;
-         opacity: 0.4;
-         -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+    &.disabled, &:disabled {
+        pointer-events: none;
+        opacity: 0.4;
+        -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
         filter: grayscale(100%);
-     }
+    }
 
-     .show-on-hover {
-         display: none;
-     }
+    .show-on-hover {
+        display: none;
+    }
 
-     &:hover .hide-on-hover {
-         display: none;
-     }
+    &:hover .hide-on-hover {
+        display: none;
+    }
 
-     &:hover .show-on-hover {
-         display: inline;
+    &:hover .show-on-hover {
+        display: inline;
 
-         &.tooltip {
-             display: block;
-             opacity: 0.9;
-         }
-     }
+        &.tooltip {
+            display: block;
+            opacity: 0.9;
+        }
+    }
 }
 
 
@@ -94,7 +94,7 @@ $iconBtnSize: $btnHeight;
 }
 
 
- .btn-secondary, a.btn-secondary {
+.btn-secondary, a.btn-secondary {
     background: white;
     border: solid 1px $orange;
     color: $orange;
@@ -123,38 +123,38 @@ $iconBtnSize: $btnHeight;
     }
 }
 
- .btn-dark {
-     background: #2d2d2d;
-     color: #fff;
- }
+.btn-dark {
+    background: #2d2d2d;
+    color: #fff;
+}
 
- .btn-light {
-     background: rgba(255, 255, 255, 0.98);
-     color: #333;
+.btn-light {
+    background: rgba(255, 255, 255, 0.98);
+    color: #333;
 
-     &:hover, &:active, &:focus {
+    &:hover, &:active, &:focus {
         background: $btnLinkHoverBg;
         outline: -webkit-focus-ring-color auto 5px !important;
-     }
+    }
 
-     &::-moz-focusring {
+    &:-moz-focusring {
         outline: auto 2px Highlight !important;
-     }
+    }
 
-     &:hover, &:active, &:focus, &:visited {
-         color: #000;
-     }
- }
+    &:hover, &:active, &:focus, &:visited {
+        color: #000;
+    }
+}
 
- .btn:not(.btn--icon) > .icon {
+.btn:not(.btn--icon) > .icon {
     margin: 0 0.5em;
     width: 1.2em;
     height: 1.2em;
     vertical-align: middle;
     transform: translateY(-0.1em);
- }
+}
 
- .btn.btn-link, a.btn.btn-link {
+.btn.btn-link, a.btn.btn-link {
      text-transform: none !important;
      padding: 0 6px 0 0;
      color: #000;
@@ -202,18 +202,18 @@ $iconBtnSize: $btnHeight;
     }
 
 
-     & .value {
-         color: #000;
-         letter-spacing: 0;
-         font-weight: normal;
-     }
- }
+    & .value {
+        color: #000;
+        letter-spacing: 0;
+        font-weight: normal;
+    }
+}
 
- .btn.dropdown-toggle {
-     padding-right: 10px;
- }
+.btn.dropdown-toggle {
+    padding-right: 10px;
+}
 
- .btn.loading {
+.btn.loading {
     @extend .progress-bar-striped;
     @extend .progress-bar-animated;
     color: rgba(255,255,255,0.5);
@@ -227,9 +227,9 @@ $iconBtnSize: $btnHeight;
     &:after {
         display: none !important;
     }
- }
+}
 
- $btnBorderRadius: 4px;
+$btnBorderRadius: 4px;
 
 .btn.btn--square {
     height: $iconBtnSize;
@@ -237,7 +237,7 @@ $iconBtnSize: $btnHeight;
     padding: 0;
 }
 
- .btn.btn--icon {
+.btn.btn--icon {
     position: relative;
     cursor: pointer;
     border-radius: $btnBorderRadius;
@@ -271,32 +271,32 @@ $iconBtnSize: $btnHeight;
     &.active {
         background: rgb(200,200,200);
     }
- }
+}
 
- .button-group {
-     & .btn {
-         border-radius: 0;
-         margin: 0;
-         border-right: 1px solid rgba(0,0,0,0.05);
+.button-group {
+    & .btn {
+        border-radius: 0;
+        margin: 0;
+        border-right: 1px solid rgba(0,0,0,0.05);
 
-         &:first-of-type {
-             border-top-left-radius: $btnBorderRadius;
-             border-bottom-left-radius: $btnBorderRadius;
-         }
+        &:first-of-type {
+            border-top-left-radius: $btnBorderRadius;
+            border-bottom-left-radius: $btnBorderRadius;
+        }
 
-         &:last-of-type {
-             border-top-right-radius: $btnBorderRadius;
-             border-bottom-right-radius: $btnBorderRadius;
-             border-right: 0 solid transparent;
-         }
-     }
- }
+        &:last-of-type {
+            border-top-right-radius: $btnBorderRadius;
+            border-bottom-right-radius: $btnBorderRadius;
+            border-right: 0 solid transparent;
+        }
+    }
+}
 
- .btn-row {
-     // White space fix
-     font-size: 0;
+.btn-row {
+    // White space fix
+    font-size: 0;
 
-     & .btn {
-         margin: 4px;
-     }
- }
+    & .btn {
+        margin: 4px;
+    }
+}

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -133,7 +133,9 @@ $iconBtnSize: $btnHeight;
      color: #333;
 
      &:hover, &:active, &:focus {
-         background: $btnLinkHoverBg;
+        background: $btnLinkHoverBg;
+        outline: -webkit-focus-ring-color auto 5px !important;
+        outline: auto 2px Highlight !important;
      }
 
      &:hover, &:active, &:focus, &:visited {

--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -135,6 +135,9 @@ $iconBtnSize: $btnHeight;
      &:hover, &:active, &:focus {
         background: $btnLinkHoverBg;
         outline: -webkit-focus-ring-color auto 5px !important;
+     }
+
+     &::-moz-focusring {
         outline: auto 2px Highlight !important;
      }
 

--- a/src/sass/modules/_viewer.scss
+++ b/src/sass/modules/_viewer.scss
@@ -5,8 +5,15 @@
     cursor: move;
 
     &:focus {
-        outline: auto 2px Highlight !important;
         outline: -webkit-focus-ring-color auto 15px !important;
+    }
+}
+
+.referencestrip > div > .openseadragon-container > .openseadragon-canvas {
+    opacity: 0.5 !important;
+
+    &:focus {
+        opacity: 1 !important;
     }
 }
 

--- a/src/sass/modules/_viewer.scss
+++ b/src/sass/modules/_viewer.scss
@@ -3,6 +3,10 @@
 .openseadragon-canvas {
     outline: none !important;
     cursor: move;
+
+    &:focus {
+        outline: -webkit-focus-ring-color auto 15px !important;
+    }
 }
 
 .osd-wrap > .openseadragon-container {

--- a/src/sass/modules/_viewer.scss
+++ b/src/sass/modules/_viewer.scss
@@ -5,6 +5,7 @@
     cursor: move;
 
     &:focus {
+        outline: auto 2px Highlight !important;
         outline: -webkit-focus-ring-color auto 15px !important;
     }
 }


### PR DESCRIPTION
 - Prevent elements that are invisible in the viewer from getting focus
    - skip to main content link
    - nav menu
    -  footer
    -  thumbnails in the drawer when the drawer is not open
 - Set visible blue border when element gets focused
 - Hide pagination button for first and last page
 - Manually add event listeners to thumbnails in the reference strip to allow `page` event when hitting enter key
 - Set up correct tab order in the viewer (for fullscreen)
    1. Main canvas
    2. Zoom in, zoom out, fit to view
    3. Compare, exit
    4. Page arrows
    5. Thumbnails in the reference strip if it is multi-view
    6. Pagination buttons
    7. Hide caption, quiz mode toggle button