### PR TITLE
PLATO-488: Fix tab ordering of the viewer

### DIFF
--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -94,15 +94,15 @@ export class ToolboxService {
                 wscript.SendKeys("{F11}");
             }
         }
-        this.setFocusToZoomBtm();
+        this.setFocusToZoomBtn();
     }
 
     /**
      * Set focus to the zoom button in the viewer
      */
-    private setFocusToZoomBtm(): void {
-        let canvasElement: HTMLElement = <HTMLElement>document.getElementsByClassName('asset-viewer__buttons')[0];
-        canvasElement && canvasElement.focus();
+    private setFocusToZoomBtn(): void {
+        let zoomInButton: HTMLElement = <HTMLElement>document.getElementsByClassName('btn--zoomIn')[0];
+      zoomInButton && zoomInButton.focus();
     }
 
     /**

--- a/src/app/_services/toolbox.service.ts
+++ b/src/app/_services/toolbox.service.ts
@@ -94,6 +94,15 @@ export class ToolboxService {
                 wscript.SendKeys("{F11}");
             }
         }
+        this.setFocusToZoomBtm();
+    }
+
+    /**
+     * Set focus to the zoom button in the viewer
+     */
+    private setFocusToZoomBtm(): void {
+        let canvasElement: HTMLElement = <HTMLElement>document.getElementsByClassName('asset-viewer__buttons')[0];
+        canvasElement && canvasElement.focus();
     }
 
     /**

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -1,4 +1,45 @@
 <div class="asset-viewer" [class.fullscreen]="isFullscreen" [class.multi-view]="isMultiView" (contextmenu)="disableContextMenu($event)">
+  <!--Viewer Buttons-->
+  <div *ngIf="!thumbnailMode">
+    <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
+      <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
+      <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
+      <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
+      <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
+      <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
+    </div>
+
+    <ng-template #zoomInTooltip><div>Zoom in</div></ng-template>
+    <ng-template #zoomOutTooltip><div>Zoom out</div></ng-template>
+    <ng-template #fitToViewTooltip><div>Fit to view</div></ng-template>
+    <ng-template #presentTooltip><div>Present</div></ng-template>
+    <ng-template #removeCompTooltip><div>Remove from<br>comparison</div></ng-template>
+
+    <!-- Hide if not multi view (do not use ngIf, OSD needs to bind) -->
+    <!-- Bottom right arrow style -->
+    <!-- <div [class.aiw-hidden]="!isMultiView" class="button-group asset-viewer__pagination" id="imagePageButtons-{{ osdViewerId }}">
+    <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><</button><span class="btn-divider"></span><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}">></button>
+    </div> -->
+    <!-- Edge pagination arrow style -->
+    <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
+      <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}" [class.aiw-hidden]="multiViewPage == 1"><i class="icon icon-prev--white"></i></button>
+      <button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}" [class.aiw-hidden]="multiViewPage == multiViewCount"><i class="icon icon-next--white"></i></button>
+    </div>
+    <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
+      <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
+      <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
+    </div>
+    <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
+      <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+        <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
+        <div class="meta-block small">
+          <div class="creator" [innerHtml]="asset.creator"></div>
+          <div class="date" [innerHtml]="asset.date"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
     <!-- Large thumbnail fallback
         - Thumbnail is always showing, and hidden by other viewers placed on top
         - This allows search crawlers to find the thumbnail
@@ -25,44 +66,5 @@
             <button class="btn btn--icon btn--next" [class.disabled]="pdfCurrentPage === pdfTotalPages" (click)="pdfNextPage()"><i class="icon icon-next--white"></i></button>
         </div>
         <div class="page-info">Page <b>{{ pdfCurrentPage }}</b> / <b>{{ pdfTotalPages }}</b></div>
-    </div>
-    <!--Viewer Buttons-->
-    <div *ngIf="!thumbnailMode">
-      <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
-        <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
-        <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
-        <button class="btn btn--icon btn--fullScreen" [class.standalone-present-icon]="state != 1" *ngIf="!isFullscreen" id="fullScreen-{{ osdViewerId }}" aria-label="Full screen" (click)="togglePresentationMode()" [ngbTooltip]="presentTooltip" placement="bottom"><i class="icon icon-present"></i></button>
-        <button class="btn btn--icon" [class.standalone-remove-icon]="state != 1" *ngIf="isFullscreen && assetCompareCount > 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison" [ngbTooltip]="removeCompTooltip" placement="bottom"><i class="icon icon-remove-from-comparison"></i></button>
-      </div>
-
-        <ng-template #zoomInTooltip><div>Zoom in</div></ng-template>
-        <ng-template #zoomOutTooltip><div>Zoom out</div></ng-template>
-        <ng-template #fitToViewTooltip><div>Fit to view</div></ng-template>
-        <ng-template #presentTooltip><div>Present</div></ng-template>
-        <ng-template #removeCompTooltip><div>Remove from<br>comparison</div></ng-template>
-
-        <!-- Hide if not multi view (do not use ngIf, OSD needs to bind) -->
-        <!-- Bottom right arrow style -->
-        <!-- <div [class.aiw-hidden]="!isMultiView" class="button-group asset-viewer__pagination" id="imagePageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><</button><span class="btn-divider"></span><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}">></button>
-        </div> -->
-        <!-- Edge pagination arrow style -->
-        <div [class.aiw-hidden]="!isMultiView" class="asset-viewer__edge-arrows" id="imagePageButtons-{{ osdViewerId }}">
-        <button class="btn btn--icon btn--prev" id="previousButton-{{ osdViewerId}}"><i class="icon icon-prev--white"></i></button><button class="btn btn--icon btn--next" id="nextButton-{{ osdViewerId}}"><i class="icon icon-next--white"></i></button>
-        </div>
-        <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
-        <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
-        <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
-        </div>
-        <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
-            <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
-            <div class="meta-block small">
-            <div class="creator" [innerHtml]="asset.creator"></div>
-            <div class="date" [innerHtml]="asset.date"></div>
-            </div>
-        </div>
-        </div>
     </div>
 </div>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -1,7 +1,7 @@
 <div class="asset-viewer" [class.fullscreen]="isFullscreen" [class.multi-view]="isMultiView" (contextmenu)="disableContextMenu($event)">
   <!--Viewer Buttons-->
   <div *ngIf="!thumbnailMode">
-    <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}">
+    <div class="button-group asset-viewer__buttons" id="imageButtons-{{ osdViewerId }}" tabindex="-1">
       <button class="btn btn--icon btn--zoomIn" [class.aiw-hidden]="state != 1" id="zoomIn-{{ osdViewerId}}" [ngbTooltip]="zoomInTooltip" aria-label="Zoom in" placement="bottom"><i class="icon icon-zoom-in"></i></button>
       <button class="btn btn--icon btn--zoomOut" [class.aiw-hidden]="state != 1" id="zoomOut-{{ osdViewerId }}" [ngbTooltip]="zoomOutTooltip" aria-label="Zoom out" placement="bottom"><i class="icon icon-zoom-out"></i></button>
       <button class="btn btn--icon btn--zoomFit" [class.aiw-hidden]="state != 1" id="zoomFit-{{ osdViewerId }}" [ngbTooltip]="fitToViewTooltip" aria-label="Fit to view" placement="bottom"><i class="icon icon-fit-to-view"></i></button>
@@ -28,15 +28,6 @@
     <div *ngIf="isMultiView && assetCompareCount < 4" class="asset-viewer_multi-view-info">
       <b>{{ multiViewPage }}</b> of <b>{{ multiViewCount }}</b>
       <button *ngIf="hasMultiViewHelp()" (click)="multiViewHelp.emit()" class="help-icon">?</button>
-    </div>
-    <div class="fullscreen-metadata" *ngIf="isFullscreen" [class.slideAway]="!showCaption">
-      <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
-        <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
-        <div class="meta-block small">
-          <div class="creator" [innerHtml]="asset.creator"></div>
-          <div class="date" [innerHtml]="asset.date"></div>
-        </div>
-      </div>
     </div>
   </div>
 
@@ -67,4 +58,14 @@
         </div>
         <div class="page-info">Page <b>{{ pdfCurrentPage }}</b> / <b>{{ pdfTotalPages }}</b></div>
     </div>
+
+    <div class="fullscreen-metadata" *ngIf="!thumbnailMode && isFullscreen" [class.slideAway]="!showCaption">
+        <div class="vertical-center-wrap"><i class="icon icon-direction icon-left" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber <= 1" title="Previous in results" tabindex="0" (click)="prevPage.emit()" (keydown.enter)="prevPage.emit()"></i>
+          <div class="title" [innerHtml]="asset.title"></div><i class="icon icon-direction icon-right" *ngIf="assetCompareCount == 1 && !quizMode" [class.disabled]="assetNumber >= assetGroupCount" title="Next in results" tabindex="0" (click)="nextPage.emit()" (keydown.enter)="nextPage.emit()"></i>
+          <div class="meta-block small">
+            <div class="creator" [innerHtml]="asset.creator"></div>
+            <div class="date" [innerHtml]="asset.date"></div>
+          </div>
+        </div>
+      </div>
 </div>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -466,7 +466,7 @@ $desktop: 992px;*/
 background:  #000 !important;
 } */
 
-.referencestrip canvas {
+.referencestrip .openseadragon-canvas {
     opacity: 0.5;
     cursor:  pointer !important;
     -webkit-transition: opacity 250ms ease-in-out;
@@ -483,7 +483,7 @@ background:  #000 !important;
     cursor: default !important;
 }
 
-.referencestrip > div[style^="background: rgb(153, 153, 153)"] canvas, .referencestrip canvas:hover {
+.referencestrip > div[style^="background: rgb(153, 153, 153)"] canvas, .referencestrip .openseadragon-canvas:hover, :focus {
     /* border: 2px solid $orange !important; */
     opacity: 1 !important;
     padding: 0px !important;

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -483,7 +483,9 @@ background:  #000 !important;
     cursor: default !important;
 }
 
-.referencestrip > div[style^="background: rgb(153, 153, 153)"] canvas, .referencestrip .openseadragon-canvas:hover, :focus {
+.referencestrip > div[style^="background: rgb(153, 153, 153)"] canvas,
+.referencestrip .openseadragon-canvas:hover,
+.referencestrip .openseadragon-canvas:focus {
     /* border: 2px solid $orange !important; */
     opacity: 1 !important;
     padding: 0px !important;

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -139,6 +139,7 @@ $desktop: 992px;*/
     height: 42px;
     border-radius: 50%;
     background: rgba(66,66,66,0.6);
+    z-index: 9999;
 }
 
 .asset-viewer__edge-arrows .btn .icon {

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.scss
@@ -33,23 +33,14 @@ $desktop: 992px;*/
     overflow: hidden;
 }
 
-.asset-viewer:hover .asset-viewer__buttons  {
-    opacity: 1;
-}
-
 @media(max-width: 576px) {
     .asset-viewer {
         height: 50vh;
         min-height: 50vh;
     }
-
-    .asset-viewer .asset-viewer__buttons {
-        opacity: 1;
-    }
 }
 
 .asset-viewer__buttons {
-    opacity: 0;
     transition: opacity 0.2s linear;
     position: absolute;
     top: 0;
@@ -121,16 +112,11 @@ $desktop: 992px;*/
 
 
 .asset-viewer__edge-arrows {
-    opacity: 0;
     transition: opacity 0.2s linear;
     position: absolute;
     pointer-events: none;
     top: calc(50% - 120px);
     width: 100%;
-}
-
-.asset-viewer:hover .asset-viewer__edge-arrows {
-    opacity: 1;
 }
 
 .asset-viewer__edge-arrows .btn {

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -406,6 +406,20 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             this.osdViewer.destroy();
         });
 
+        this.osdViewer.addOnceHandler("tile-drawn", () => {
+            // Get all canvas elements, first one is the main canvas, second one is the navigator
+            // The canvas in the reference strip starts as the third one in the collection
+            let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+            // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
+            for (let i = 2; i < canvasElements.length; i++) {
+                canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
+                    if (event.keyCode === 13) {
+                        this.osdViewer.goToPage(i-2)
+                    }
+                })
+            }
+        })
+
         this.osdViewer.addHandler('pan', (value: any) => {
             // Save viewport pan for downloading the view
             this.asset.viewportDimensions.center = value.center

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,14 +407,13 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
-            // Get all canvas elements, first one is the main canvas, second one is the navigator
-            // The canvas in the reference strip starts as the third one in the collection
-            let canvasElements = document.getElementsByClassName("openseadragon-canvas")
+            // Get all thumbnails in the reference strip
+            let canvasElements = document.querySelectorAll(".referencestrip > div > .openseadragon-container > .openseadragon-canvas");
             // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
-            for (let i = 2; i < canvasElements.length; i++) {
+            for (let i = 0; i < canvasElements.length; i++) {
                 canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
                     if (event.keyCode === 13) {
-                        this.osdViewer.goToPage(i-2)
+                        this.osdViewer.goToPage(i)
                     }
                 })
             }

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,17 +407,17 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
-            // Get all thumbnails in the reference strip
-            let canvasElements = document.querySelectorAll(".referencestrip > div > .openseadragon-container > .openseadragon-canvas");
-            // Loop through all canvas elements in the reference strip and add event listener to keydown enter for accessibility
-            for (let i = 0; i < canvasElements.length; i++) {
-                canvasElements.item(i).addEventListener("keydown", (event: KeyboardEvent) => {
-                    if (event.keyCode === 13) {
-                        this.osdViewer.goToPage(i)
-                    }
-                })
-            }
-        })
+          // Get all thumbnails in the reference strip
+          let referenceStripThumbnails = document.querySelectorAll(".referencestrip .openseadragon-canvas");
+
+          referenceStripThumbnails.forEach((referenceStripThumbnail, index) => {
+            referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
+             if (event.keyCode === 13) {
+               this.osdViewer.goToPage(index)
+             }
+           })
+          })
+        });
 
         this.osdViewer.addHandler('pan', (value: any) => {
             // Save viewport pan for downloading the view

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -5,19 +5,19 @@
     .title-nav-cntnr.col-md-12([class.hidden]="isFullscreen")
       .row
         .col-2
-          span#previousPageLink.back-results(*ngIf="prevRouteParams.length > 0", (keyup.enter)="backToResults()", (click)="backToResults()", aria-label="Back to results", role="link")
+          span#previousPageLink.back-results(*ngIf="prevRouteParams.length > 0", (keyup.enter)="backToResults()", (click)="backToResults()", tabindex="1", aria-label="Back to results", role="link")
             i.icon.icon-arrow-back
             span.d-none.d-md-inline-block {{ 'ASSET_PAGE.LINKS.BACK' | translate}}
         .col-sm-8.col-md-offset-2.col-lg-9.col-lg-offset-1
-          .title-wrap(*ngIf="assets[0]", tabindex="0")
+          .title-wrap(*ngIf="assets[0]", tabindex="1")
             .title.text-truncate([innerHTML]="assets[0].title ? assets[0].title : ''", [attr.aria-label]="getTitleAndResults()")
             //- Pagination
             .paginator
-              i.icon.icon-direction.icon-left(title="Previous in results", (click)="showPrevAsset()", (keyup.enter)="showPrevAsset()", [class.disabled]="assetNumber <= 1", [attr.tabindex]="assetNumber <= 1 ? -1 : 0", aria-label="Previous item, press enter to go to previous result item. You can also use left and right arrow keys to navigate between result items.", role="button")
+              i.icon.icon-direction.icon-left(title="Previous in results", (click)="showPrevAsset()", (keyup.enter)="showPrevAsset()", [class.disabled]="assetNumber <= 1", [attr.tabindex]="assetNumber <= 1 ? -1 : 1", aria-label="Previous item, press enter to go to previous result item. You can also use left and right arrow keys to navigate between result items.", role="button")
               span#assetPageNumber.font-weight-bold {{ assetNumber }}
               span.font-weight-normal &nbsp;of&nbsp;
               span#assetPageCount.font-weight-bold {{ totalAssetCount - restrictedAssetsCount }}
-              i.icon.icon-direction.icon-right(title="Next in results", (click)="showNextAsset()", (keyup.enter)="showNextAsset()", [class.disabled]="assetNumber >= totalAssetCount - restrictedAssetsCount", [attr.tabindex]="assetNumber >= totalAssetCount - restrictedAssetsCount ? -1 : 0", aria-label="Next item, press enter to go to next result item. You can also use left and right arrow keys to navigate between result items.", role="button")
+              i.icon.icon-direction.icon-right(title="Next in results", (click)="showNextAsset()", (keyup.enter)="showNextAsset()", [class.disabled]="assetNumber >= totalAssetCount - restrictedAssetsCount", [attr.tabindex]="assetNumber >= totalAssetCount - restrictedAssetsCount ? -1 : 1", aria-label="Next item, press enter to go to next result item. You can also use left and right arrow keys to navigate between result items.", role="button")
     //- for accessibility so that page has title
     h1.sr-only([innerHTML]="getTitleAndResults()")
     //- Asset Viewer Row
@@ -93,24 +93,24 @@
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
-          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", aria-label="Edit details for this item")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="2", aria-label="Edit details for this item")
             | {{ 'ASSET_PAGE.BUTTONS.EDIT_DETAILS' | translate}}
           //- the .driver-find-group-btn class is important for the tour to find it, be careful when removing or changing it
           .dropdown.d-inline-block.driver-find-group-btn(ngbDropdown, aria-haspopup="true")
-            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, aria-label="Add to groups")
+            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, tabindex="2", aria-label="Add to groups")
               | {{ 'ASSET_PAGE.BUTTONS.ADD_TO_GROUP' | translate}}
               = " "
             .dropdown-menu(ngbDropdownMenu)
               a#addItemToGroupLink.dropdown-item(
                 (click)="addAssetToIG()",
-              
+                tabindex="2",
                 aria-label="Add Item to Group",
                 role="button")
                 i.icon.icon-add-item
                 | &nbsp;Add item
               a#addViewToGroupLink.dropdown-item(
                 (click)="addAssetToIG(true)",
-              
+                tabindex="2",
                 aria-label="Add View to Group",
                 [class.disabled]="assetViewer.state !== 1 || multiviewItems",
                 role="button")
@@ -118,7 +118,7 @@
                 | &nbsp;Add detail view
           //- Download dropdown options
           .dropdown.d-inline-block(ngbDropdown, *ngIf="assets[0].downloadLink && (user.isLoggedIn || hasExternalAccess || assets[0].publicDownload)", triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
-            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", aria-label="Download")
+            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
               | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
               = " "
             .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
@@ -132,7 +132,7 @@
                 [class.disabled]="assets[0].disableDownload",
                 title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
                 target="_blank",
-              
+                tabindex="2",
                 aria-label="Download item",
                 role="button")
                 i.icon.icon-download
@@ -144,26 +144,26 @@
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_blank",
-              
+                tabindex="2",
                 aria-label="Download item’s detail view",
                 role="button")
                 i.icon.icon-download-detail-view
                 | &nbsp;Download detail view
           //- False door button if user is not logged in
-          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", aria-label="Download")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
             | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
             i#downloadAssetLink.icon.icon-download-asset-orange
           .row#asset-btn
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", aria-label="Cite this item", role="button", tabindex="0")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", aria-label="See this item in print preview", role="button")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="2", aria-label="See this item in print preview", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.PRINT' | translate}}
 
           //- Copy URL
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
-            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", aria-label="Copy Item URL")
+            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
+            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 
@@ -239,9 +239,9 @@
               .value([innerHtml]="assets[0].SSID", aria-labelledby="ssid")
           //- IAP and Report Error
           .text-left.pt-2
-            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
-            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
-            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", tabindex="8", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
+            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", tabindex="14", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
+            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
 
         //- Report Error Form, hidden by default
         .mt-2.d-none([class.d-block]="showEditDetails")
@@ -252,37 +252,37 @@
             .form-body
               .form-group
                 label(for="creatorInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.CREATOR' | translate }}
-                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false")
+                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="titleInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE' | translate }}
-                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false")
+                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false", tabindex="6")
                 .has-danger(*ngIf="editDetailsFormSubmitted && editDetailsForm.controls['title'].hasError('required')")
                   p.form-control-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE_REQUIRED_MSG' | translate }}
               .form-group
                 label(for="worktypeInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.WORK_TYPE' | translate }}
-                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false")
+                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="dateInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DATE' | translate }}
-                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false")
+                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="locationInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.LOCATION' | translate }}
-                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false")
+                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="materialInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.MATERIAL' | translate }}
-                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false")
+                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="descriptionInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DESCRIPTION' | translate }}
-                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false")
+                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false", tabindex="6")
               .form-group
                 label(for="subjectInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SUBJECT' | translate }}
-                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false")
+                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false", tabindex="6")
               .form-group.has-danger(*ngIf="uiMessages.deleteFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_ERROR' | translate }}
               .form-group.has-danger(*ngIf="uiMessages.saveFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_ERROR' | translate }}
               .btn-row
-                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
-                button.btn.btn-primary(type="submit", [class.loading]="isProcessing") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
+                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+                button.btn.btn-primary(type="submit", [class.loading]="isProcessing", tabindex="6") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
     .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
       button.btn.btn-light(*ngIf="!quizMode && !showAssetDrawer", (click)="toggleAssetDrawer(!showAssetDrawer)")

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -5,19 +5,19 @@
     .title-nav-cntnr.col-md-12([class.hidden]="isFullscreen")
       .row
         .col-2
-          span#previousPageLink.back-results(*ngIf="prevRouteParams.length > 0", (keyup.enter)="backToResults()", (click)="backToResults()", tabindex="1", aria-label="Back to results", role="link")
+          span#previousPageLink.back-results(*ngIf="prevRouteParams.length > 0", (keyup.enter)="backToResults()", (click)="backToResults()", aria-label="Back to results", role="link")
             i.icon.icon-arrow-back
             span.d-none.d-md-inline-block {{ 'ASSET_PAGE.LINKS.BACK' | translate}}
         .col-sm-8.col-md-offset-2.col-lg-9.col-lg-offset-1
-          .title-wrap(*ngIf="assets[0]", tabindex="1")
+          .title-wrap(*ngIf="assets[0]", tabindex="0")
             .title.text-truncate([innerHTML]="assets[0].title ? assets[0].title : ''", [attr.aria-label]="getTitleAndResults()")
             //- Pagination
             .paginator
-              i.icon.icon-direction.icon-left(title="Previous in results", (click)="showPrevAsset()", (keyup.enter)="showPrevAsset()", [class.disabled]="assetNumber <= 1", [attr.tabindex]="assetNumber <= 1 ? -1 : 1", aria-label="Previous item, press enter to go to previous result item. You can also use left and right arrow keys to navigate between result items.", role="button")
+              i.icon.icon-direction.icon-left(title="Previous in results", (click)="showPrevAsset()", (keyup.enter)="showPrevAsset()", [class.disabled]="assetNumber <= 1", [attr.tabindex]="assetNumber <= 1 ? -1 : 0", aria-label="Previous item, press enter to go to previous result item. You can also use left and right arrow keys to navigate between result items.", role="button")
               span#assetPageNumber.font-weight-bold {{ assetNumber }}
               span.font-weight-normal &nbsp;of&nbsp;
               span#assetPageCount.font-weight-bold {{ totalAssetCount - restrictedAssetsCount }}
-              i.icon.icon-direction.icon-right(title="Next in results", (click)="showNextAsset()", (keyup.enter)="showNextAsset()", [class.disabled]="assetNumber >= totalAssetCount - restrictedAssetsCount", [attr.tabindex]="assetNumber >= totalAssetCount - restrictedAssetsCount ? -1 : 1", aria-label="Next item, press enter to go to next result item. You can also use left and right arrow keys to navigate between result items.", role="button")
+              i.icon.icon-direction.icon-right(title="Next in results", (click)="showNextAsset()", (keyup.enter)="showNextAsset()", [class.disabled]="assetNumber >= totalAssetCount - restrictedAssetsCount", [attr.tabindex]="assetNumber >= totalAssetCount - restrictedAssetsCount ? -1 : 0", aria-label="Next item, press enter to go to next result item. You can also use left and right arrow keys to navigate between result items.", role="button")
     //- for accessibility so that page has title
     h1.sr-only([innerHTML]="getTitleAndResults()")
     //- Asset Viewer Row
@@ -93,24 +93,24 @@
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
-          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="2", aria-label="Edit details for this item")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", aria-label="Edit details for this item")
             | {{ 'ASSET_PAGE.BUTTONS.EDIT_DETAILS' | translate}}
           //- the .driver-find-group-btn class is important for the tour to find it, be careful when removing or changing it
           .dropdown.d-inline-block.driver-find-group-btn(ngbDropdown, aria-haspopup="true")
-            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, tabindex="2", aria-label="Add to groups")
+            button#addToGroupDropdown.btn.btn-primary(ngbDropdownToggle, aria-label="Add to groups")
               | {{ 'ASSET_PAGE.BUTTONS.ADD_TO_GROUP' | translate}}
               = " "
             .dropdown-menu(ngbDropdownMenu)
               a#addItemToGroupLink.dropdown-item(
                 (click)="addAssetToIG()",
-                tabindex="2",
+              
                 aria-label="Add Item to Group",
                 role="button")
                 i.icon.icon-add-item
                 | &nbsp;Add item
               a#addViewToGroupLink.dropdown-item(
                 (click)="addAssetToIG(true)",
-                tabindex="2",
+              
                 aria-label="Add View to Group",
                 [class.disabled]="assetViewer.state !== 1 || multiviewItems",
                 role="button")
@@ -118,7 +118,7 @@
                 | &nbsp;Add detail view
           //- Download dropdown options
           .dropdown.d-inline-block(ngbDropdown, *ngIf="assets[0].downloadLink && (user.isLoggedIn || hasExternalAccess || assets[0].publicDownload)", triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
-            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
+            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", aria-label="Download")
               | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
               = " "
             .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
@@ -132,7 +132,7 @@
                 [class.disabled]="assets[0].disableDownload",
                 title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
                 target="_blank",
-                tabindex="2",
+              
                 aria-label="Download item",
                 role="button")
                 i.icon.icon-download
@@ -144,26 +144,26 @@
                 (keyup.arrowup)="downloadOptsArrowUp($event.target)",
                 [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
                 target="_blank",
-                tabindex="2",
+              
                 aria-label="Download item’s detail view",
                 role="button")
                 i.icon.icon-download-detail-view
                 | &nbsp;Download detail view
           //- False door button if user is not logged in
-          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
+          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", aria-label="Download")
             | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
             i#downloadAssetLink.icon.icon-download-asset-orange
           .row#asset-btn
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", aria-label="Cite this item", role="button", tabindex="0")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="2", aria-label="See this item in print preview", role="button")
+            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", aria-label="See this item in print preview", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.PRINT' | translate}}
 
           //- Copy URL
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
-            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
+            input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", aria-label="Item URL")
+            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 
@@ -239,9 +239,9 @@
               .value([innerHtml]="assets[0].SSID", aria-labelledby="ssid")
           //- IAP and Report Error
           .text-left.pt-2
-            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", tabindex="8", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
-            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", tabindex="14", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
-            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+            a#buttonRequestIap.btn.btn-secondary.my-1(*ngIf="iapFormUrl", [attr.href]="getIapFormUrl(assets[0])", (click)="logIAP(assets[0])", title="Request Image for Academic Publishing", target="_blank") {{'ASSET_PAGE.BUTTONS.GET_IAP' | translate}}
+            a#buttonReportAssetError.btn.btn-secondary.my-1(*ngIf="errorFormUrl", [attr.href]="errorFormUrl", title="Report an error", target="_blank") {{'ASSET_PAGE.BUTTONS.REPORT_ERROR' | translate}}
+            button.btn.btn-secondary.ml-2(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", (click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
 
         //- Report Error Form, hidden by default
         .mt-2.d-none([class.d-block]="showEditDetails")
@@ -252,37 +252,37 @@
             .form-body
               .form-group
                 label(for="creatorInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.CREATOR' | translate }}
-                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false", tabindex="6")
+                input#creatorInput.form-control(type="text", [formControl]="editDetailsForm.controls['creator']", placeholder="", spellcheck="false")
               .form-group
                 label(for="titleInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE' | translate }}
-                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false", tabindex="6")
+                input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false")
                 .has-danger(*ngIf="editDetailsFormSubmitted && editDetailsForm.controls['title'].hasError('required')")
                   p.form-control-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE_REQUIRED_MSG' | translate }}
               .form-group
                 label(for="worktypeInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.WORK_TYPE' | translate }}
-                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false", tabindex="6")
+                input#worktypeInput.form-control(type="text", [formControl]="editDetailsForm.controls['work_type']", placeholder="", spellcheck="false")
               .form-group
                 label(for="dateInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DATE' | translate }}
-                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false", tabindex="6")
+                input#dateInput.form-control(type="text", [formControl]="editDetailsForm.controls['date']", placeholder="", spellcheck="false")
               .form-group
                 label(for="locationInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.LOCATION' | translate }}
-                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false", tabindex="6")
+                input#locationInput.form-control(type="text", [formControl]="editDetailsForm.controls['location']", placeholder="", spellcheck="false")
               .form-group
                 label(for="materialInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.MATERIAL' | translate }}
-                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false", tabindex="6")
+                input#materialInput.form-control(type="text", [formControl]="editDetailsForm.controls['material']", placeholder="", spellcheck="false")
               .form-group
                 label(for="descriptionInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DESCRIPTION' | translate }}
-                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false", tabindex="6")
+                input#descriptionInput.form-control(type="text", [formControl]="editDetailsForm.controls['description']", placeholder="", spellcheck="false")
               .form-group
                 label(for="subjectInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SUBJECT' | translate }}
-                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false", tabindex="6")
+                input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false")
               .form-group.has-danger(*ngIf="uiMessages.deleteFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_ERROR' | translate }}
               .form-group.has-danger(*ngIf="uiMessages.saveFailure")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_ERROR' | translate }}
               .btn-row
-                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
-                button.btn.btn-primary(type="submit", [class.loading]="isProcessing", tabindex="6") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
+                button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}
+                button.btn.btn-primary(type="submit", [class.loading]="isProcessing") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
     .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
       button.btn.btn-light(*ngIf="!quizMode && !showAssetDrawer", (click)="toggleAssetDrawer(!showAssetDrawer)")

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -285,15 +285,16 @@
                 button.btn.btn-primary(type="submit", [class.loading]="isProcessing", tabindex="6") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_BTN' | translate }}
 
     .fullscreen-btns.button-group(*ngIf="isFullscreen", [class.fade-out]="showAssetDrawer")
-      button.btn.btn-light(*ngIf="!quizMode", (click)="toggleAssetDrawer(!showAssetDrawer)")
+      button.btn.btn-light(*ngIf="!quizMode && !showAssetDrawer", (click)="toggleAssetDrawer(!showAssetDrawer)")
           | {{ 'ASSET_PAGE.BUTTONS.COMPARE' | translate}}
           i.icon.icon-compare
       button.btn.btn-light(
-          type="button",
-          (click)="exitPresentationMode()",
-          aria-label="Close",
-          title="Exit Fullscreen"
-        )
+        *ngIf="!showAssetDrawer"
+        type="button",
+        (click)="exitPresentationMode()",
+        aria-label="Close",
+        title="Exit Fullscreen"
+      )
         | Exit
         .icon.icon-exit-fullscreen
     //- Asset Drawer
@@ -312,7 +313,7 @@
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
         div.pt-1.pb-3(*ngIf="prevAssetResults.thumbnails.length < 1")
           .alert.alert-info {{ 'ASSET_PAGE.MESSAGES.NEEDASSETS' | translate}}
-        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)")
+        ang-thumbnail.card.card--asset(*ngFor="let asset of prevAssetResults.thumbnails", [thumbnail]="asset", [ngClass]="{ 'selected' : asset.selected || isPrimaryAsset(asset) }", (click)="toggleAsset(asset)", (keydown.enter)="toggleAsset(asset)")
         .text-center.pt-2
           pagination([pageObj]="pagination", (goToPage)="goToPage($event)", style="display:inline-block")
 ang-agree-modal(

--- a/src/app/collection-badge/collection-badge.component.pug
+++ b/src/app/collection-badge/collection-badge.component.pug
@@ -6,7 +6,7 @@
   placement="right",
   aria-haspopup="true",
   [attr.aria-label]="collectionType.alt",
-  tabindex="0"
+  tabindex="3"
 ) {{ collectionType.badgeText }}
 <ng-template #tipContent>
   div([innerHtml]="collectionType.alt")

--- a/src/app/collection-badge/collection-badge.component.pug
+++ b/src/app/collection-badge/collection-badge.component.pug
@@ -6,7 +6,7 @@
   placement="right",
   aria-haspopup="true",
   [attr.aria-label]="collectionType.alt",
-  tabindex="3"
+  tabindex="0"
 ) {{ collectionType.badgeText }}
 <ng-template #tipContent>
   div([innerHtml]="collectionType.alt")

--- a/src/sass/modules/_viewer.scss
+++ b/src/sass/modules/_viewer.scss
@@ -9,14 +9,6 @@
     }
 }
 
-.referencestrip > div > .openseadragon-container > .openseadragon-canvas {
-    opacity: 0.5 !important;
-
-    &:focus {
-        opacity: 1 !important;
-    }
-}
-
 .osd-wrap > .openseadragon-container {
     min-height: 600px;
 


### PR DESCRIPTION
Now the tab order is:
 - zoom buttons
 - multi-view pagination button (multi-views only)
 - main canvas
 - thumbnails in the reference strip (multi-views only)
 - results pagination button
 - hide caption & quiz mode button
 - compare & exit button
 - interactive elements in the drawer (if drawer opened)