### PR TITLE
PLATO-518: Provide alternative text for the IIIF viewer on the item page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ docker-compose.yml
 .env
 
 .vscode/settings.json
+.npmrc

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -414,11 +414,11 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             let referenceStripThumbnails = document.querySelectorAll(".referencestrip .openseadragon-canvas");
 
             referenceStripThumbnails.forEach((referenceStripThumbnail, index) => {
-                referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
-                if (event.keyCode === 13) {
-                this.osdViewer.goToPage(index)
-                }
-            })
+                    referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
+                        if (event.keyCode === 13) {
+                        this.osdViewer.goToPage(index)
+                    }
+                })
             })
         });
 

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -414,8 +414,8 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
             let referenceStripThumbnails = document.querySelectorAll(".referencestrip .openseadragon-canvas");
 
             referenceStripThumbnails.forEach((referenceStripThumbnail, index) => {
-                    referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
-                        if (event.keyCode === 13) {
+                referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
+                    if (event.keyCode === 13) {
                         this.osdViewer.goToPage(index)
                     }
                 })

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -407,16 +407,19 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
         });
 
         this.osdViewer.addOnceHandler("tile-drawn", () => {
-          // Get all thumbnails in the reference strip
-          let referenceStripThumbnails = document.querySelectorAll(".referencestrip .openseadragon-canvas");
+            let mainContentCanvas: HTMLElement = <HTMLElement>document.getElementsByTagName("canvas")[0];
+            mainContentCanvas && mainContentCanvas.setAttribute("aria-label", this.assets[0].title ? this.assets[0].title : this.asset[0].description);
 
-          referenceStripThumbnails.forEach((referenceStripThumbnail, index) => {
-            referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
-             if (event.keyCode === 13) {
-               this.osdViewer.goToPage(index)
-             }
-           })
-          })
+            // Get all thumbnails in the reference strip
+            let referenceStripThumbnails = document.querySelectorAll(".referencestrip .openseadragon-canvas");
+
+            referenceStripThumbnails.forEach((referenceStripThumbnail, index) => {
+                referenceStripThumbnail.addEventListener("keydown", (event: KeyboardEvent) => {
+                if (event.keyCode === 13) {
+                this.osdViewer.goToPage(index)
+                }
+            })
+            })
         });
 
         this.osdViewer.addHandler('pan', (value: any) => {


### PR DESCRIPTION
Resolves PLATO-518

## Description

- Add a description to the IIIF canvas using an aria-label to provide alternative text within the viewer space. 
- We should use title metadata as part of the alternative text if available and fallback to the description if no title is available.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
