### PR TITLE
PLATO-510: Omit Date option from Sort on Personal Collection page

### DIFF
--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -13,7 +13,7 @@
                 .dropdown-menu(ngbDropdownMenu, aria-labelledby="sortdropdownMenu")
                   button.dropdown-item([disabled]="activeSort.index == '1'", (click)="changeSortOpt('1', 'Title')", tabindex="3") Title
                   button.dropdown-item([disabled]="activeSort.index == '2'", (click)="changeSortOpt('2', 'Creator')", tabindex="3") Creator
-                  button.dropdown-item([disabled]="activeSort.index == '3'", (click)="changeSortOpt('3', 'Date')", tabindex="3") Date
+                  button.dropdown-item(*ngIf="!isPersonalCollection", [disabled]="activeSort.index == '3'", (click)="changeSortOpt('3', 'Date')", tabindex="3") Date
                   button.dropdown-item([disabled]="activeSort.index == '4'", (click)="changeSortOpt('4', 'Recently Added')", tabindex="3") Recently Added
                   button.dropdown-item([disabled]="activeSort.index == '0'", (click)="changeSortOpt('0', 'Relevance')", tabindex="3") Relevance
               li.pagesizelist.dropdown(ngbDropdown)
@@ -117,9 +117,9 @@
             )
             a.card.card--asset([attr.data-id]="asset.objectId", [ngClass]="{'selected': ( isSelectedAsset(asset) > -1 ), 'lrgThmb': largeThmbView }", (click)="selectAsset(asset, $event)", (focus)="showBox($event)", (blur)="hideBox($event)", [routerLink]="editMode ? null : constructNavigationCommands(asset)", tabIndex="-1")
               ang-thumbnail(
-                [thumbnail]="asset", 
-                [reorderMode]="false", 
-                [editMode]="editMode", 
+                [thumbnail]="asset",
+                [reorderMode]="false",
+                [editMode]="editMode",
                 [largeThmbView]="largeThmbView"
               )
             .mobile--hide

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -41,6 +41,7 @@ export class AssetGrid implements OnInit, OnDestroy {
     return this.totalAssets
   }
 
+  public isPersonalCollection: boolean = false;
   public searchLoading: boolean;
   public showFilters: boolean = true;
   public showAdvancedModal: boolean = false;
@@ -216,6 +217,8 @@ export class AssetGrid implements OnInit, OnDestroy {
       if (prefs && prefs.largeThumbnails) {
         this.largeThmbView = prefs.largeThumbnails
       }
+
+    this.isPersonalCollection = this._router.url.indexOf('pcollection/') > -1
   }
 
   private isBrowser: boolean = isPlatformBrowser(this.platformId)
@@ -299,6 +302,7 @@ export class AssetGrid implements OnInit, OnDestroy {
           this.activeSort.label = 'Relevance';
         }
 
+        console.log("personal collection:" + this.isPersonalCollection)
         this.isLoading = true;
       })).subscribe()
     );

--- a/src/app/asset-grid/asset-grid.component.ts
+++ b/src/app/asset-grid/asset-grid.component.ts
@@ -302,7 +302,6 @@ export class AssetGrid implements OnInit, OnDestroy {
           this.activeSort.label = 'Relevance';
         }
 
-        console.log("personal collection:" + this.isPersonalCollection)
         this.isLoading = true;
       })).subscribe()
     );


### PR DESCRIPTION
Personal Collection items do have `date` fields to sort by. Removing the option from the available sortable choices for the personal collection page only.