### PR TITLE
PLATO-486: Remove inactive button in artstor viewer

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -21,8 +21,8 @@
     <div class="pdf-viewer-container" *ngIf="state == 6">
         <pdf-viewer [src]="pdfViewerOpts" [original-size]="false" [render-text]="true" [autoresize]="true" [show-all]="false" [page]="pdfCurrentPage" [zoom]="pdfZoomValue" (after-load-complete)="onPdfLoad($event)" (error)="onPdfError($event)"></pdf-viewer>
         <div class="asset-viewer__edge-arrows">
-            <button class="btn btn--icon btn--prev" [class.disabled]="pdfCurrentPage === 1" (click)="pdfPrevPage()"><i class="icon icon-prev--white"></i></button>
-            <button class="btn btn--icon btn--next" [class.disabled]="pdfCurrentPage === pdfTotalPages" (click)="pdfNextPage()"><i class="icon icon-next--white"></i></button>
+            <button class="btn btn--icon btn--prev" [class.aiw-hidden]="pdfCurrentPage === 1" (click)="pdfPrevPage()"><i class="icon icon-prev--white"></i></button>
+            <button class="btn btn--icon btn--next" [class.aiw-hidden]="pdfCurrentPage === pdfTotalPages" (click)="pdfNextPage()"><i class="icon icon-next--white"></i></button>
         </div>
         <div class="page-info">Page <b>{{ pdfCurrentPage }}</b> / <b>{{ pdfTotalPages }}</b></div>
     </div>
@@ -49,20 +49,23 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == 1" class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId }}"><i class="icon icon-prev--white"></i></button>
+            <button [class.aiw-hidden]="multiViewPage == multiViewCount" class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId }}"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
         <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
         <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
         </div>
         <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" (click)="prevPage.emit()"></i>
-            <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" (click)="nextPage.emit()"></i>
-            <div class="meta-block small">
-            <div class="creator" [innerHtml]="asset.creator"></div>
-            <div class="date" [innerHtml]="asset.date"></div>
+            <div class="vertical-center-wrap">
+                <i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber > 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+                <div class="title" [innerHtml]="asset.title"></div>
+                <i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode && assetNumber < assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()" (keydown.tab)="setFocusToCtrBtns()"></i>
+                <div class="meta-block small">
+                    <div class="creator" [innerHtml]="asset.creator"></div>
+                    <div class="date" [innerHtml]="asset.date"></div>
+                </div>
             </div>
-        </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
 - For first image in the collection, do not show the `previous` button
 - For last image in the collection, do not show the `next` button