### PR TITLE
SRCHX-549: Sort collection results by `worksequence_num` on collection page

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -216,6 +216,12 @@ export class AssetSearchService {
       } else if (sortIndex == '4') {
         query['sort'] = 'updatedon_str'
       }
+
+      // For collection pages, if there is no search term, sort by `work_sequence_num`
+      if(options['colId'] && !options['term'] && sortIndex === '0') {
+        query['sortorder'] = 'asc'
+        query['sort'] = 'worksequence_num'
+      } 
     }
   }
 


### PR DESCRIPTION
Resolves SRCHX-549

## Description

This PR includes a fix for collection page making sure we sort the collection result items by `worksequence_num` if there is no search term present.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
