### PR TITLE
PLATO-227: Fix screenreader message error on group presentation mode

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -143,8 +143,9 @@ export class AppComponent {
         if (isPlatformBrowser(this.platformId)) {
           // focus on the wrapper of the "skip to main content link" everytime new page is loaded
           let mainEl = <HTMLElement>(this._dom.byId('skip-main-content-div'))
-          if (!(event.url.indexOf('browse') > -1) && !(event.url.indexOf('search') > -1) && !(event.url.indexOf('asset') > -1)) // Don't set focus to skip to main content on browse pages so that we can easily go between browse levels
+          if (mainEl && !(event.url.indexOf('browse') > -1) && !(event.url.indexOf('search') > -1) && !(event.url.indexOf('asset') > -1)) { // Don't set focus to skip to main content on browse pages so that we can easily go between browse levels
             mainEl.focus()
+          }
         }
 
         // Detect featureflag=solrmetadata and set cookie

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -670,7 +670,8 @@ export class AssetPage implements OnInit, OnDestroy {
           });
         }
 
-        this.screenReaderMessage = `Entering full screen. Viewing ${this.assets[0].title}`
+        let baseScreenReaderMessage = "Entering full screen."
+        this.screenReaderMessage = this.assets[0] ?  `${baseScreenReaderMessage} Viewing ${this.assets[0].title}` : baseScreenReaderMessage
       }
     }
     this.isFullscreen = isFullscreen

--- a/src/app/shared/group-title/group-title.component.ts
+++ b/src/app/shared/group-title/group-title.component.ts
@@ -88,10 +88,12 @@ import { ImageGroup } from 'datatypes'
         queryParams['w'] = this.ig.items[0].zoom.pointWidth
         queryParams['h'] = this.ig.items[0].zoom.pointHeight
       }
-      // Enter fullscreen - must fire within click binding (Firefox, Safari)
-      this._toolbox.requestFullScreen()
       // Route to viewer
-      this._router.navigate(['/asset', id, queryParams]);
+      this._router.navigate(['/asset', id, queryParams])
+        .then(() => {
+          // Enter fullscreen - must fire within click binding (Firefox, Safari)
+          this._toolbox.requestFullScreen()
+        });
     }
 
 }


### PR DESCRIPTION
Resolves [PLATO-227](https://jira.jstor.org/browse/PLATO-227)

Fixing error generated when asset may not have been loaded by the time we want to use it for the screenreader message.