### PR TITLE
PLATO-550: Add link to IIIF viewer keyboard instructions

### DIFF
--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -80,6 +80,6 @@
     </div>
 
 </div>
-<a [class.aiw-hidden]="state != 1" [routerLink]="['/support']">
+<a [class.aiw-hidden]="state != 1" class="link" [routerLink]="['/support']">
   Viewer Keyboard Instructions
 </a>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -80,3 +80,6 @@
     </div>
 
 </div>
+<a [class.aiw-hidden]="state != 1" [routerLink]="['/support']">
+  Viewer Keyboard Instructions
+</a>

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -80,6 +80,6 @@
     </div>
 
 </div>
-<a [class.aiw-hidden]="state != 1" class="link" [routerLink]="['/support']">
-  Viewer Keyboard Instructions
+<a [class.aiw-hidden]="state != 1" class="link text-primary p-1 mobile--hide" [routerLink]="['/support']" target="_blank">
+  Use this viewer with your keyboard
 </a>


### PR DESCRIPTION
Resolves [PLATO-550](https://jira.jstor.org/browse/PLATO-550)

## Description

Adds a link on non-mobile screens to open up the keyboard instructions for the IIIF viewr

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [X] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [X] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [X] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
