### PR TITLE
BLUE-206: Divide out bottom sections

### DIFF
--- a/src/app/shared/footer/footer.component.pug
+++ b/src/app/shared/footer/footer.component.pug
@@ -60,7 +60,7 @@
         //- mobile divider
         .col-sm-12.d-md-none
           hr
-        .col-md-3.col-7
+        .col-md-3.col-12
           ul.list-unstyled
             li(*ngFor="let link of links", [innerHtml]="'FOOTER.LINKS.' + link | translate")
             = " "
@@ -70,7 +70,10 @@
             //-   a.link.footer-logout([routerLink]="['/login']", *ngIf="!user || _auth.isPublicOnly()") Log In
           .mt-1
             #google_translate_element.translate-flyout
-        .col-md-3.col-5
+        //- mobile divider
+        .col-sm-12.d-md-none
+          hr
+        .col-md-3.col-12
           div.social-icons
             a.icon.icon-twitter(target="_blank" href="http://twitter.com/#!/artstor" aria-label="Follow us on Twitter.")
             a.icon.icon-facebook(target="_blank" href="https://www.facebook.com/ARTstor" aria-label="Keep up with Artstor on Facebook.")


### PR DESCRIPTION
Resolves BLUE-206

## Description

After UX review, it was determined that we should support at least 320px wide views. The Google Select Language section is separated out from the disclaimer section to avoid competing for space.

<img width="440" alt="Screen Shot 2020-03-27 at 3 49 41 PM" src="https://user-images.githubusercontent.com/2147624/77794611-9816b980-7042-11ea-81fa-38732a121571.png">


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [x] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [x] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
