### PR TITLE
PLATO-466: Confirm and build page of commands for VISIBLE Image Viewer Keyboard Instructions

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -138,7 +138,8 @@ import { LOCAL_STORAGE , WINDOW} from '@ng-toolkit/universal'
 // Error tracking utility for sentry.io
 import * as Sentry from '@sentry/browser';
 // Project Dependencies
-import { version } from '../../package.json'
+import { version } from '../../package.json';
+import { SupportPageComponent } from './support-page/support-page.component'
 
 /**
  * Sentry.io client-side reporter
@@ -291,7 +292,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     PromptComponent,
     TypeIdPipe,
     UploaderComponent,
-    FocusTrapDirective
+    FocusTrapDirective,
+    SupportPageComponent
   ],
   imports: [ // import Angular's modules
     BrowserModule.withServerTransition({ appId: 'avatar' }),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -23,6 +23,7 @@ import { BrowseRoutes } from './browse-page/browse-page.routes'
 import { AccountPage } from './account-page/account-page.component'
 import { LegacyRouteResolver } from './legacy.service'
 import { LinkPage } from './link-page'
+import { SupportPageComponent } from './support-page/support-page.component'
 
 
 export const ROUTES: Routes = [
@@ -64,6 +65,7 @@ export const ROUTES: Routes = [
   { path: 'associated/:objectId', component: AssociatedPage, canActivate: [AuthService] },
   { path: 'associated', component: AssociatedPage, canActivate: [AuthService] },
   { path: 'register', component: RegisterComponent, canActivate: [AuthService] },
+  { path: 'support', component: SupportPageComponent },
   { path: 'link', component: LinkPage },
   { path: 'library', children: [
     { path: '**', component: NoContent, resolve: [LegacyRouteResolver] }

--- a/src/app/support-page/support-page.component.pug
+++ b/src/app/support-page/support-page.component.pug
@@ -8,31 +8,31 @@
     tbody
       tr
         td Move viewport up
-        td W, Up Arrow
+        td w, Up Arrow
       tr
         td Move viewport down
-        td S, Down Arrow
+        td s, Down Arrow
       tr
         td Move viewport left
-        td A, Left Arrow
+        td a, Left Arrow
       tr
         td Move viewport right
-        td D, Right arrow
+        td d, Right arrow
       tr
         td Zoom / Move viewport home
         td 0
       tr
         td Zoom viewport out
-        td - / _, Shift + S, Shift + Down arrow
+        td - / _, Shift + s, Shift + Down arrow
       tr
         td Zoom viewport in
-        td = / +, Shift + W, Shift + Up arrow
+        td = / +, Shift + w, Shift + Up arrow
       tr
         td Rotate clockwise
-        td R
+        td r
       tr
         td Rotate counterclockwise
-        td Shift + R
+        td Shift + r
       tr
         td Flip horizontally
-        td F
+        td f

--- a/src/app/support-page/support-page.component.pug
+++ b/src/app/support-page/support-page.component.pug
@@ -1,0 +1,38 @@
+.container.main-content
+  h1 Keyboard Shortcuts
+  table
+    thead
+      tr
+        th Action
+        th Keyboard Shortcut
+    tbody
+      tr
+        td Move viewport up
+        td W, Up Arrow
+      tr
+        td Move viewport down
+        td S, Down Arrow
+      tr
+        td Move viewport left
+        td A, Left Arrow
+      tr
+        td Move viewport right
+        td D, Right arrow
+      tr
+        td Zoom / Move viewport home
+        td 0
+      tr
+        td Zoom viewport out
+        td - / _, Shift + S, Shift + Down arrow
+      tr
+        td Zoom viewport in
+        td = / +, Shift + W, Shift + Up arrow
+      tr
+        td Rotate clockwise
+        td R
+      tr
+        td Rotate counterclockwise
+        td Shift + R
+      tr
+        td Flip horizontally
+        td F

--- a/src/app/support-page/support-page.component.scss
+++ b/src/app/support-page/support-page.component.scss
@@ -1,0 +1,23 @@
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 32px;
+    margin-bottom: 32px;
+    border-radius: 3px;
+    border-bottom: 1px solid #ccc;
+
+    thead {
+        border-top: 1px solid #ccc;
+        border-bottom: 1px solid #ccc;
+
+        th {
+            padding: 10px 10px 10px;
+        }
+    }
+
+    tbody {
+        td {
+            padding: 10px 10px 10px;
+        }
+    } 
+}

--- a/src/app/support-page/support-page.component.ts
+++ b/src/app/support-page/support-page.component.ts
@@ -5,7 +5,7 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './support-page.component.pug',
   styleUrls: ['./support-page.component.scss']
 })
-export class SupportPageComponent implements OnInit {
+export class SupportPageComponent {
 
   constructor() { }
 

--- a/src/app/support-page/support-page.component.ts
+++ b/src/app/support-page/support-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-support-page',
+  templateUrl: './support-page.component.pug',
+  styleUrls: ['./support-page.component.scss']
+})
+export class SupportPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/support-page/support-page.component.ts
+++ b/src/app/support-page/support-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-support-page',
@@ -8,8 +8,5 @@ import { Component, OnInit } from '@angular/core';
 export class SupportPageComponent {
 
   constructor() { }
-
-  ngOnInit() {
-  }
 
 }


### PR DESCRIPTION
Resolves PLATO-466

## Description

- Build a support page that lists image viewer commands: https://openseadragon.github.io/examples/ui-keyboard-navigation/
- Same style as workspace notes keyboard navigation: https://www.jstor.org/support/text-editor-help/

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
