### PR TITLE
SRCHX-511: Make sure that the request id is logged properly for the artstor_search event

### DIFF
--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -39,6 +39,7 @@ export class AssetService {
     public pagination: Observable<any>
     public selection: Observable<any>
     public selectModeToggle: EventEmitter<any> = new EventEmitter()
+    public searchRequestIdAvailable: EventEmitter<any> = new EventEmitter()
 
 
     // Set up subject observable for previousRouteTS
@@ -840,6 +841,8 @@ export class AssetService {
                     data['count'] = data.total
                     // Set the allResults object
                     this.updateLocalResults(data)
+                    // Emit the event for search request id being available, so that it can be used in Captain's Log event
+                    this.searchRequestIdAvailable.emit()
             }, (error) => {
                     console.error(error)
                     this.allResultsSource.next({'error': error})

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -5,7 +5,7 @@ import { Subscription }   from 'rxjs'
 import { map } from 'rxjs/operators'
 
 // Project Dependencies
-import { AssetService, AuthService, LogService, FlagService, DomUtilityService, ScriptService, TitleService } from '../_services'
+import { AssetService, AuthService, LogService, FlagService, DomUtilityService, ScriptService, TitleService, AssetSearchService } from '../_services'
 import { AssetFiltersService } from '../asset-filters/asset-filters.service'
 import { AssetGrid } from './../asset-grid/asset-grid.component'
 import { AppConfig } from '../app.service'
@@ -36,6 +36,7 @@ export class SearchPage implements OnInit, OnDestroy {
   constructor(
         public _appConfig: AppConfig,
         private _assets: AssetService,
+        private _assetSearch: AssetSearchService,
         private route: ActivatedRoute,
         private _filters: AssetFiltersService,
         private _flags: FlagService,
@@ -102,13 +103,18 @@ export class SearchPage implements OnInit, OnDestroy {
         // Remove search term value
         delete logFilters['term']
         // Post search info to Captain's Log
-        this._captainsLog.log({
-          eventType: 'artstor_search',
-          additional_fields: {
-            'searchTerm': params['term'],
-            'searchFilters': logFilters
-          }
-        })
+        this.subscriptions.push(
+          this._assets.searchRequestIdAvailable.pipe(map((abc) => {
+            this._captainsLog.log({
+              eventType: 'artstor_search',
+              referring_requestid: this._assetSearch.latestSearchRequestId,
+              additional_fields: {
+                'searchTerm': params['term'],
+                'searchFilters': logFilters
+              }
+            })
+          })).subscribe()
+        )
 
         this._title.setSubtitle( '"' + params['term'] + '"' )
         this._assets.queryAll(params, refreshSearch);


### PR DESCRIPTION
Resolves SRCHX-511

## Description

Changes in this make sure that we are sending the correct `requestid` value while logging the `artstor_search` event into captain's log. 

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
