### PR TITLE
PLATO-496: Reformatting badge icons in AIW asset group thumbnails

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -27,7 +27,7 @@
       i.icon.icon-cluster(
         *ngIf="thumbnail.partofcluster",
         (click)="openLink($event, ['/cluster', thumbnail.clusterid, { objTitle :  thumbnail.name }])",
-        title="View related media button icon. Press enter to click this button",
+        title="View related media button icon. Press enter to click this button.",
         tabIndex="3",
         (keyup.enter)="openLink($event, ['/cluster', thumbnail.clusterid, { objTitle :  thumbnail.name }])"
       )
@@ -35,7 +35,7 @@
       i.icon.icon-collab(
         *ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0",
         (click)="openLink($event, ['/associated', thumbnail.id])",
-        title="Others are also interested in button icon. Press enter to click this button",
+        title="Others are also interested in button icon. Press enter to click this button.",
         tabIndex="3",
         (keyup.enter)="openLink($event, ['/associated', thumbnail.artstorid])"
       )
@@ -47,7 +47,8 @@
         (mouseout)="mouseOverMedia=false",
         [ngbTooltip]="mediaTooltip",
         triggers="focusin:focusout mouseenter:mouseleave",
-        placement="right"
+        placement="right",
+        [attr.title]="objectTypeId + 'asset type icon.'",
       )
       <ng-template #mediaTooltip>
         div {{thumbnail.objectTypeId | typeIdPipe:true }}
@@ -64,7 +65,7 @@
         tabIndex="3",
         (mouseover)="mouseOverDetailIcon=true",
         (mouseout)="mouseOverDetailIcon=false"
-        title="Detail view button icon. Press enter to click this button and go to the asset detail",
+        title="Detail view button icon. Press enter to click this button and go to the asset detail.",
       )
       //- Multi view icon
       .multiview-indicator(
@@ -74,7 +75,7 @@
         triggers="focusin:focusout mouseenter:mouseleave",
         placement="right",
         aria-haspopup="true",
-        title="See multiview items button icon. Press enter to click this button",
+        title="See multiview items button icon. Press enter to click this button.",
         tabIndex="3", role="button"
       )
       i.icon(

--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -18,10 +18,11 @@
         [ngbTooltip]="iapTooltip",
         triggers="focusin:focusout mouseenter:mouseleave",
         placement="right"
-        )
-        <ng-template #iapTooltip>
-          div Images for Academic Publishing
-        </ng-template>
+        title="Images for academic publishing icon.",
+      )
+      <ng-template #iapTooltip>
+        div Images for Academic Publishing
+      </ng-template>
       //- Clustered asset (has Duplicates and Details)
       i.icon.icon-cluster(
         *ngIf="thumbnail.partofcluster",
@@ -31,25 +32,57 @@
         (keyup.enter)="openLink($event, ['/cluster', thumbnail.clusterid, { objTitle :  thumbnail.name }])"
       )
       //- Associated or "Grouped with" assets
-      i.icon.icon-collab(*ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0", (click)="openLink($event, ['/associated', thumbnail.id])", title="Others are also interested in button icon. Press enter to click this button", tabIndex="3", (keyup.enter)="openLink($event, ['/associated', thumbnail.artstorid])")
+      i.icon.icon-collab(
+        *ngIf="thumbnail.frequentlygroupedwith && thumbnail.frequentlygroupedwith.length > 0",
+        (click)="openLink($event, ['/associated', thumbnail.id])",
+        title="Others are also interested in button icon. Press enter to click this button",
+        tabIndex="3",
+        (keyup.enter)="openLink($event, ['/associated', thumbnail.artstorid])"
+      )
       //- Media type icon (w/ tooltip)
-      i.icon(*ngIf="thumbnail.objectTypeId && (thumbnail.objectTypeId != 10) && (multiviewItemCount <= 1)",
-          [ngClass]="[ mouseOverMedia ? 'icon-' + (thumbnail.objectTypeId | typeIdPipe) + '-hover' : 'icon-' + (thumbnail.objectTypeId | typeIdPipe) ]",
-          (mouseover)="mouseOverMedia=true",
-          (mouseout)="mouseOverMedia=false",
-          [ngbTooltip]="mediaTooltip",
-          triggers="focusin:focusout mouseenter:mouseleave",
-          placement="right")
-
-        <ng-template #mediaTooltip>
-          div {{thumbnail.objectTypeId | typeIdPipe:true }}
-        </ng-template>
+      i.icon(
+        *ngIf="thumbnail.objectTypeId && (thumbnail.objectTypeId != 10) && (multiviewItemCount <= 1)",
+        [ngClass]="[ mouseOverMedia ? 'icon-' + (thumbnail.objectTypeId | typeIdPipe) + '-hover' : 'icon-' + (thumbnail.objectTypeId | typeIdPipe) ]",
+        (mouseover)="mouseOverMedia=true",
+        (mouseout)="mouseOverMedia=false",
+        [ngbTooltip]="mediaTooltip",
+        triggers="focusin:focusout mouseenter:mouseleave",
+        placement="right"
+      )
+      <ng-template #mediaTooltip>
+        div {{thumbnail.objectTypeId | typeIdPipe:true }}
+      </ng-template>
       //- Detail view icon
-      i.icon(*ngIf="thumbnail.zoom", [ngClass]="[ mouseOverDetailIcon ? 'icon-detail-view-hover' : 'icon-detail-view' ]", [ngbTooltip]="tipDetailView", ngbTooltip, triggers="focusin:focusout mouseenter:mouseleave", placement="right", aria-haspopup="true", tabIndex="3", (mouseover)="mouseOverDetailIcon=true", (mouseout)="mouseOverDetailIcon=false")
+      i.icon(
+        *ngIf="thumbnail.zoom",
+        [ngClass]="[ mouseOverDetailIcon ? 'icon-detail-view-hover' : 'icon-detail-view' ]",
+        [ngbTooltip]="tipDetailView",
+        ngbTooltip,
+        triggers="focusin:focusout mouseenter:mouseleave",
+        placement="right",
+        aria-haspopup="true",
+        tabIndex="3",
+        (mouseover)="mouseOverDetailIcon=true",
+        (mouseout)="mouseOverDetailIcon=false"
+        title="Detail view button icon. Press enter to click this button and go to the asset detail",
+      )
       //- Multi view icon
-      .multiview-indicator(*ngIf="multiviewItemCount > 1", [ngbTooltip]="tipMultiView", ngbTooltip, triggers="focusin:focusout mouseenter:mouseleave", placement="right", aria-haspopup="true", title="See multiview items button icon. Press enter to click this button", tabIndex="3", role="button")
-        i.icon([ngClass]="[ mouseOverMultiview ? 'icon-multiview-hover' : 'icon-multiview' ]", (mouseover)="mouseOverMultiview=true", (mouseout)="mouseOverMultiview=false")
-        span.multiview-count {{multiviewItemCount}}
+      .multiview-indicator(
+        *ngIf="multiviewItemCount > 1",
+        [ngbTooltip]="tipMultiView",
+        ngbTooltip,
+        triggers="focusin:focusout mouseenter:mouseleave",
+        placement="right",
+        aria-haspopup="true",
+        title="See multiview items button icon. Press enter to click this button",
+        tabIndex="3", role="button"
+      )
+      i.icon(
+        [ngClass]="[ mouseOverMultiview ? 'icon-multiview-hover' : 'icon-multiview' ]",
+        (mouseover)="mouseOverMultiview=true",
+        (mouseout)="mouseOverMultiview=false"
+      )
+      span.multiview-count {{multiviewItemCount}}
 
     <ng-template #tipMultiView>
       div This item has <br> multiple views


### PR DESCRIPTION
Resolves [PLATO-496](https://jira.jstor.org/browse/PLATO-496)

## Description

To pass accessibility, we are giving titles to the icons on the asset thumbnails in the image group. 

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [X] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [X] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [X] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
