### PR TITLE
PLATO-206: Clean up help link/icon css rules and enhance for better accessibility

### DIFF
--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -65,7 +65,7 @@
             .modal-footer
               ng-container(*ngIf="!serviceResponse.success")
                 .wrapper
-                  a.help-link-icon.mr-2(href="http://support.artstor.org/?article=create-and-manage-image-groups", target="_blank", tabindex="13", aria-label="Learn more about groups", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") ?
+                  a.help-link-icon.mr-2(href="https://support.artstor.org/?article=create-and-manage-image-groups", target="_blank", tabindex="13", aria-label="Learn more about groups", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") ?
                   .link(*ngIf="showCreateGroup", (click)="createGroup.emit()", (keyup.enter)="createGroup.emit()", tabindex="12", aria-label="Add to New Group", role="link") Create new group
                 .wrapper
                   button.btn.btn-secondary.mr-2((click)="closeModal.emit()", type="button", data-dismiss="modal", tabindex="11", aria-label="Cancel") {{ 'ADD_TO_GROUP_MODAL.CONTROLS.CANCEL' | translate}}

--- a/src/app/modals/add-to-group/add-to-group.component.pug
+++ b/src/app/modals/add-to-group/add-to-group.component.pug
@@ -65,7 +65,7 @@
             .modal-footer
               ng-container(*ngIf="!serviceResponse.success")
                 .wrapper
-                  a.help-link.mr-2(href="http://support.artstor.org/?article=create-and-manage-image-groups", target="_blank", tabindex="13", aria-label="Learn more about groups", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") ?
+                  a.help-link-icon.mr-2(href="http://support.artstor.org/?article=create-and-manage-image-groups", target="_blank", tabindex="13", aria-label="Learn more about groups", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") ?
                   .link(*ngIf="showCreateGroup", (click)="createGroup.emit()", (keyup.enter)="createGroup.emit()", tabindex="12", aria-label="Add to New Group", role="link") Create new group
                 .wrapper
                   button.btn.btn-secondary.mr-2((click)="closeModal.emit()", type="button", data-dismiss="modal", tabindex="11", aria-label="Cancel") {{ 'ADD_TO_GROUP_MODAL.CONTROLS.CANCEL' | translate}}

--- a/src/app/modals/add-to-group/add-to-group.component.scss
+++ b/src/app/modals/add-to-group/add-to-group.component.scss
@@ -59,27 +59,6 @@
         .wrapper {
             display: inline-flex;
 
-            .help-link {
-                border-radius: 50%;
-                width: 22px;
-                height: 22px;
-                line-height: 22px;
-                text-align: center;
-                vertical-align: middle;
-                display: inline-block;
-                cursor: pointer;
-                font-family: Arial, Helvetica, sans-serif;
-                font-size: 12px;
-                font-weight: 600;
-                color: $color-white !important;
-                background-color: var(--gray-dark);
-
-                &:hover {
-                    background-color: #fafafa;
-                    color: var(--gray-dark) !important;
-                }
-            }
-
             .link {
                 font-family: Verdana;
                 font-size: 12px;

--- a/src/app/modals/add-to-group/add-to-group.component.ts
+++ b/src/app/modals/add-to-group/add-to-group.component.ts
@@ -135,7 +135,7 @@ export class AddToGroupModal implements OnInit, OnDestroy, AfterViewInit {
 
   // Set focus on the last modal element in tab order
   public focusLastElement(event: any) {
-    let lastElement: HTMLElement = <HTMLElement>this._dom.bySelector('.help-link')
+    let lastElement: HTMLElement = <HTMLElement>this._dom.bySelector('.help-link-icon')
     lastElement.focus()
     event.stopPropagation()
     event.preventDefault()

--- a/src/app/modals/new-ig-modal/new-ig-modal.component.pug
+++ b/src/app/modals/new-ig-modal/new-ig-modal.component.pug
@@ -73,7 +73,7 @@
             span([innerHtml]="errorMsg")
         .modal-footer
           .wrapper
-            a.help-link.mr-2(href="http://support.artstor.org/?article=create-and-manage-image-groups", target="_blank") ?
+            a.help-link-icon.mr-2(href="http://support.artstor.org/?article=create-and-manage-image-groups", target="_blank") ?
             .link.modal-footer-link-left(*ngIf="!editIG && !copyIG && showAddToGroup && hasPrivateGroups", (click)="addToGroup.emit()") {{ 'NEW_GROUP_MODAL.SHOW_ADD_TO_IMAGE_GROUP' | translate }}
           .wrapper
             button.btn.btn-secondary.mr-2(type="button", (click)="closeModal.emit()") {{ 'NEW_GROUP_MODAL.CONTROLS.CLOSE' | translate }}

--- a/src/app/modals/share-ig-link/share-ig-link.component.pug
+++ b/src/app/modals/share-ig-link/share-ig-link.component.pug
@@ -16,5 +16,5 @@
             .form-control-feedback(*ngIf="igCopied") {{ 'SHARE_IG_LINK_MODAL.COPY_SUCCESS' | translate }}
             .form-control-feedback(*ngIf="serviceStatus.tokenError") {{ 'SHARE_IG_LINK_MODAL.SERVICE_ERROR' | translate }}
       .modal-footer
-        a.btn.btn-link.with-pad(href="http://support.artstor.org/?article=creating-links", role="button", target="_blank", tabindex="0") Help
+        a.link.help-link-text(href="https://support.artstor.org/?article=creating-links", role="button", target="_blank", tabindex="0") Help
         button.btn.btn-primary((click)="closeModal.emit()", tabindex="0", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") Close

--- a/src/app/modals/share-link-modal/share-link-modal.component.pug
+++ b/src/app/modals/share-link-modal/share-link-modal.component.pug
@@ -27,5 +27,5 @@
               | {{ 'SHARE_IMG_LINK_MODAL.COPY_TO_CLIPBOARD' | translate }}
             .copy-status-msg {{ copyHTMLStatusMsg }}
       .modal-footer
-        button.btn.btn-link.with-pad((click)="showHelp()", tabindex="0") {{ 'SHARE_IMG_LINK_MODAL.HELP' | translate }}
+        a.link.help-link-text(href="https://support.artstor.org/?article=creating-links", target="_blank", tabindex="0") {{ 'SHARE_IMG_LINK_MODAL.HELP' | translate }}
         button.btn.btn-primary((click)="closeModal.emit()", tabindex="0", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") {{ 'SHARE_IMG_LINK_MODAL.CLOSE' | translate }}

--- a/src/app/modals/share-link-modal/share-link-modal.component.ts
+++ b/src/app/modals/share-link-modal/share-link-modal.component.ts
@@ -123,9 +123,4 @@ export class ShareLinkModal implements OnInit, AfterViewInit {
     document.body.removeChild(textArea);
   }
 
-  // Doesn't get called on SSR application
-  public showHelp(): void{
-    window.open('http://support.artstor.org/?article=creating-links', 'Artstor Support', 'width=600,height=500');
-  }
-
 }

--- a/src/app/uploader/uploader.component.pug
+++ b/src/app/uploader/uploader.component.pug
@@ -23,4 +23,4 @@
             i.icon.icon-loading
       .file-name.error-wrap(*ngIf="invalidFiles && invalidFiles.length > 0")
         .error-msg(*ngFor="let file of invalidFiles") "{{ file.name }}" is not a valid JPEG
-  a.mt-2.link.help(href="http://support.artstor.org/?article-category=09-using-your-own-images", target="_blank", tabindex="0", (keydown.tab)="helpTabKeyDown($event)") {{ 'UPLOAD_IMAGES_MODAL.HELP' | translate }}
+  a.mt-2.link.help-link-text(href="http://support.artstor.org/?article-category=09-using-your-own-images", target="_blank", tabindex="0", (keydown.tab)="helpTabKeyDown($event)") {{ 'UPLOAD_IMAGES_MODAL.HELP' | translate }}

--- a/src/app/uploader/uploader.component.scss
+++ b/src/app/uploader/uploader.component.scss
@@ -65,14 +65,9 @@
       color: #444;
       letter-spacing: 0.4px;
   }
-  .help{
-      float: right;
-      color: var(--orange);
-      text-decoration-color: var(--orange);
 
-      &:hover, &:active {
-          outline: 0;
-      }
+  .help-link-text {
+    float: right;
   }
 
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -353,3 +353,37 @@ body body{
     left: calc(50% - 0.4rem);
   }
 }
+
+.help-link-text {
+  margin-right: 10px !important;
+  color: var(--orange) !important;
+  text-decoration-color: var(--orange) !important;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background: none !important;
+  }
+}
+
+.help-link-icon {
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  line-height: 22px;
+  text-align: center;
+  vertical-align: middle;
+  display: inline-block;
+  cursor: pointer;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: $color-white !important;
+  background-color: var(--gray-dark);
+
+  &:hover,
+  &:active,
+  &:focus {
+    background: var(--gray-dark) !important;
+  }
+}

--- a/src/sass/modules/_modals.scss
+++ b/src/sass/modules/_modals.scss
@@ -212,27 +212,6 @@ ang-new-ig-modal .modal-content {
         margin-right: 40px;
       }
 
-      .help-link {
-          border-radius: 50%;
-          width: 22px;
-          height: 22px;
-          line-height: 22px;
-          text-align: center;
-          vertical-align: middle;
-          display: inline-block;
-          cursor: pointer;
-          font-family: Arial, Helvetica, sans-serif;
-          font-size: 12px;
-          font-weight: 600;
-          color: $color-white !important;
-          background-color: var(--gray-dark);
-
-          &:hover {
-              background-color: #fafafa;
-              color: var(--gray-dark) !important;
-          }
-      }
-
       .link {
           font-family: Verdana;
           font-size: 12px;


### PR DESCRIPTION
Resolves PLATO-206

There are currently two types of "help" links that can appear in modals across Artstor. 

1) Text based links:
![image](https://user-images.githubusercontent.com/3267412/73463368-23c5df80-434b-11ea-8ca8-356fe4534f06.png)

2) Icon based links
![image](https://user-images.githubusercontent.com/3267412/73463436-3c35fa00-434b-11ea-8bf5-04dbc554d94d.png)


Some of the styles were duplicated and others were colliding with eachother. To help clean things up I moved the two different styles to the top level scss file, and created new classes `help-link-text` and `help-link-icon` for referencing them.

This PR also ensures we are meeting the accessibility requirements outlined in PLATO-206