### PR TITLE
BLUE-193: Update dropdown item highlight contrast

### DIFF
--- a/src/app/asset-page/asset-page.component.scss
+++ b/src/app/asset-page/asset-page.component.scss
@@ -619,8 +619,9 @@ $titleNavBg: #eee;
         display: flex;
         align-items: center;
 
-        &:hover {
+        &:hover, &:focus {
             background-color: $color-gray-2;
+            color: inherit;
         }
 
         .icon {

--- a/src/sass/modules/_forms.scss
+++ b/src/sass/modules/_forms.scss
@@ -100,6 +100,10 @@ button.dropdown-item, a.dropdown-item {
     & .icon {
         vertical-align: middle;
     }
+    &:hover, &:focus {
+      color: #fff;
+      background-color: #0039c6;
+    }
 }
 
 // Style untouched: Safari fix


### PR DESCRIPTION
on-behalf-of: @ithaka <robert.niznik@ithaka.org>

Resolves BLUE-193

## Description

Update contrast for dropdown items when hovered and focused so that they are WCAG AA and AAA compliant.

<img width="529" alt="Screen Shot 2020-03-11 at 10 27 22 AM" src="https://user-images.githubusercontent.com/2147624/76428356-f4f84b80-6383-11ea-8d88-1a22aab457ed.png">


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [x] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
