### PR TITLE
PLATO-495: Accessibility fixes for asset page

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -188,7 +188,7 @@
                 //- Creator
                 .value.meta-link(
                   *ngIf="fieldName === 'Creator'",
-                  [attr.id]="cleanId(fieldName)",
+                  [attr.data-qa-id]="cleanId(fieldName)",
                   (click)="trackCreatorLink(value)",
                   [innerHTML]="value | filterLink:'artcreator'",
                   [attr.aria-labelledby]="cleanId(fieldName)"
@@ -201,14 +201,14 @@
                 //- Subject
                 a.value.meta-link(
                   *ngIf="fieldName === 'Subject'",
-                  [attr.id]="cleanId(fieldName)",
+                  [attr.data-qa-id]="cleanId(fieldName)",
                   (click)="trackSubjectLink(value)",
                   [innerHTML]="value | filterLink:'artsubject'",
                   [attr.aria-labelledby]="cleanId(fieldName)"
                 )
                 //- Other fields (culture, material, work type, description...etc)
                 div(*ngIf="fieldName !== 'Collection' && fieldName !== 'Subject' && fieldName !== 'Creator'")
-                  .value([attr.id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
+                  .value([attr.data-qa-id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
           //- Rights
           .meta-block(*ngIf="assets[0].formattedMetadata.Rights && assets[0].formattedMetadata.Rights.length > 0")
             .label#Rights Rights

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -93,7 +93,7 @@
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
-          button#assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="2", aria-label="Edit details for this item")
+          button.assetpage-btn.btn.btn-secondary(*ngIf="user.isLoggedIn && assets[0].personalCollectionOwner === user['baseProfileId']", [class.active]="showEditDetails", (click)="loadEditDetailsForm()", tabindex="2", aria-label="Edit details for this item")
             | {{ 'ASSET_PAGE.BUTTONS.EDIT_DETAILS' | translate}}
           //- the .driver-find-group-btn class is important for the tour to find it, be careful when removing or changing it
           .dropdown.d-inline-block.driver-find-group-btn(ngbDropdown, aria-haspopup="true")
@@ -150,20 +150,20 @@
                 i.icon.icon-download-detail-view
                 | &nbsp;Download detail view
           //- False door button if user is not logged in
-          button#assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
+          button.assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
             | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
             i#downloadAssetLink.icon.icon-download-asset-orange
           .row#asset-btn
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
+            a.assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
-            a#assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="2", aria-label="See this item in print preview", role="button")
+            a.assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", [routerLink]="['/assetprint/' + assets[0].id]", (click)="logPrint(assets[0])", (keydown.enter)="logPrint(assets[0])", target="_blank", tabindex="2", aria-label="See this item in print preview", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.PRINT' | translate}}
 
           //- Copy URL
           //- * Do not show for Personal Collection assets
           .btn-group#copy-link(*ngIf="isBrowser && !assets[0].personalCollectionOwner")
             input#generatedImgURL.form-control.form-control__copy(#copyUrlInput="", readonly, [ngModel]="generatedImgURL", (click)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Item URL")
-            button#assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
+            button.assetpage-btn.btn.btn-secondary([class.active]="showCopyUrl", (mousedown)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (mouseup)="copyUrlInput.select(); document.execCommand('copy', false, null);", (keydown.enter)="showCopyUrl ? showCopyUrl = false : copyGeneratedImgURL(assets[0])", (keyup.enter)="copyUrlInput.select(); document.execCommand('copy', false, null);", tabindex="2", aria-label="Copy Item URL")
               | {{ 'ASSET_PAGE.BUTTONS.LINK' | translate}}
               //- i#genImgURLlink.icon.icon-share-white
 

--- a/src/app/asset-page/asset-page.component.scss
+++ b/src/app/asset-page/asset-page.component.scss
@@ -516,7 +516,7 @@ $titleNavBg: #eee;
     margin-left: 0.15rem;
     max-width: 25rem;
     width: 100%;
-    #assetpage-btn {
+    .assetpage-btn {
         margin-left:0;
         width:6rem;
     }
@@ -535,7 +535,7 @@ $titleNavBg: #eee;
     margin-right: 0;
 }
 
-#assetpage-btn, #downloadAssetDropdown {
+.assetpage-btn, #downloadAssetDropdown {
 
     &.btn-primary {
         width: 12rem;

--- a/src/app/asset-pp-page/asset-pp-page.component.pug
+++ b/src/app/asset-pp-page/asset-pp-page.component.pug
@@ -8,7 +8,7 @@
     h2 Item Details
     .table
       .meta-row.row(*ngFor="let fieldName of asset.formattedMetadata | keys")
-        .col-md-4.lbl([attr.id]="cleanId(fieldName)") {{ fieldName }}
+        .col-md-4.lbl([attr.data-qa-id]="cleanId(fieldName)") {{ fieldName }}
         .col-md-8
           .value(*ngFor="let value of asset.formattedMetadata[fieldName]")
             span([innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")


### PR DESCRIPTION
Found a couple issues after running our accessibility compliance gem on the artstor asset page.

Issues fixed:
1. Duplicated `assetpage-btn` ids - Just converted this over to using a class instead
2. Duplicated ids when a metadata field contained more than one value - For example, if a particular image had two `Subjects` of `Dolls` and `Doll Clothes`. We would display both of those values each with an `id` of ` subjects`. The solution here is to just convert to using a different attribute called `data-qa-id`.