### PR TITLE
SRCHX-447-448-247: 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.101",
+  "version": "2.7.102",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/browse-page/browse-page.component.pug
+++ b/src/app/browse-page/browse-page.component.pug
@@ -2,5 +2,5 @@ div
   nav-menu
   .container.main-content(tabindex="-1")
     nav.nav.nav-inline.coll-nav
-      a.nav-link#mainContent(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)", tabindex="3") {{ colOpt.label }}
+      a.nav-link(*ngFor="let colOpt of colMenuArray", [routerLink]="[colOpt.link]", routerLinkActive="active", (click)="selectColMenu(colOpt.link)", tabindex="3") {{ colOpt.label }}
     router-outlet

--- a/src/app/browse-page/browse-page.component.scss
+++ b/src/app/browse-page/browse-page.component.scss
@@ -210,6 +210,9 @@
     }
 }
 
+#iconSearchSubmit {
+  font-size: 0;
+}
 
 #iconSearchSubmit, #iconSearchClear {
     &.form-control__icon {

--- a/src/app/browse-page/browse-page.component.scss
+++ b/src/app/browse-page/browse-page.component.scss
@@ -17,6 +17,7 @@
     margin-right: 1rem;
     display: inline-block;
     background: #fff;
+    text-decoration: underline;
 
     &:hover, &:active, &:focus {
         color: #000 !important;
@@ -55,6 +56,7 @@
         display: inline-block;
         text-indent: 0;
         padding: 0;
+        text-decoration: underline;
 
         &:hover, &:active, &:focus {
             color: #000;

--- a/src/app/browse-page/library.component.pug
+++ b/src/app/browse-page/library.component.pug
@@ -8,9 +8,9 @@ nav.nav.nav-inline.browse-nav
         label.sr-only(for="browsePageFilter") Filter Collections by title, there are more than 300 collections in the Artstor Digital Library
         input#browsePageFilter.form-control.has-icon(placeholder="Filter by collection title...", tabindex="6", [(ngModel)]="searchTerm", (keydown.enter)="addRouteParam('searchTerm', searchTerm)")
         label.sr-only(for="iconSearchSubmit") Filter
-        button#iconSearchSubmit.icon.icon-filter.form-control__icon((click)="addRouteParam('searchTerm', searchTerm)", (keydown.enter)="addRouteParam('searchTerm', searchTerm)", tabindex="6")
-      #alertNoResults.alert.alert-warning.input-group(*ngIf="filteredCategoryFacets.length === 0 && !loading", [innerHtml]="'No search results found'")
-      #alertNoSearchTerm.alert.alert-warning.input-group(*ngIf="noTermMsg", [innerHtml]="'Please enter search term(s).'")
+        button#iconSearchSubmit.icon.icon-filter.form-control__icon((click)="addRouteParam('searchTerm', searchTerm)", (keydown.enter)="addRouteParam('searchTerm', searchTerm)", tabindex="6") Filter
+      #alertNoResults.alert.alert-warning.input-group(*ngIf="filteredCategoryFacets.length === 0 && !loading", [innerHtml]="'No search results found'" role="alert")
+      #alertNoSearchTerm.alert.alert-warning.input-group(*ngIf="noTermMsg", [innerHtml]="'Please enter search term(s).'" role="alert")
     h1.mb-4 Artstor Digital Library
     ul.filter-list(role="region", id="filtered-col-list", aria-live="polite")
       .sr-only Showing titles with your search '{{searchTermForSR}}'.

--- a/src/app/browse-page/library.component.ts
+++ b/src/app/browse-page/library.component.ts
@@ -238,7 +238,7 @@ export class LibraryComponent implements OnInit {
           // If the search term is available filter category facets on search term
           this.filteredCategoryFacets = this.searchTerm ? this.categoryFacets.filter(item => { return item.title.match(new RegExp(this.searchTerm, "i")) ? true : false }) : this.categoryFacets
           this.searchTermForSR = this.searchTerm
-          
+
           this.loading = false
 
           storageBrwseColObj[facetType] = this.categoryFacets
@@ -275,7 +275,7 @@ export class LibraryComponent implements OnInit {
    * @param value The value of the parameter
    */
   private addRouteParam(key: string, value: any) {
-    this.noTermMsg = false;
+    this.noTermMsg = value === "";
     let currentParamsObj: Params = Object.assign({}, this.route.snapshot.params);
     currentParamsObj[key] = value;
     this.router.navigate([currentParamsObj], { relativeTo: this.route });

--- a/src/app/home/featured/featured.component.pug
+++ b/src/app/home/featured/featured.component.pug
@@ -1,4 +1,4 @@
-.row#featured-container.mx-0((mouseenter)="pauseSlideShow()", (mouseleave)="runSlideshow(primaryFeaturedIndex)")
+.row#featured-container.mx-0
   //- Primary Image
   .col-sm-9.featured-col#featured-primary
     ng-container(*ngFor="let i of [0,1,2]")
@@ -12,11 +12,11 @@
   //- Secondary Images
   .col-sm-3.featured-col#featured-side
     .card(*ngFor="let collection of featured; let i = index")
-      a.card__placard(*ngIf="primaryFeaturedIndex === i", (focus)="pauseSlideShow()", (focusout)="secondaryImgsFocusOut(i)", [attr.href]="featured[i].link | translate", tabindex="4", [attr.aria-label]="'Featured Collection: ' + (collection.subheading | translate) + '. Press enter to open this collection.'")
+      a.card__placard(*ngIf="primaryFeaturedIndex === i", [attr.href]="featured[i].link | translate", tabindex="4", [attr.aria-label]="'Featured Collection: ' + (collection.subheading | translate) + '. Press enter to open this collection.'")
         //- Title and description of the current primary image
         .featured-title([innerHtml]="collection.subheading | translate")
         p.featured-caption.small([innerHtml]="collection.description | translate")
-      a.link.hidden-text(*ngIf="primaryFeaturedIndex !== i", [attr.href]="featured[i].link | translate", (mouseenter)="switchFeaturedIndex(i)", (click)="switchFeaturedIndex(i)", (focus)="pauseSlideShow()", (focusout)="secondaryImgsFocusOut(i)", tabindex="4") {{ featured[i].link_title | translate}}
+      a.link.hidden-text(*ngIf="primaryFeaturedIndex !== i", [attr.href]="featured[i].link | translate", (mouseenter)="switchFeaturedIndex(i)", (click)="switchFeaturedIndex(i)", tabindex="4") {{ featured[i].link_title | translate}}
         img.no-stretch.featured-side-img([attr.src]="collection.img_src | translate",
         [attr.alt]="collection.alt | translate", [attr.title]="collection.link_title | translate", [attr.aria-label]="'Featured Collection: ' + (collection.subheading | translate) + '. Press enter to open this collection.'")
 

--- a/src/app/home/featured/featured.component.pug
+++ b/src/app/home/featured/featured.component.pug
@@ -2,7 +2,7 @@
   //- Primary Image
   .col-sm-9.featured-col#featured-primary
     ng-container(*ngFor="let i of [0,1,2]")
-      a.card.featured-card.hidden-text([class.fade-in]="primaryFeaturedIndex == i", [attr.href]="featured[i].link | translate", tabindex="-1" data-qa="featuredCollectionLink" style="font-sixe:0") {{ featured[i].link_title | translate }}
+      a.card.featured-card.hidden-text([class.fade-in]="primaryFeaturedIndex == i", [attr.href]="featured[i].link | translate", tabindex="-1" data-qa="featuredCollectionLink") {{ featured[i].link_title | translate }}
         img#primary-featured-img.card-img-top.no-stretch(
           [attr.src]="featured[i].img_src | translate",
           [attr.alt]="featured[i].alt | translate",

--- a/src/app/home/featured/featured.component.pug
+++ b/src/app/home/featured/featured.component.pug
@@ -2,7 +2,7 @@
   //- Primary Image
   .col-sm-9.featured-col#featured-primary
     ng-container(*ngFor="let i of [0,1,2]")
-      a#featuredCollectionLink.card.featured-card([class.fade-in]="primaryFeaturedIndex == i", [attr.href]="featured[i].link | translate", tabindex="-1")
+      a.card.featured-card.hidden-text([class.fade-in]="primaryFeaturedIndex == i", [attr.href]="featured[i].link | translate", tabindex="-1" data-qa="featuredCollectionLink" style="font-sixe:0") {{ featured[i].link_title | translate }}
         img#primary-featured-img.card-img-top.no-stretch(
           [attr.src]="featured[i].img_src | translate",
           [attr.alt]="featured[i].alt | translate",
@@ -16,7 +16,7 @@
         //- Title and description of the current primary image
         .featured-title([innerHtml]="collection.subheading | translate")
         p.featured-caption.small([innerHtml]="collection.description | translate")
-      a.link(*ngIf="primaryFeaturedIndex !== i", [attr.href]="featured[i].link | translate", (mouseenter)="switchFeaturedIndex(i)", (click)="switchFeaturedIndex(i)", (focus)="pauseSlideShow()", (focusout)="secondaryImgsFocusOut(i)", tabindex="4")
+      a.link.hidden-text(*ngIf="primaryFeaturedIndex !== i", [attr.href]="featured[i].link | translate", (mouseenter)="switchFeaturedIndex(i)", (click)="switchFeaturedIndex(i)", (focus)="pauseSlideShow()", (focusout)="secondaryImgsFocusOut(i)", tabindex="4") {{ featured[i].link_title | translate}}
         img.no-stretch.featured-side-img([attr.src]="collection.img_src | translate",
         [attr.alt]="collection.alt | translate", [attr.title]="collection.link_title | translate", [attr.aria-label]="'Featured Collection: ' + (collection.subheading | translate) + '. Press enter to open this collection.'")
 
@@ -24,7 +24,7 @@
 .row#featured-mobile-container
   ngb-carousel
     ng-template(*ngFor="let collection of featured", ngbSlide)
-      a#featuredCollectionLink.card.featured-card([attr.href]="collection.link | translate")
+      a.card.featured-card.hidden-text([attr.href]="collection.link | translate" data-qa="featuredCollectionLink")
         img.d-block.w-100([attr.src]="collection.img_src | translate", [attr.alt]="collection.alt | translate", [attr.title]="collection.link_title | translate")
       p.small.p-1([innerHTML]="collection.caption | translate")
 

--- a/src/app/home/featured/featured.component.scss
+++ b/src/app/home/featured/featured.component.scss
@@ -9,6 +9,10 @@
     }
 }
 
+.hidden-text {
+  font-size: 0;
+}
+
 #featured-container {
     margin-bottom: 10px;
 
@@ -27,7 +31,7 @@
             &:last-child {
                 padding-bottom: 0;
             }
-            
+
             & .featured-side-img {
                 margin: auto;
                 animation: fader 1.5s;

--- a/src/app/home/featured/featured.component.ts
+++ b/src/app/home/featured/featured.component.ts
@@ -32,44 +32,11 @@ export class FeaturedComponent implements OnInit {
   private intervalId: any
 
   constructor(
-      public _appConfig: AppConfig, 
+      public _appConfig: AppConfig,
       public _auth: AuthService,
       @Inject(PLATFORM_ID) private platformId: Object
       ) {
     this.conf = this._appConfig.config.featuredCollection // 'HOME.FEATURED' in en.json
-  }
-
-  /**
-   * runSlideShow - Start the homepage slideshow
-   * @param primary_index pass in primaryFeaturedIndex,
-   * so it is locally scoped within setInterval.
-   */
-  public runSlideshow(primary_index: number) {
-    this.primaryFeaturedIndex = primary_index
-
-    this.intervalId = setInterval(() => {
-      if (!this.skipAutoSlide) {
-        if (this.primaryFeaturedIndex === 2)
-          this.primaryFeaturedIndex = 0
-        else
-          this.primaryFeaturedIndex += 1
-      } else {
-        this.skipAutoSlide = false
-      }
-    }, 9000)
-  }
-
-  /**
-   * runSlideShow - Pause the homepage slideshow
-   */
-  public pauseSlideShow() {
-    clearInterval(this.intervalId)
-  }
-
-  public secondaryImgsFocusOut(index) {
-    if (index === 0 || index === 2) {
-      this.runSlideshow(this.primaryFeaturedIndex)
-    }
   }
 
   ngOnInit() {
@@ -91,11 +58,6 @@ export class FeaturedComponent implements OnInit {
     this.base = this.conf + '.' + this.featuredType + '.'
     this.initCollections()
 
-    // Run client-side
-    if (isPlatformBrowser(this.platformId)) {
-      // Start slideshow
-      this.runSlideshow(this.primaryFeaturedIndex)
-    }
   }
 
   /**

--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -46,10 +46,13 @@
         .card([class.col-sm-3]="!showBlog")
           .card-header
           h3 {{ 'HOME.QUESTIONS.HEADING' | translate }}
-          ul.list-group.list-group-flush.list-group-clean(*ngIf="siteID=='ARTSTOR'")
-            a#linkEmailInstitutionContact.list-group-item.small([href]="institution.institutionContact && institution.institutionContact[0] && institution.institutionContact[0].email ? 'mailto:' + institution.institutionContact[0].email : 'mailto:userservices@artstor.org'") {{ 'HOME.QUESTIONS.EMAIL_INSTITUTION' | translate }}
-            a#linkEmailArtstor.list-group-item.small([href]="artStorEmailLink") {{ 'HOME.QUESTIONS.EMAIL_ARTSTOR' | translate }}
-            a#linkArtstorWebinar.list-group-item.small(href="http://www.artstor.org/webinars?view=ADL", target="_blank") {{ 'HOME.QUESTIONS.WEBINAR' | translate }}
+          ul.list-group.list-group-flush.list-group-clean.no-bullets(*ngIf="siteID=='ARTSTOR'")
+            li.list-group-item.small
+              a#linkEmailInstitutionContact([href]="institution.institutionContact && institution.institutionContact[0] && institution.institutionContact[0].email ? 'mailto:' + institution.institutionContact[0].email : 'mailto:userservices@artstor.org'") {{ 'HOME.QUESTIONS.EMAIL_INSTITUTION' | translate }}
+            li.list-group-item.small
+              a#linkEmailArtstor([href]="artStorEmailLink") {{ 'HOME.QUESTIONS.EMAIL_ARTSTOR' | translate }}
+            li.list-group-item.small
+              a#linkArtstorWebinar(href="http://www.artstor.org/webinars?view=ADL", target="_blank") {{ 'HOME.QUESTIONS.WEBINAR' | translate }}
             li#itemArtstorAccess.list-group-item.small(*ngIf="institution.displayName") {{ 'HOME.ACCESS_PROVIDED_BY' | translate }}
               br
               b {{ institution.displayName }}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -27,6 +27,10 @@
     }
 }
 
+.no-bullets {
+  list-style: none;
+}
+
 .featured-caption {
     @extend %SansRegular;
     font-size: 10px;


### PR DESCRIPTION
Resolves [SRCHX-447](https://jira.jstor.org/browse/SRCHX-447)
Resolves [SRCHX-448](https://jira.jstor.org/browse/SRCHX-448)
Resolves [SRCHX-247](https://jira.jstor.org/browse/SRCHX-247)


## Description
More multiple accessibility fixes to the Artstor website.

**SRCHX-447 (Browse Page)**
- add discernable text to buttons, hidden on page
- remove duplicate and unused id (main-content)
- **FIXED** the alert message when filtering when no text entered

**SRCHX-448 (Home Page)**
- remove duplicate ids since they must be unique from the featured cards, used data-qa instead
- links must have discernable text, hidden on the page
- `<ul>` tags must only contain `<li>`, added a no-bullets class with styling 

**SRCHX-247 (Home Page slideshow)**
- removed the auto-cycling to avoid confusion and accessibility problems


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
