### PR TITLE
SRCHX-2444-248-496: Multiple AIW Accessibility fixes

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -103,6 +103,7 @@
             .dropdown-menu(ngbDropdownMenu)
               a#addItemToGroupLink.dropdown-item(
                 (click)="addAssetToIG()",
+                (keydown.enter)="addAssetToIG()",
                 tabindex="2",
                 aria-label="Add Item to Group",
                 role="button")
@@ -110,6 +111,7 @@
                 | &nbsp;Add item
               a#addViewToGroupLink.dropdown-item(
                 (click)="addAssetToIG(true)",
+                (keydown.enter)="addAssetToIG(true)",
                 tabindex="2",
                 aria-label="Add View to Group",
                 [class.disabled]="assetViewer.state !== 1 || multiviewItems",

--- a/src/app/modals/login-req-modal/login-req-modal.component.pug
+++ b/src/app/modals/login-req-modal/login-req-modal.component.pug
@@ -2,7 +2,7 @@
   .modal-dialog(role="document", focusTrap)
     .modal-content
       .modal-header
-        h4.modal-title {{ 'LOGIN_REQUIRED_MODAL.HEADING' | translate }}
+        h4.modal-title(#loginRequiredHeader, tabindex="0",) {{ 'LOGIN_REQUIRED_MODAL.HEADING' | translate }}
         button.close(type="button", (click)="closeModal.emit()", aria-label="Close")
           span(aria-hidden="true") &times;
       .modal-body

--- a/src/app/modals/login-req-modal/login-req-modal.component.ts
+++ b/src/app/modals/login-req-modal/login-req-modal.component.ts
@@ -20,6 +20,8 @@ export class LoginReqModal {
   @Output()
   public closeModal: EventEmitter<any> = new EventEmitter();
 
+  @ViewChild("loginRequiredHeader", {read: ElementRef}) loginRequiredHeaderElement: ElementRef;
+
   constructor(
     private _router: Router,
     public _auth: AuthService,
@@ -33,6 +35,17 @@ export class LoginReqModal {
     // Set focus to the modal to make the links in the modal first thing to tab for accessibility
     // let htmlelement: HTMLElement = <HTMLElement>this._dom.byId('modal');
     // htmlelement.focus();
+  }
+
+  ngAfterViewInit() {
+    this.startModalFocus()
+  }
+
+  // Set initial focus on the modal Title h1
+  public startModalFocus() {
+    if (this.loginRequiredHeaderElement && this.loginRequiredHeaderElement.nativeElement){
+      this.loginRequiredHeaderElement.nativeElement.focus()
+    }
   }
 
   goToLogin() {

--- a/src/app/modals/search-modal/search-modal.component.pug
+++ b/src/app/modals/search-modal/search-modal.component.pug
@@ -80,7 +80,7 @@
                                 | {{ child.name }} {{ child.count ? '(' + child.count +')' : '' }}
       .modal-footer
         .alert.alert-warning(*ngIf="error.empty", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.EMPTY_SEARCH' | translate")
-        .alert.alert-warning(*ngIf="error.date", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE' | translate")
+        .alert.alert-warning(*ngIf="error.date", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE' | translate", role="alert", attr.aria-label="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE'")
         label.sr-only(for="helpBtn") Help
         button.btn.btn-link.with-pad(id="helpBtn", tabindex="0", (click)="openHelp()") <u> {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.HELP' | translate }} </u>
         label.sr-only(for="clearBtn") Clear all search queries

--- a/src/app/search-page/search-page.component.pug
+++ b/src/app/search-page/search-page.component.pug
@@ -4,8 +4,7 @@
     .row
       .col-sm-3(style="margin-top: 1rem;")
         .mobile--hide
-          div(aria-activedescendant="button")
-            button.skip-btn#skip-to-search-link((click)="skipToSearchSec()", (keyup.enter)="skipToSearchSec()", tabindex="2", class="sr-only sr-only-focusable") This is the filters section. Skip to the search results section.
+          button.skip-btn#skip-to-search-link((click)="skipToSearchSec()", (keyup.enter)="skipToSearchSec()", tabindex="2", class="sr-only sr-only-focusable") This is the filters section. Skip to the search results section.
           h3.browse-category {{ 'HOME.HEADINGS.FEATURED' | translate }}
           p.small(*ngIf="siteID!='SAHARA' && _auth.isPublicOnly()", [innerHtml]="'HOME.CONTENT_ACCESS.PUBLIC' | translate")
           p.small(*ngIf="siteID!='SAHARA' && !_auth.isPublicOnly()", [innerHtml]="'HOME.CONTENT_ACCESS.USER' | translate")
@@ -13,8 +12,7 @@
           ang-asset-filters
       .col-sm-9
         h1.mobile--show Results
-        div(aria-activedescendant="button")
-          button.skip-btn#skip-to-filter-link((click)="skipToFilterSec()", (keyup.enter)="skipToFilterSec()", tabindex="3", class="sr-only sr-only-focusable") This is the search results section. Skip to the filters section.
+        button.skip-btn#skip-to-filter-link((click)="skipToFilterSec()", (keyup.enter)="skipToFilterSec()", tabindex="3", class="sr-only sr-only-focusable") This is the search results section. Skip to the filters section.
         .row.no-gutters.row--search-bar
           #mainContent.col-md-9.search-page-highlight
             ang-search(*ngIf="_auth.isPublicOnly()", [allowSearchInRes]="true", [UserNotLoggedIn]="true")

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -338,7 +338,8 @@
     "COLLECTION_HEADING": "Collection",
     "ERRORS": {
       "EMPTY_SEARCH": "<b>Search is Empty</b> Please add a search term or select a filter",
-      "DUMB_DATE": "<b>End Date is less than Start Date</b> End date must be greater than or equal to Start date."
+      "DUMB_DATE": "<b>End Date is less than Start Date</b> End date must be greater than or equal to Start date.",
+      "DUMB_DATE_ARIA_MESSAGE": "Error: End Date is less than Start Date. End date must be greater than or equal to Start date."
     },
     "BUTTONS":{
       "HELP": "Help",


### PR DESCRIPTION
Resolves [SRCHX-244](https://jira.jstor.org/browse/SRCHX-244)
Resolves [SRCHX-248](https://jira.jstor.org/browse/SRCHX-248)
Resolves [SRCHX-496](https://jira.jstor.org/browse/SRCHX-496)

## Description
A couple changes here... it's a nice read.
-  First ticket: Download and Add to Image group buttons on the asset page were not keyboard interactive. This had to do with the focus on the please login modal that shows up when they are not logged in. 
- Second ticket: Needed to add an aria label to the alert in advanced search so that the screen reader announces the error when it appear in the modal when the user enters a end date less than a start date.
- Third ticket: Removed a useless div around the screen reader only elements that allow the user to switch between filter section and search result section on the search-page

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [x] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
