### PR TITLE
PLATO-495: Remove aria-labelledby attribute on metadata fields

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -190,8 +190,7 @@
                   *ngIf="fieldName === 'Creator'",
                   [attr.data-qa-id]="cleanId(fieldName)",
                   (click)="trackCreatorLink(value)",
-                  [innerHTML]="value | filterLink:'artcreator'",
-                  [attr.aria-labelledby]="cleanId(fieldName)"
+                  [innerHTML]="value | filterLink:'artcreator'"
                 )
                   //- [routerLink]="['/search', 'artcreator:(' + value + ')']",
                 //- Collections
@@ -203,12 +202,11 @@
                   *ngIf="fieldName === 'Subject'",
                   [attr.data-qa-id]="cleanId(fieldName)",
                   (click)="trackSubjectLink(value)",
-                  [innerHTML]="value | filterLink:'artsubject'",
-                  [attr.aria-labelledby]="cleanId(fieldName)"
+                  [innerHTML]="value | filterLink:'artsubject'"
                 )
                 //- Other fields (culture, material, work type, description...etc)
                 div(*ngIf="fieldName !== 'Collection' && fieldName !== 'Subject' && fieldName !== 'Creator'")
-                  .value([attr.data-qa-id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify", [attr.aria-labelledby]="cleanId(fieldName)")
+                  .value([attr.data-qa-id]="cleanId(fieldName)", [innerHTML]="cleanFieldValue(value) | linkify")
           //- Rights
           .meta-block(*ngIf="assets[0].formattedMetadata.Rights && assets[0].formattedMetadata.Rights.length > 0")
             .label#Rights Rights


### PR DESCRIPTION
Removes the `aria-labelledby` attribute on the metadata values as they weren't really being used correctly, and it was causing failures using our accessibility gem. Discussed this with change with Florence too.