### PR TITLE
SRCHX-553: Sort by worksequence in Duplicates and Details

### DIFF
--- a/src/app/_services/asset-search.service.ts
+++ b/src/app/_services/asset-search.service.ts
@@ -218,10 +218,10 @@ export class AssetSearchService {
       }
 
       // For collection pages, if there is no search term, sort by `work_sequence_num`
-      if(options['colId'] && !options['term'] && sortIndex === '0') {
+      if((options['colId'] || options['clusterId']) && !options['term'] && sortIndex === '0') {
         query['sortorder'] = 'asc'
         query['sort'] = 'worksequence_num'
-      } 
+      }
     }
   }
 


### PR DESCRIPTION
Resolves SRCHX-553

## Description
On the Duplicates and Details page, we want the items to be sorted by work sequence number in ascending order. This page has a clusterId, which was what we will use to trigger this sorting.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
