### PR TITLE
SRCHX-447-448: Better accessiblity fixes for browse and home page

### DIFF
--- a/src/app/browse-page/library.component.pug
+++ b/src/app/browse-page/library.component.pug
@@ -12,14 +12,14 @@ nav.nav.nav-inline.browse-nav
       #alertNoResults.alert.alert-warning.input-group(*ngIf="filteredCategoryFacets.length === 0 && !loading", [innerHtml]="'No search results found'" role="alert")
       #alertNoSearchTerm.alert.alert-warning.input-group(*ngIf="noTermMsg", [innerHtml]="'Please enter search term(s).'" role="alert")
     h1.mb-4 Artstor Digital Library
-    ul.filter-list(role="region", id="filtered-col-list", aria-live="polite")
+    ul.filter-list(id="filtered-col-list", aria-live="polite" role="list")
       .sr-only Showing titles with your search '{{searchTermForSR}}'.
-      li.filter.filter--browse(*ngFor="let facet of filteredCategoryFacets; let i=index;", [class.hidden]="facet.title === '' || !facet.name")
+      li.filter.filter--browse(*ngFor="let facet of filteredCategoryFacets; let i=index;", [class.hidden]="facet.title === '' || !facet.name" role="listitem")
         a.tag-link(*ngIf="facetQueryMap[facetType] == 'category'", [routerLink]="['/category', facet.name ]", tabindex="7", attr.aria-label="{{facet.title}}, which has {{facet.count}} items")
           | {{ facet.title }} ({{facet.count}})
         a.tag-link(*ngIf="facetQueryMap[facetType] != 'category'", [routerLink]="['/search/*', getLinkParam(facetType, facet.name)]", tabindex="7", attr.aria-label="{{facet.name}}, which has {{facet.count}} items")
           | {{facet.name}} ({{facet.count}})
-      li.filter.filter--browse(*ngFor="let key of ObjectKeys(hierarchicalFacets).sort()")
+      li.filter.filter--browse(*ngFor="let key of ObjectKeys(hierarchicalFacets).sort()" role="listitem")
         a.tag-link([routerLink]="['/search/*', getLinkParam(facetType, hierarchicalFacets[key].element.efq)]", tabindex="7", attr.aria-label="{{key}}, which has {{hierarchicalFacets[key].element.count}} items") {{key}} ({{hierarchicalFacets[key].element.count}})
         ul
           li.filter.filter--browse(*ngFor="let childKey of ObjectKeys(hierarchicalFacets[key].children).sort()")

--- a/src/app/home/featured/featured.component.pug
+++ b/src/app/home/featured/featured.component.pug
@@ -3,7 +3,7 @@
   .col-sm-9.featured-col#featured-primary
     ng-container(*ngFor="let i of [0,1,2]")
       a.card.featured-card.hidden-text([class.fade-in]="primaryFeaturedIndex == i", [attr.href]="featured[i].link | translate", tabindex="-1" data-qa="featuredCollectionLink") {{ featured[i].link_title | translate }}
-        img#primary-featured-img.card-img-top.no-stretch(
+        img.card-img-top.no-stretch(
           [attr.src]="featured[i].img_src | translate",
           [attr.alt]="featured[i].alt | translate",
           [attr.title]="featured[i].link_title | translate",


### PR DESCRIPTION
Resolves [SRCHX-447](https://jira.jstor.org/browse/SRCHX-447)
Resolves [SRCHX-448](https://jira.jstor.org/browse/SRCHX-448)

## Description
Accessibility tickets are fun. 

Needed role's to be list and list item, otherwise even though a `<li>` was wrapped by a `<ul>`, accessibility tools thought it was not.

Also another ID that needed to be removed. Unused throughout the code and was creating duplicates


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
