### PR TITLE
PLATO-487: Make thumbnails in the reference strip accessible with keyboard

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -406,6 +406,20 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             this.osdViewer.destroy();
         });
 
+        this.osdViewer.addOnceHandler("tile-drawn", () => {
+            // Get all canvas elements, first one is the main canvas, second one is the navigator
+            // The canvas in the reference strip starts as the third one in the collection
+            let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+            // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
+            for (let i = 2; i < canvasElements.length; i++) {
+                canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
+                    if (event.keyCode === 13) {
+                        this.osdViewer.goToPage(i-2)
+                    }
+                })
+            }
+        })
+
         this.osdViewer.addHandler('pan', (value: any) => {
             // Save viewport pan for downloading the view
             this.asset.viewportDimensions.center = value.center

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,14 +407,13 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
-            // Get all canvas elements, first one is the main canvas, second one is the navigator
-            // The canvas in the reference strip starts as the third one in the collection
-            let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+            // Get all thumbnails in the reference strip
+            let canvasElements = document.querySelectorAll(".referencestrip > div > .openseadragon-container > .openseadragon-canvas");
             // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
-            for (let i = 2; i < canvasElements.length; i++) {
+            for (let i = 0; i < canvasElements.length; i++) {
                 canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
                     if (event.keyCode === 13) {
-                        this.osdViewer.goToPage(i-2)
+                        this.osdViewer.goToPage(i)
                     }
                 })
             }


### PR DESCRIPTION
Add event listeners to thumbnails in the reference strip so that hitting enter on the thumbnail will paginate to that image.

Note: there is a hardcoded `i-2` because the first element with `openseadragon-canvas` class will always be the main canvas, the second element will be the navigator (this is true even in fullscreen mode where we don't show the navigator). The thumbnails start with the third element in the collection. And it is true in compare mode, too.