### PR TITLE
PLATO-207: Make group tags appear clickable on Browse Groups page

### DIFF
--- a/src/app/browse-page/card-view/card-view.component.pug
+++ b/src/app/browse-page/card-view/card-view.component.pug
@@ -58,5 +58,5 @@
             ul.filter-list(#groupTagsList="")
               i(*ngIf="!group.tags.length") This group does not have any tags.
               li.filter-item(*ngFor="let tag of group.tags")
-                a.font-weight-bold((click)="selectTag(tag)", (keyup.enter)="selectTag(tag)", tabindex="3", attr.aria-label="{{ tag }}, press enter to display image groups associated with this tag.") {{ tag }}
+                a.font-weight-bold.group-tag-name((click)="selectTag(tag)", (keyup.enter)="selectTag(tag)", tabindex="3", attr.aria-label="{{ tag }}, press enter to display image groups associated with this tag.") {{ tag }}
           .expander.link--action.small([class.hidden]="groupTagsList.scrollHeight < 70", [class.collapsed]="tagsCollapsed", (click)="tagsCollapsed = !tagsCollapsed", (keyup.enter)="tagsCollapsed = !tagsCollapsed", [innerHtml]="tagsCollapsed ? 'Show all ' + group.tags.length + ' tags....' : 'Show less'", role="button", tabindex="3", [attr.aria-label]="tagsCollapsed ? 'Show all ' + group.tags.length + ' tags, press enter to view all tags associated with this group.' : 'Show less. Press enter to decrease the amount of tags displayed with this image group.'") Show all {{ group.tags.length }} tags....

--- a/src/app/browse-page/card-view/card-view.component.scss
+++ b/src/app/browse-page/card-view/card-view.component.scss
@@ -68,11 +68,11 @@ $tagLinkBg: #efefef;
     }
 
 
-    // For expand/collapse tags exceeding three lines 
+    // For expand/collapse tags exceeding three lines
     .groupTagsCntnr{
         overflow: hidden;
         padding-top: 1px;
-        
+
         &.limit{
             max-height: 4em;
             margin-bottom: 5px;
@@ -194,7 +194,7 @@ $tagLinkBg: #efefef;
 .icon {
     width: 5.5em;
     height: 7em;
-    
+
     &.img-state{
         background-size: 100%;
         position: absolute;
@@ -212,4 +212,12 @@ $tagLinkBg: #efefef;
 .cardview-text {
     padding-left: 1em;
     padding-right: 1em;
+}
+
+.group-tag-name {
+  border: 1px solid #cfcfcf;
+}
+
+.filter-item {
+  margin-top: 2px; // this is necessary to make top border of group tag visible
 }


### PR DESCRIPTION
PLATO-207: On the Browse Groups page, the group tag elements do not appear to be interactive until they are hovered over. These elements need to have some indication (other than hover state changing their appearance) that they are interactive. Have added `1px solid #cfcfcf` border around tags.