### PR TITLE
PALS-98: Make Login heading H1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.74",
+  "version": "2.7.75",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/login/login.component.pug
+++ b/src/app/login/login.component.pug
@@ -5,7 +5,7 @@
     .col-sm-6
       .card.card--light
         .card-header
-          h2.h1#loginHeading {{ copyBase + 'LOGIN.REG_LOGIN.HEADING' | translate }}
+          h1.h1#loginHeading {{ copyBase + 'LOGIN.REG_LOGIN.HEADING' | translate }}
         .card-body
           ang-login-form(
             (userEmail)="username = $event", 


### PR DESCRIPTION
Resolves PALS-98

1. Artstor Login Page Lacks 1st Level Heading for Designation
2. As a user, I want to know what content I am looking at and where I am within the site without searching for this information so that I don't feel lost, confused, or frustrated.

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable

**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [x] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
