### PR TITLE
PALS-294: AIW: Temporarily remove login-to-download requirement

### DIFF
--- a/src/app/_services/flag.service.ts
+++ b/src/app/_services/flag.service.ts
@@ -91,7 +91,8 @@ export interface FeatureFlags {
   solrMetadata?: boolean,
   // detailViews?: boolean,
   exportGoogle?: boolean,
-  relatedResFlag?: boolean
+  relatedResFlag?: boolean,
+  requireLoginForAdlDownload?: boolean
 }
 
 interface FlagServiceResponse {

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -89,7 +89,6 @@
     //- Asset Metadata Column
     .col-md-4(*ngIf="assets[0]",[class.hidden]="isFullscreen")
       .py-3
-        //- If the user has not accepted the agreement, show modal when clicked, otherwise download immediately
         .btn-row
           //- Edit
           //- * (mouseup) is a Firefox fix for firing the copy event
@@ -118,43 +117,19 @@
                 role="button")
                 i.icon.icon-add-detail-view([class.disabled]="assetViewer.state !== 1 || multiviewItems")
                 | &nbsp;Add detail view
-          //- Download dropdown options
-          .dropdown.d-inline-block(ngbDropdown, *ngIf="assets[0].downloadLink && (user.isLoggedIn || hasExternalAccess || assets[0].publicDownload)", triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
-            button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
-              | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
-              = " "
-            .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
-              h6.dropdown-header(*ngIf="assets[0].disableDownload") Item not available for download
-              a#downloadAssetLink.dropdown-item(download,
-                [attr.href]="userHasAcceptedTerms() ? generatedFullURL : null",
-                (click)="handleDownloadImageClick()",
-                (keydown.enter)="handleDownloadImageClick()",
-                (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
-                (keyup.arrowup)="downloadOptsArrowUp($event.target)",
-                [class.disabled]="assets[0].disableDownload",
-                title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
-                target="_blank",
-                tabindex="2",
-                aria-label="Download item",
-                role="button")
-                i.icon.icon-download
-                | &nbsp;Download item
-              a#downloadViewLink.dropdown-item(
-                [attr.href]="userHasAcceptedTerms() ? downloadViewLink : null",
-                (click)="handleDownloadViewClick()",
-                (keydown.enter)="handleDownloadViewClick()",
-                (keyup.arrowup)="downloadOptsArrowUp($event.target)",
-                [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
-                target="_blank",
-                tabindex="2",
-                aria-label="Download item’s detail view",
-                role="button")
-                i.icon.icon-download-detail-view
-                | &nbsp;Download detail view
-          //- False door button if user is not logged in
-          button.assetpage-btn.btn.btn-secondary(*ngIf="assets[0].downloadLink && !(user.isLoggedIn || hasExternalAccess) && !assets[0].publicDownload", (click)="showLoginModal = true", (keydown.enter)="showLoginModal = true", tabindex="2", aria-label="Download")
-            | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
-            i#downloadAssetLink.icon.icon-download-asset-orange
+          ng-container(*ngIf="requireLoginForAdlDownload")
+            ng-container(*ngIf="user.isLoggedIn || assets[0].publicDownload")
+              ng-container(*ngTemplateOutlet="downloadDropdown")
+            ng-container(*ngIf="!user.isLoggedIn && !assets[0].publicDownload")
+              ng-container(*ngTemplateOutlet="falseDoorDownload")
+          ng-container(*ngIf="!requireLoginForAdlDownload")
+            ng-container(*ngIf="assets[0].publicDownload")
+              ng-container(*ngTemplateOutlet="downloadDropdown")
+            ng-container(*ngIf="!assets[0].publicDownload")
+              ng-container(*ngIf="(user?.status || user.isLoggedIn)")
+                ng-container(*ngTemplateOutlet="downloadDropdown")
+              ng-container(*ngIf="!(user?.status || user.isLoggedIn)")
+                ng-container(*ngTemplateOutlet="falseDoorDownload")
           .row#asset-btn
             a.assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
@@ -351,4 +326,52 @@ ang-confirm-modal(*ngIf="showDeletePCModal", (closeModal)="closeDeletePC($event)
 <ng-template #multiViewDownloadDisabled>
   div This is not available for download at this time.
 </ng-template>
+
+<ng-template #downloadDropdown>
+  .dropdown.d-inline-block(*ngIf="assets[0].downloadLink", ngbDropdown, triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
+    button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
+      | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
+      = " "
+    .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
+      h6.dropdown-header(*ngIf="assets[0].disableDownload") Item not available for download
+      a#downloadAssetLink.dropdown-item(download,
+        [attr.href]="userHasAcceptedTerms() ? generatedFullURL : null",
+        (click)="handleDownloadImageClick()",
+        (keydown.enter)="handleDownloadImageClick()",
+        (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
+        (keyup.arrowup)="downloadOptsArrowUp($event.target)",
+        [class.disabled]="assets[0].disableDownload",
+        title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
+        target="_blank",
+        tabindex="2",
+        aria-label="Download item",
+        role="button")
+        i.icon.icon-download
+        | &nbsp;Download item
+      a#downloadViewLink.dropdown-item(
+        [attr.href]="userHasAcceptedTerms() ? downloadViewLink : null",
+        (click)="handleDownloadViewClick()",
+        (keydown.enter)="handleDownloadViewClick()",
+        (keyup.arrowup)="downloadOptsArrowUp($event.target)",
+        [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
+        target="_blank",
+        tabindex="2",
+        aria-label="Download item’s detail view",
+        role="button")
+        i.icon.icon-download-detail-view
+        | &nbsp;Download detail view
+</ng-template>
+
+<ng-template #falseDoorDownload>
+  button.assetpage-btn.btn.btn-secondary(
+    *ngIf="assets[0].downloadLink",
+    (click)="showLoginModal = true",
+    (keydown.enter)="showLoginModal = true",
+    tabindex="2",
+    aria-label="Download"
+  )
+    | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
+    i#downloadAssetLink.icon.icon-download-asset-orange
+</ng-template>
+
 

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -117,19 +117,48 @@
                 role="button")
                 i.icon.icon-add-detail-view([class.disabled]="assetViewer.state !== 1 || multiviewItems")
                 | &nbsp;Add detail view
-          ng-container(*ngIf="requireLoginForAdlDownload")
-            ng-container(*ngIf="user.isLoggedIn || assets[0].publicDownload")
-              ng-container(*ngTemplateOutlet="downloadDropdown")
-            ng-container(*ngIf="!user.isLoggedIn && !assets[0].publicDownload")
-              ng-container(*ngTemplateOutlet="falseDoorDownload")
-          ng-container(*ngIf="!requireLoginForAdlDownload")
-            ng-container(*ngIf="assets[0].publicDownload")
-              ng-container(*ngTemplateOutlet="downloadDropdown")
-            ng-container(*ngIf="!assets[0].publicDownload")
-              ng-container(*ngIf="(user?.status || user.isLoggedIn)")
-                ng-container(*ngTemplateOutlet="downloadDropdown")
-              ng-container(*ngIf="!(user?.status || user.isLoggedIn)")
-                ng-container(*ngTemplateOutlet="falseDoorDownload")
+          ng-container([ngSwitch]="showDownloadDropdown")
+            .dropdown.d-inline-block(*ngSwitchCase="true", ngbDropdown, triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
+              button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
+                | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
+                = " "
+              .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
+                h6.dropdown-header(*ngIf="assets[0].disableDownload") Item not available for download
+                a#downloadAssetLink.dropdown-item(download,
+                  [attr.href]="userHasAcceptedTerms() ? generatedFullURL : null",
+                  (click)="handleDownloadImageClick()",
+                  (keydown.enter)="handleDownloadImageClick()",
+                  (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
+                  (keyup.arrowup)="downloadOptsArrowUp($event.target)",
+                  [class.disabled]="assets[0].disableDownload",
+                  title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
+                  target="_blank",
+                  tabindex="2",
+                  aria-label="Download item",
+                  role="button")
+                  i.icon.icon-download
+                  | &nbsp;Download item
+                a#downloadViewLink.dropdown-item(
+                  [attr.href]="userHasAcceptedTerms() ? downloadViewLink : null",
+                  (click)="handleDownloadViewClick()",
+                  (keydown.enter)="handleDownloadViewClick()",
+                  (keyup.arrowup)="downloadOptsArrowUp($event.target)",
+                  [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
+                  target="_blank",
+                  tabindex="2",
+                  aria-label="Download item’s detail view",
+                  role="button")
+                  i.icon.icon-download-detail-view
+                  | &nbsp;Download detail view
+            button.assetpage-btn.btn.btn-secondary(
+              *ngSwitchCase="false",
+              (click)="showLoginModal = true",
+              (keydown.enter)="showLoginModal = true",
+              tabindex="2",
+              aria-label="Download"
+            )
+              | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
+              i#downloadAssetLink.icon.icon-download-asset-orange
           .row#asset-btn
             a.assetpage-btn.btn.btn-secondary(*ngIf="assets[0]", (click)="showGenerateCitation = true", (focus)="closeDropdowns()", (keydown.enter)="showGenerateCitation = true", tabindex="2", aria-label="Cite this item", role="button")
               | {{ 'ASSET_PAGE.BUTTONS.GENERATE_CITATION' | translate}}
@@ -326,52 +355,3 @@ ang-confirm-modal(*ngIf="showDeletePCModal", (closeModal)="closeDeletePC($event)
 <ng-template #multiViewDownloadDisabled>
   div This is not available for download at this time.
 </ng-template>
-
-<ng-template #downloadDropdown>
-  .dropdown.d-inline-block(*ngIf="assets[0].downloadLink", ngbDropdown, triggers="focusin:focusout mouseenter:mouseleave", placement="bottom", aria-haspopup="true")
-    button#downloadAssetDropdown.btn.btn-secondary(ngbDropdownToggle [class.loading]="downloadLoading", (click)="genDownloadLinks()", (keydown.enter)="genDownloadLinks()", (keyup.arrowdown)="downloadOptsArrowDown($event.target)", tabindex="2", aria-label="Download")
-      | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
-      = " "
-    .dropdown-menu.download-menu(ngbDropdownMenu, aria-labelledby="dropdownBasic1")
-      h6.dropdown-header(*ngIf="assets[0].disableDownload") Item not available for download
-      a#downloadAssetLink.dropdown-item(download,
-        [attr.href]="userHasAcceptedTerms() ? generatedFullURL : null",
-        (click)="handleDownloadImageClick()",
-        (keydown.enter)="handleDownloadImageClick()",
-        (keyup.arrowdown)="downloadOptsArrowDown($event.target)",
-        (keyup.arrowup)="downloadOptsArrowUp($event.target)",
-        [class.disabled]="assets[0].disableDownload",
-        title="{{ assets[0].disableDownload ? 'Image is not available for download.' : 'Image download'}}",
-        target="_blank",
-        tabindex="2",
-        aria-label="Download item",
-        role="button")
-        i.icon.icon-download
-        | &nbsp;Download item
-      a#downloadViewLink.dropdown-item(
-        [attr.href]="userHasAcceptedTerms() ? downloadViewLink : null",
-        (click)="handleDownloadViewClick()",
-        (keydown.enter)="handleDownloadViewClick()",
-        (keyup.arrowup)="downloadOptsArrowUp($event.target)",
-        [class.disabled]="!downloadViewReady || assets[0].disableDownload || assets[0].typeName !== 'image'",
-        target="_blank",
-        tabindex="2",
-        aria-label="Download item’s detail view",
-        role="button")
-        i.icon.icon-download-detail-view
-        | &nbsp;Download detail view
-</ng-template>
-
-<ng-template #falseDoorDownload>
-  button.assetpage-btn.btn.btn-secondary(
-    *ngIf="assets[0].downloadLink",
-    (click)="showLoginModal = true",
-    (keydown.enter)="showLoginModal = true",
-    tabindex="2",
-    aria-label="Download"
-  )
-    | {{ 'ASSET_PAGE.BUTTONS.DOWNLOAD' | translate}}
-    i#downloadAssetLink.icon.icon-download-asset-orange
-</ng-template>
-
-

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -455,6 +455,27 @@ export class AssetPage implements OnInit, OnDestroy {
     this._group.hasPrivateGroups()
   } // OnInit
 
+  get showDownloadDropdown() {
+    const isLoggedIn = this.user && this.user.isLoggedIn;
+    const publicDownload = this.assets && this.assets[0] && this.assets[0].publicDownload;
+    const downloadLink = this.assets && this.assets[0] && this.assets[0].downloadLink;
+    const userStatus = this.user && this.user.status;
+
+    if (!downloadLink) {
+      return false;
+    }
+
+    if (!this.requireLoginForAdlDownload) {
+      if (!publicDownload) {
+        return userStatus || isLoggedIn;
+      }
+
+      return true;
+    }
+
+    return !!(isLoggedIn || publicDownload);
+  }
+
   ngOnDestroy() {
     this.subscriptions.forEach((sub) => {
       sub.unsubscribe();
@@ -462,7 +483,6 @@ export class AssetPage implements OnInit, OnDestroy {
     // Clear asset info from data layer
     this.trackContentDataLayer(<Asset>{})
   }
-
 
   handleLoadedMetadata(asset: Asset, assetIndex: number) {
     console.log("Handle loaded metadata for " + asset.id)

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -465,15 +465,15 @@ export class AssetPage implements OnInit, OnDestroy {
       return false;
     }
 
-    if (!this.requireLoginForAdlDownload) {
-      if (!publicDownload) {
-        return userAuthedWithInstitution || isLoggedIn;
-      }
-
+    if (publicDownload) {
       return true;
     }
 
-    return !!(isLoggedIn || publicDownload);
+    if (!this.requireLoginForAdlDownload) {
+      return userAuthedWithInstitution;
+    }
+
+    return isLoggedIn;
   }
 
   ngOnDestroy() {

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -459,7 +459,7 @@ export class AssetPage implements OnInit, OnDestroy {
     const isLoggedIn = this.user && this.user.isLoggedIn;
     const publicDownload = this.assets && this.assets[0] && this.assets[0].publicDownload;
     const downloadLink = this.assets && this.assets[0] && this.assets[0].downloadLink;
-    const userStatus = this.user && this.user.status;
+    const userAuthedWithInstitution = this.user && this.user.status;
 
     if (!downloadLink) {
       return false;
@@ -467,7 +467,7 @@ export class AssetPage implements OnInit, OnDestroy {
 
     if (!this.requireLoginForAdlDownload) {
       if (!publicDownload) {
-        return userStatus || isLoggedIn;
+        return userAuthedWithInstitution || isLoggedIn;
       }
 
       return true;

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -87,6 +87,7 @@ export class AssetPage implements OnInit, OnDestroy {
   // Feature Flags
   public relatedResFlag: boolean = false
   public isFullscreen: boolean = false
+  public requireLoginForAdlDownload: boolean = false
 
   private encryptedAccess: boolean = false
   private document = document
@@ -235,7 +236,8 @@ export class AssetPage implements OnInit, OnDestroy {
     this.quizModeTTDismissed = this._storage.getLocal('quizModeTTDismissed') ? this._storage.getLocal('quizModeTTDismissed') : false
     this.subscriptions.push(
       this._flags.flagUpdates.subscribe((flags) => {
-        this.relatedResFlag = flags.relatedResFlag ? true : false
+        this.relatedResFlag = flags.relatedResFlag;
+        this.requireLoginForAdlDownload = flags.requireLoginForAdlDownload;
       }),
       this.route.params.subscribe((routeParams) => {
         this.assetGroupId = routeParams['groupId']


### PR DESCRIPTION
PALS-294

## Description

If a user has access via an ADL Institution, let them download an image (after accepting T&Cs) without logging into an individual account.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
