### PR TITLE
SRCHX-429: Show outline on showdow for pagination controls

### DIFF
--- a/src/app/shared/pagination/pagination.component.scss
+++ b/src/app/shared/pagination/pagination.component.scss
@@ -80,8 +80,9 @@ button.page-link {
     }
 
     &:active, &:focus {
-        outline: none;
         box-shadow: none;
+        outline: auto;
+        outline-color: -webkit-focus-ring-color;
     }
 }
 


### PR DESCRIPTION
The PR ensures that we show the outline for the pagination control once it gains focus.