### PR TITLE
PALS-136: Activate User Idle timeout functionality in Artstor

### DIFF
--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -263,6 +263,7 @@ export class AuthService implements CanActivate {
 
   // Reset the idle watcher
   public resetIdleWatcher(): void {
+    
     this.idle.watch();
     // When a user comes back, we don't want to wait for the time interval to refresh the session
     this.refreshUserSession(true)

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -206,7 +206,7 @@ export class AuthService implements CanActivate {
        * - Poll /userinfo every 15min
        * - Refreshs AccessToken with IAC
        */
-      const userInfoInterval = 15 * 1000 * 60
+      const userInfoInterval = .5 * 1000 * 60
       // Run every X mins
       setInterval(() => {
         this.refreshUserSession(true)
@@ -230,6 +230,7 @@ export class AuthService implements CanActivate {
 
      this.idle.onIdleEnd.pipe(
        map(() => {
+         console.log("idle end")
          this.idleState = 'No longer idle.';
          // We want to ensure a user is refreshed as soon as they return to the tab
          this.refreshUserSession(true)
@@ -237,6 +238,7 @@ export class AuthService implements CanActivate {
 
      this.idle.onTimeout.pipe(
        map(() => {
+         console.log("Timed out!")
          let user = this.getUser();
          // console.log(user);
          if (user && user.isLoggedIn){
@@ -251,6 +253,7 @@ export class AuthService implements CanActivate {
 
      this.idle.onIdleStart.pipe(
        map(() => {
+         console.log("idle start!")
          this.idleState = 'You\'ve gone idle!';
          let currentDateTime = new Date().toUTCString();
          this._storage.setLocal('userGoneIdleAt', currentDateTime);

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -263,7 +263,6 @@ export class AuthService implements CanActivate {
 
   // Reset the idle watcher
   public resetIdleWatcher(): void {
-    
     this.idle.watch();
     // When a user comes back, we don't want to wait for the time interval to refresh the session
     this.refreshUserSession(true)

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -15,7 +15,7 @@ import { AppConfig } from '../app.service'
 
 // For session timeout management
 import { IdleWatcherUtil } from 'shared/idle-watcher'
-import { Idle, DEFAULT_INTERRUPTSOURCES, EventTargetInterruptSource} from '@ng-idle/core'
+import { Idle, EventTargetInterruptSource} from '@ng-idle/core'
 import { ArtstorStorageService } from '../../../projects/artstor-storage/src/public_api'
 import { Angulartics2 } from 'angulartics2'
 import { environment } from 'environments/environment'
@@ -80,11 +80,6 @@ export class AuthService implements CanActivate {
     private injector: Injector,
     private angulartics: Angulartics2
   ) {
-
-    // For session timeout on user inactivity
-    this.idle.setIdle(IdleWatcherUtil.generateIdleTime()); // Set an idle time of 1 min, before starting to watch for timeout
-    this.idle.setTimeout(IdleWatcherUtil.generateSessionLength()); // Log user out after 90 mins of inactivity
-    this.idle.setInterrupts([new EventTargetInterruptSource(window, 'mousemove keydown DOMMouseScroll mousewheel mousedown touchstart touchmove scroll')]);
 
     this.isBrowser = isPlatformBrowser(this.platformId)
     // Set WLV and App Config variables
@@ -212,7 +207,7 @@ export class AuthService implements CanActivate {
        * - Poll /userinfo every 15min
        * - Refreshs AccessToken with IAC
        */
-      const userInfoInterval = .5 * 1000 * 60
+      const userInfoInterval = 15 * 1000 * 60
       // Run every X mins
       setInterval(() => {
         this.refreshUserSession(true)
@@ -229,6 +224,11 @@ export class AuthService implements CanActivate {
   }
 
   public initIdleWatcher(): void {
+
+    // For session timeout on user inactivity
+    this.idle.setIdle(IdleWatcherUtil.generateIdleTime()); // Set an idle time of 1 min, before starting to watch for timeout
+    this.idle.setTimeout(IdleWatcherUtil.generateSessionLength()); // Log user out after 90 mins of inactivity
+    this.idle.setInterrupts([new EventTargetInterruptSource(window, 'mousemove keydown DOMMouseScroll mousewheel mousedown touchstart touchmove scroll')]);
 
      this.idle.onIdleEnd.subscribe(() => {
          console.log("idle end")

--- a/src/app/shared/idle-watcher.ts
+++ b/src/app/shared/idle-watcher.ts
@@ -6,7 +6,7 @@ export class IdleWatcherUtil {
    */
   public static generateSessionLength(): number {
 
-    let sessionLengthInMins: number = 1
+    let sessionLengthInMins: number = 90
     let sessionLengthInSecs: number = sessionLengthInMins * 60
 
     return sessionLengthInSecs;

--- a/src/app/shared/idle-watcher.ts
+++ b/src/app/shared/idle-watcher.ts
@@ -6,7 +6,7 @@ export class IdleWatcherUtil {
    */
   public static generateSessionLength(): number {
 
-    let sessionLengthInMins: number = 90
+    let sessionLengthInMins: number = 2
     let sessionLengthInSecs: number = sessionLengthInMins * 60
 
     return sessionLengthInSecs;

--- a/src/app/shared/idle-watcher.ts
+++ b/src/app/shared/idle-watcher.ts
@@ -6,7 +6,7 @@ export class IdleWatcherUtil {
    */
   public static generateSessionLength(): number {
 
-    let sessionLengthInMins: number = 2
+    let sessionLengthInMins: number = 1
     let sessionLengthInSecs: number = sessionLengthInMins * 60
 
     return sessionLengthInSecs;


### PR DESCRIPTION
Resolves PALS-136: user idle timeout issue

Whenever the user is idle for more than 90 minutes, we will logout the user by expiring the session.

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable

**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable