### PR TITLE
PALS-213: Don't track user idle time after log out

### DIFF
--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -263,7 +263,11 @@ export class AuthService implements CanActivate {
 
   // Reset the idle watcher
   public resetIdleWatcher(): void {
-    this.idle.watch();
+    let user = this.getUser();
+    // After user logged out, don't track idle time
+    if (user && user.isLoggedIn) {
+      this.idle.watch();
+    }
     // When a user comes back, we don't want to wait for the time interval to refresh the session
     this.refreshUserSession(true)
   }


### PR DESCRIPTION
Resolves PALS-213

Even after user logs out, Artstor watches idle time and triggers session expired modal dialog. PALS-213 resolves it. Artstor doesn't watch idle time of the user anymore after log out.

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [x] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
