### PR TITLE
SRCHX-230: Avoid screen readers from reading thumbnail info twice.

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -1,4 +1,4 @@
-.card-block.card-text(tabindex="3", [attr.aria-label]="thumbnail.name + ', '  + thumbnail.agent + ', ' + thumbnail.date", [attr.id]="('item-' + itemIndex)", [ngClass]="{ 'reorder--asset' : arrowReorderMode }")
+.card-block.card-text(role="link", tabindex="3", [attr.aria-label]="thumbnail.name + ', '  + thumbnail.agent + ', ' + thumbnail.date", [attr.id]="('item-' + itemIndex)", [ngClass]="{ 'reorder--asset' : arrowReorderMode }")
   .card-img-top
     //- Thumbnail Image
     img(*ngIf="src", id="{{thumbnail.id}}", [class.disablePointerEvents]="reorderMode", [attr.src]="src", (error)="thumbnailError()", [attr.alt]="thumbnailAlt", [attr.title]="thumbnailAlt", aria-role="image")


### PR DESCRIPTION
Changing role to `link` for wrapper `.card` element in thumbnail component would prevent the screen readers to read the parent thumbnail info, once the focus is on the first child element.