### PR TITLE
BLUE-206: Update footer columns spacing for smaller viewports

### DIFF
--- a/src/app/shared/footer/footer.component.pug
+++ b/src/app/shared/footer/footer.component.pug
@@ -60,7 +60,7 @@
         //- mobile divider
         .col-sm-12.d-md-none
           hr
-        .col-md-3.col-6
+        .col-md-3.col-7
           ul.list-unstyled
             li(*ngFor="let link of links", [innerHtml]="'FOOTER.LINKS.' + link | translate")
             = " "
@@ -70,7 +70,7 @@
             //-   a.link.footer-logout([routerLink]="['/login']", *ngIf="!user || _auth.isPublicOnly()") Log In
           .mt-1
             #google_translate_element.translate-flyout
-        .col-md-3.col-6
+        .col-md-3.col-5
           div.social-icons
             a.icon.icon-twitter(target="_blank" href="http://twitter.com/#!/artstor" aria-label="Follow us on Twitter.")
             a.icon.icon-facebook(target="_blank" href="https://www.facebook.com/ARTstor" aria-label="Keep up with Artstor on Facebook.")


### PR DESCRIPTION
Resolves BLUE-206

## Description

The Google "Select Language" select is overlapping text when viewport is 420px wide and text spacing is increased using this [tool](https://codepen.io/stevef/full/YLMqbo). Update column spacing classes to fix this.

<img width="378" alt="Screen Shot 2020-03-27 at 8 45 19 AM" src="https://user-images.githubusercontent.com/2147624/77757278-53216180-7007-11ea-8cc1-193b76e7e792.png">

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [x] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [x] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
