### PR TITLE
PLATO-240: Added aria alerting for the error region

### DIFF
--- a/src/app/uploader/uploader.component.pug
+++ b/src/app/uploader/uploader.component.pug
@@ -21,6 +21,6 @@
         div(*ngFor="let queueObj of uploader.queue")
           .queue-item.pb-1(*ngIf="queueObj.isReady") {{ queueObj.file.name }}
             i.icon.icon-loading
-      .file-name.error-wrap(*ngIf="invalidFiles && invalidFiles.length > 0")
+      .file-name.error-wrap(*ngIf="invalidFiles && invalidFiles.length > 0" role="alert" aria-atomic="false")
         .error-msg(*ngFor="let file of invalidFiles") "{{ file.name }}" is not a valid JPEG
   a.mt-2.link.help(href="http://support.artstor.org/?article-category=09-using-your-own-images", target="_blank", tabindex="0", (keydown.tab)="helpTabKeyDown($event)") {{ 'UPLOAD_IMAGES_MODAL.HELP' | translate }}


### PR DESCRIPTION
Resolves [PLATO-240](https://jira.jstor.org/browse/PLATO-240)

Added `role="alert"` and` aria-atomic="false"` to read out new errors as users try to upload content to a personal collection that aren't jpegs. 

![image](https://user-images.githubusercontent.com/13315416/73021646-f54d7f00-3df5-11ea-9693-cba3400089be.png)
