### PR TITLE
PLATO-488: Create correct tab order for Artstor viewer

### DIFF
--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -94,6 +94,15 @@ export class ToolboxService {
                 wscript.SendKeys("{F11}");
             }
         }
+        this.setFocusToCanvas();
+    }
+
+    /**
+     * Set focus to the main canvas in the viewer
+     */
+    private setFocusToCanvas(): void {
+        let canvasElement: HTMLElement = <HTMLElement>document.getElementsByClassName('openseadragon-canvas')[0];
+        canvasElement && canvasElement.focus();
     }
 
     /**

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -29,10 +29,10 @@
     <!--Viewer Buttons-->
     <div *ngIf="!thumbnailMode">
       <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
-        <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
-        <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
-        <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
+        <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom" tabindex="1"><i class="icon icon-zoom-in"></i></button>
+        <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom" tabindex="1"><i class="icon icon-zoom-out"></i></button>
+        <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom" tabindex="1"><i class="icon icon-fit-to-view"></i></button>
+        <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom" tabindex="1"><i class="icon icon-present"></i></button>
         <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
       </div>
 
@@ -49,15 +49,15 @@
         </div> -->
         <!-- Edge pagination arrow style -->
         <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
+        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}" tabindex="3"><i class="icon icon-prev--white"></i></button><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}" tabindex="3"><i class="icon icon-next--white"></i></button>
         </div>
         <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
         <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
         <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
         </div>
         <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
-            <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
+        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="5" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+            <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="5" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
             <div class="meta-block small">
             <div class="creator" [innerHtml]="asset.creator"></div>
             <div class="date" [innerHtml]="asset.date"></div>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,6 +407,9 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
+            let mainCanvasElement = document.getElementsByClassName("openseadragon-canvas")[0];
+            mainCanvasElement.setAttribute("tabindex", "1")
+            
             // Get all thumbnails in the reference strip
             let canvasElements = document.querySelectorAll(".referencestrip > div > .openseadragon-container > .openseadragon-canvas");
             // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
@@ -416,6 +419,7 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
                         this.osdViewer.goToPage(i)
                     }
                 })
+                canvasElements.item(i).setAttribute("tabindex", "4")
             }
         })
 

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -74,16 +74,16 @@
 
       .col-md-12.quiz-caption-cntnr(*ngIf="isFullscreen", [ngClass]="[ showAssetCaption ? '' : 'cntnr-bg' ]")
         ang-promo-tooltip(*ngIf="user.isLoggedIn && !quizModeTTDismissed && studyMode", [options]="quizModeTooltipOpts", (close)="closeQuizModeTooltip()")
-        .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", tabindex="0", (click)="showAssetCaption = !showAssetCaption", (keydown.enter)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
+        .caption-btn-cntnr([ngClass]="[ showAssetCaption ? 'active' : '' ]", tabindex="6", (click)="showAssetCaption = !showAssetCaption", (keydown.enter)="showAssetCaption = !showAssetCaption", title="{{ showAssetCaption ? 'Hide Asset Meta Information' : 'Show Asset Meta Information' }}")
           span.caption-btn
           | {{ showAssetCaption ? 'HIDE CAPTION' : 'SHOW CAPTION' }}
         .quiz-browse-cntnr(*ngIf="quizMode")
           i.icon.icon-direction.icon-left([class.disabled]="!quizShuffle && assetNumber <= 1 ? true : false", title="Previous in results", tabindex="0", (tap)="showPrevAsset()", (keydown.enter)="showPrevAsset()")
           i.icon.icon-direction.icon-right([class.disabled]="!quizShuffle && assetNumber >= totalAssetCount - restrictedAssetsCount ? true: false", title="Next in results", tabindex="0", (tap)="showNextAsset()", (keydown.enter)="showNextAsset()")
-        .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", tabindex="0", (tap)="toggleQuizShuffle()", (keydown.enter)="toggleQuizShuffle()", title="Toggle Asset Suffle")
+        .shuffle-cntnr(*ngIf="quizMode", [ngClass]="[ quizShuffle ? 'active' : '' ]", tabindex="6", (tap)="toggleQuizShuffle()", (keydown.enter)="toggleQuizShuffle()", title="Toggle Asset Suffle")
           span.shuffle-btn
           | SHUFFLE {{ quizShuffle ? 'ON' : 'OFF' }}
-        .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", tabindex="0", (tap)="toggleQuizMode()", (keydown.enter)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
+        .quiz-cntnr([ngClass]="[ quizMode ? 'active' : '' ]", tabindex="6", (tap)="toggleQuizMode()", (keydown.enter)="toggleQuizMode()", title="{{ quizMode ? 'Deactivate Quiz Mode' : 'Activate Quiz Mode' }}")
           span.quiz-btn
           | QUIZ MODE {{ quizMode ? 'ON' : 'OFF' }}
     //- Asset Metadata Column
@@ -93,24 +93,24 @@
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
-          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="2", aria-label="Edit details for this item")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="7", aria-label="Edit details for this item")
             | {{ 'ASSET_PAGE.BUTTONS.EDIT_DETAILS' | translate}}
           //- the .driver-find-group-btn class is important for the tour to find it, be careful when removing or changing it
           .dropdown.d-inline-block.driver-find-group-btn(ngbDropdown, aria-haspopup="true")
-            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, tabindex="2", aria-label="Add to groups")
+            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, tabindex="7", aria-label="Add to groups")
               | {{ 'ASSET_PAGE.BUTTONS.ADD_TO_GROUP' | translate}}
               = " "
             .dropdown-menu(ngbDropdownMenu)
               a#addItemToGroupLink.dropdown-item(
                 (click)="addAssetToIG()",
-                tabindex="2",
+                tabindex="7",
                 aria-label="Add Item to Group",
                 role="button")
                 i.icon.icon-add-item
                 | &nbsp;Add item
               a#addViewToGroupLink.dropdown-item(
                 (click)="addAssetToIG(true)",
-                tabindex="2",
+                tabindex="7",
                 aria-label="Add View to Group",
                 [class.disabled]="assetViewer.state !== 1 || multiviewItems",
                 role="button")
@@ -118,7 +118,7 @@
                 | &nbsp;Add detail view
           //- Download dropdown options
           .dropdown.d-inline-block(ngbDropdown, *ngIf="assets[0].downloadLink && (user.isLoggedIn || hasExternalAccess || assets[0].publicDownload)", triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
-            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
+            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="7", aria-label="Download")
               | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
               = " "
             .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
@@ -132,7 +132,7 @@
                 [class.disabled]="assets[0].disableDownload",
                 title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
                 target="_blank",
-                tabindex="2",
+                tabindex="7",
                 aria-label="Download item",
                 role="button")
                 i.icon.icon-download
@@ -144,26 +144,26 @@
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_blank",
-                tabindex="2",
+                tabindex="7",
                 aria-label="Download item’s detail view",
                 role="button")
                 i.icon.icon-download-detail-view
                 | &nbsp;Download detail view
           //- False door button if user is not logged in
-          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="7", aria-label="Download")
             | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
             i#downloadAssetLink.icon.icon-download-asset-orange
           .row#asset-btn
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="7", aria-label="Cite this item", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="2", aria-label="See this item in print preview", role="button")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="7", aria-label="See this item in print preview", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.PRINT' | translate}}
 
           //- Copy URL
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
-            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
+            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="7", aria-label="Item URL")
+            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="7", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 
@@ -239,9 +239,9 @@
               .value([innerHtml]="assets[0].SSID", aria-labelledby="ssid")
           //- IAP and Report Error
           .text-left.pt-2
-            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", tabindex="8", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
-            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", tabindex="14", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
-            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
+            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
+            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
 
         //- Report Error Form, hidden by default
         .mt-2.d-none([class.d-block]="showEditDetails")
@@ -252,47 +252,48 @@
             .form-body
               .form-group
                 label(for="creatorInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.CREATOR' | translate }}
-                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false", tabindex="6")
+                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false")
               .form-group
                 label(for="titleInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE' | translate }}
-                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false", tabindex="6")
+                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false")
                 .has-danger(*ngIf="editDetailsFormSubmitted && editDetailsForm.controls['title'].hasError('required')")
                   p.form-control-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE_REQUIRED_MSG' | translate }}
               .form-group
                 label(for="worktypeInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.WORK_TYPE' | translate }}
-                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false", tabindex="6")
+                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false")
               .form-group
                 label(for="dateInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DATE' | translate }}
-                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false", tabindex="6")
+                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false")
               .form-group
                 label(for="locationInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.LOCATION' | translate }}
-                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false", tabindex="6")
+                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false")
               .form-group
                 label(for="materialInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.MATERIAL' | translate }}
-                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false", tabindex="6")
+                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false")
               .form-group
                 label(for="descriptionInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DESCRIPTION' | translate }}
-                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false", tabindex="6")
+                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false")
               .form-group
                 label(for="subjectInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SUBJECT' | translate }}
-                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false", tabindex="6")
+                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false")
               .form-group.has-danger(*ngIf="uiMessages.deleteFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_ERROR' | translate }}
               .form-group.has-danger(*ngIf="uiMessages.saveFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_ERROR' | translate }}
               .btn-row
-                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
-                button.btn.btn-primary(type="submit", [class.loading]="isProcessing", tabindex="6") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
+                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+                button.btn.btn-primary(type="submit", [class.loading]="isProcessing") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
     .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-      button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
+      button.btn.btn-light(*ngIf="!quizMode", tabindex="7", (click)="toggleAssetDrawer(!showAssetDrawer)")
           | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
           i.icon.icon-compare
       button.btn.btn-light(
           type="button",
           (click)="exitPresentationMode()",
           aria-label="Close",
-          title="Exit Fullscreen"
+          title="Exit Fullscreen",
+          tabindex="7"
         )
         | Exit
         .icon.icon-exit-fullscreen

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -285,7 +285,7 @@
                 button.btn.btn-primary(type="submit", [class.loading]="isProcessing") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
     .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-      button.btn.btn-light(*ngIf="!quizMode", tabindex="7", (click)="toggleAssetDrawer(!showAssetDrawer)")
+      button.btn.btn-light(*ngIf="!quizMode", tabindex="2", (click)="toggleAssetDrawer(!showAssetDrawer)")
           | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
           i.icon.icon-compare
       button.btn.btn-light(
@@ -293,7 +293,7 @@
           (click)="exitPresentationMode()",
           aria-label="Close",
           title="Exit Fullscreen",
-          tabindex="7"
+          tabindex="2"
         )
         | Exit
         .icon.icon-exit-fullscreen

--- a/src/app/collection-badge/collection-badge.component.pug
+++ b/src/app/collection-badge/collection-badge.component.pug
@@ -6,7 +6,7 @@
   placement="right",
   aria-haspopup="true",
   [attr.aria-label]="collectionType.alt",
-  tabindex="3"
+  tabindex="0"
 ) {{ collectionType.badgeText }}
 <ng-template #tipContent>
   div([innerHtml]="collectionType.alt")


### PR DESCRIPTION
- In fullscreen mode, the tab order is:
   - Main canvas
   - Zoom in, zoom out, fit to view
   - Compare, exit
   - Page arrows
   - Thumbnails in the reference strip if it is multi-view
   - Pagination buttons
   - Hide caption, quiz mode toggle button
- Make sure the newly added `tabindex` doesn't interfere the original tab order in non-fullscreen mode