### PR TITLE
PLATO-609: Success and error messaging accessibility

### DIFF
--- a/src/app/account-page/account-page.component.pug
+++ b/src/app/account-page/account-page.component.pug
@@ -25,9 +25,9 @@
                 option(*ngFor="let dept of userDepts", [ngValue]="dept.id") {{ dept.desc }}
             .form-group
               button#btnSubmitUpdate.btn.btn-primary([class.loading]="updateLoading", [disabled]="accountUpdateForm.pristine", type="submit", name="action", tabindex="0") {{ 'ACCOUNT.UPDATE_FORM.SUBMIT_BUTTON' | translate }}
-            .form-group.has-success(*ngIf="messages.updateSuccess")
+            .form-group.has-success(*ngIf="messages.updateSuccess", role="status", aria-live="assertive")
               .form-control-feedback {{ 'ACCOUNT.UPDATE_FORM.SUCCESS_MESSAGE' | translate }}
-            .form-group.has-danger(*ngIf="messages.updateError")
+            .form-group.has-danger(*ngIf="messages.updateError", role="status", aria-live="assertive")
               .form-control-feedback {{ 'ACCOUNT.UPDATE_FORM.FAILURE_MESSAGE' | translate }}
 
           button.link--button((click)="showChangePassModal = true", tabindex="0", #changePasswordButton) {{ 'ACCOUNT.CHANGE_PASSWORD_LINK' | translate }}

--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -260,7 +260,7 @@
               .form-group
                 label(for="titleInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE' | translate }}
                 input#titleInput.form-control(type="text", [formControl]="editDetailsForm.controls['title']", placeholder="", spellcheck="false", tabindex="6")
-                .has-danger(*ngIf="editDetailsFormSubmitted && editDetailsForm.controls['title'].hasError('required')")
+                .has-danger(*ngIf="editDetailsFormSubmitted && editDetailsForm.controls['title'].hasError('required')", role="status", aria-live="assertive")
                   p.form-control-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.TITLE_REQUIRED_MSG' | translate }}
               .form-group
                 label(for="worktypeInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.WORK_TYPE' | translate }}
@@ -280,9 +280,9 @@
               .form-group
                 label(for="subjectInput") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SUBJECT' | translate }}
                 input#subjectInput.form-control(type="text", [formControl]="editDetailsForm.controls['subject']", placeholder="", spellcheck="false", tabindex="6")
-              .form-group.has-danger(*ngIf="uiMessages.deleteFailure")
+              .form-group.has-danger(*ngIf="uiMessages.deleteFailure", role="status", aria-live="assertive")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_ERROR' | translate }}
-              .form-group.has-danger(*ngIf="uiMessages.saveFailure")
+              .form-group.has-danger(*ngIf="uiMessages.saveFailure", role="status", aria-live="assertive")
                 .form-group-feedback {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.SAVE_ERROR' | translate }}
               .btn-row
                 button.btn.btn-secondary((click)="showDeletePCModal = true", type="button", tabindex="6", [class.loading]="deleteLoading") {{ 'ASSET_PAGE.EDIT_DETAILS_FORM.DELETE_BTN' | translate }}

--- a/src/app/modals/change-password/change-password.component.pug
+++ b/src/app/modals/change-password/change-password.component.pug
@@ -24,7 +24,7 @@
             label(for="inputNewPasswordConfirm") {{ 'ACCOUNT.CHANGE_PASS.LABELS.NEW_PASS_CONFIRM' | translate }}
             input#inputNewPasswordConfirm.form-control([formControl]="passForm.controls['newPassConfirm']", type="password")
             div#msgPassConfirmError.form-control-feedback(*ngIf="passForm.hasError('passwordMismatch')") {{ 'ACCOUNT.CHANGE_PASS.PASS_CONFIRM_ERROR' | translate }}
-          .form-group([class.has-danger]="serviceResponses.generalError || serviceResponses.wrongPass", [class.has-success]="serviceResponses.success")
+          .form-group([class.has-danger]="serviceResponses.generalError || serviceResponses.wrongPass", [class.has-success]="serviceResponses.success", role="status", aria-live="assertive")
             .form-control-feedback(*ngIf="serviceResponses.success") {{ 'ACCOUNT.CHANGE_PASS.CHANGE_SUCCESS' | translate }}
             .form-control-feedback(*ngIf="serviceResponses.generalError") {{ 'ACCOUNT.CHANGE_PASS.GENERAL_ERROR' | translate }}
             .form-control-feedback(*ngIf="serviceResponses.wrongPass") {{ 'ACCOUNT.CHANGE_PASS.WRONG_PASS_ERROR' | translate }}

--- a/src/app/modals/change-password/change-password.component.pug
+++ b/src/app/modals/change-password/change-password.component.pug
@@ -11,19 +11,19 @@
           .form-group([class.has-danger]="submitted && passForm.controls['oldPass'].hasError('required')")
             label(for="inputOldPassword") {{ 'ACCOUNT.CHANGE_PASS.LABELS.OLD_PASS' | translate }}
             input#inputOldPassword.form-control([formControl]="passForm.controls['oldPass']", type="password")
-            div#msgOldPassRequired.form-control-feedback(*ngIf="submitted && passForm.controls['oldPass'].hasError('required')")
+            div#msgOldPassRequired.form-control-feedback(*ngIf="submitted && passForm.controls['oldPass'].hasError('required')", role="status", aria-live="assertive")
               | {{ 'ACCOUNT.CHANGE_PASS.OLD_PASS_REQUIRED' | translate }}
           .form-group([class.has-danger]="submitted && passForm.controls['newPass'].hasError('required')", [class.has-warning]="passForm.controls['newPass'].dirty && passForm.controls['newPass'].hasError('required') || passForm.controls['newPass'].hasError('minlength')")
             label(for="inputNewPassword") {{ 'ACCOUNT.CHANGE_PASS.LABELS.NEW_PASS' | translate }}
             input#inputNewPassword.form-control([formControl]="passForm.controls['newPass']", type="password")
-            div#msgNewPassMinLength.form-control-feedback(*ngIf="passForm.controls['newPass'].dirty && passForm.controls['newPass'].hasError('required') || passForm.controls['newPass'].hasError('minlength')")
+            div#msgNewPassMinLength.form-control-feedback(*ngIf="passForm.controls['newPass'].dirty && passForm.controls['newPass'].hasError('required') || passForm.controls['newPass'].hasError('minlength')", role="status", aria-live="assertive")
               | {{ 'ACCOUNT.CHANGE_PASS.MIN_LENGTH_PROMPT' | translate }}
-            div#msgNewPassRequired.form-control-feedback(*ngIf="submitted && passForm.controls['newPass'].hasError('required')")
+            div#msgNewPassRequired.form-control-feedback(*ngIf="submitted && passForm.controls['newPass'].hasError('required')", role="status", aria-live="assertive")
               | {{ 'ACCOUNT.CHANGE_PASS.NEW_PASS_REQUIRED' | translate }}
           .form-group([class.has-danger]="submitted && passForm.controls['newPassConfirm'].hasError('required')", [class.has-warning]="passForm.hasError('passwordMismatch')")
             label(for="inputNewPasswordConfirm") {{ 'ACCOUNT.CHANGE_PASS.LABELS.NEW_PASS_CONFIRM' | translate }}
             input#inputNewPasswordConfirm.form-control([formControl]="passForm.controls['newPassConfirm']", type="password")
-            div#msgPassConfirmError.form-control-feedback(*ngIf="passForm.hasError('passwordMismatch')") {{ 'ACCOUNT.CHANGE_PASS.PASS_CONFIRM_ERROR' | translate }}
+            div#msgPassConfirmError.form-control-feedback(*ngIf="passForm.hasError('passwordMismatch')", role="status", aria-live="assertive") {{ 'ACCOUNT.CHANGE_PASS.PASS_CONFIRM_ERROR' | translate }}
           .form-group([class.has-danger]="serviceResponses.generalError || serviceResponses.wrongPass", [class.has-success]="serviceResponses.success", role="status", aria-live="assertive")
             .form-control-feedback(*ngIf="serviceResponses.success") {{ 'ACCOUNT.CHANGE_PASS.CHANGE_SUCCESS' | translate }}
             .form-control-feedback(*ngIf="serviceResponses.generalError") {{ 'ACCOUNT.CHANGE_PASS.GENERAL_ERROR' | translate }}

--- a/src/app/modals/edit-personal-collection/edit-personal-collection.component.pug
+++ b/src/app/modals/edit-personal-collection/edit-personal-collection.component.pug
@@ -14,7 +14,8 @@
             .form-control-feedback(*ngIf="uiMessages.imgUploadFailure") {{ 'EDIT_PC_MODAL.MESSAGES.IMG_UPLOAD_FAILURE' | translate }}
             .form-control-feedback(*ngIf="uiMessages.imgDeleteFailure") {{ 'EDIT_PC_MODAL.MESSAGES.IMG_DELETE_FAILURE' | translate }}
           .form-group.has-success(
-            *ngIf="uiMessages.imgUploadSuccess || uiMessages.imgDeleteSuccess"
+            *ngIf="uiMessages.imgUploadSuccess || uiMessages.imgDeleteSuccess",
+            role="status", aria-live="assertive"
           )
             .form-control-feedback(*ngIf="uiMessages.imgUploadSuccess") {{ 'EDIT_PC_MODAL.MESSAGES.IMG_UPLOAD_SUCCESS' | translate }}
             .form-control-feedback(*ngIf="uiMessages.imgDeleteSuccess") {{ 'EDIT_PC_MODAL.MESSAGES.IMG_DELETE_SUCCESS' | translate }}
@@ -67,7 +68,7 @@
               .form-group.has-success(
                 *ngIf="uiMessages.metadataUpdateSuccess"
               )
-                .form-control-feedback(*ngIf="uiMessages.metadataUpdateSuccess") {{ 'EDIT_PC_MODAL.MESSAGES.METADATA_UPDATE_SUCCESS' | translate }}
+                .form-control-feedback(*ngIf="uiMessages.metadataUpdateSuccess", role="status", aria-live="assertive") {{ 'EDIT_PC_MODAL.MESSAGES.METADATA_UPDATE_SUCCESS' | translate }}
       .modal-footer([ngClass]="{ 'border-none' : !editMode && (!collectionAssets || collectionAssets.length === 0) }")
         .form-group(*ngIf="editMode")
           button.btn.btn-secondary.mr-2((click)="clearSelectedAsset()", type="button", tabindex="0") {{ 'EDIT_PC_MODAL.BUTTONS.CLOSE' | translate }}

--- a/src/app/modals/generate-citation/generate-citation.component.pug
+++ b/src/app/modals/generate-citation/generate-citation.component.pug
@@ -25,7 +25,7 @@
             .value
               textarea#copyChicago(#copyChicago="", readonly) {{ chicago_citation }}
             button.copy-clipboard((click)=" copyChicago.select(); document.execCommand('copy', false, null); citationCopied = true; ") {{ 'GENERATE_CITATION_MODAL.COPY_CLIPBOARD' | translate }}
-          .form-control-feedback(*ngIf="citationCopied") {{ 'GENERATE_CITATION_MODAL.COPY_SUCCESS' | translate }}
+          .form-control-feedback(*ngIf="citationCopied", role="status", aria-live="assertive") {{ 'GENERATE_CITATION_MODAL.COPY_SUCCESS' | translate }}
       .modal-footer
         a.btn.btn-link.with-pad(href="https://support.artstor.org/?article=export-citations", target="_blank") Help
         button.btn.btn-primary((click)="closeModal.emit()", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") Close

--- a/src/app/modals/share-ig-link/share-ig-link.component.pug
+++ b/src/app/modals/share-ig-link/share-ig-link.component.pug
@@ -13,8 +13,8 @@
             .value
               textarea#copyURL(#copyURL="", readonly, [attr.aria-label]="'SHARE_IG_LINK_MODAL.TEXTAREA_ARIA_LABEL' | translate", tabindex="0") {{ shareLink }}
             .copy-clipboard((click)="copyURL.select(); document.execCommand('copy', false, null); igCopied = true;", tabindex="0", (keyup.enter)="copyURL.select(); document.execCommand('copy', false, null); igCopied = true;") Copy to Clipboard
-            .form-control-feedback(*ngIf="igCopied") {{ 'SHARE_IG_LINK_MODAL.COPY_SUCCESS' | translate }}
-            .form-control-feedback(*ngIf="serviceStatus.tokenError") {{ 'SHARE_IG_LINK_MODAL.SERVICE_ERROR' | translate }}
+            .form-control-feedback(*ngIf="igCopied", role="status", aria-live="assertive") {{ 'SHARE_IG_LINK_MODAL.COPY_SUCCESS' | translate }}
+            .form-control-feedback(*ngIf="serviceStatus.tokenError", role="status", aria-live="assertive") {{ 'SHARE_IG_LINK_MODAL.SERVICE_ERROR' | translate }}
       .modal-footer
         a.link.help-link-text(href="https://support.artstor.org/?article=creating-links", role="button", target="_blank", tabindex="0") Help
         button.btn.btn-primary((click)="closeModal.emit()", tabindex="0", (keydown.tab)="$event.stopPropagation(); $event.preventDefault(); startModalFocus()") Close

--- a/src/app/register/register.component.pug
+++ b/src/app/register/register.component.pug
@@ -30,36 +30,42 @@
                 input#emailInput.form-control(type="email", spellcheck="false", [formControl]="registerForm.controls['email']", tabindex="0")
                 p#errEmailRequired.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['email'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.EMAIL_REQUIRED' | translate }}
                 p#errEmailInvalid.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['email'].hasError('emailInvalid') && !registerForm.controls['email'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.EMAIL_INVALID' | translate }}
               .form-group
                 label(for="emailConfirmInput") Confirm Email Address
                 input#emailConfirmInput.form-control(type="email", spellcheck="false", [formControl]="registerForm.controls['emailConfirm']", tabindex="0")
                 p#errEmailMismatch.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.hasError('emailMismatch')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.EMAIL_MISMATCH' | translate }}
               .form-group
                 label(for="passwordInput") Password (7 character minimum)
                 input#passwordInput.form-control(type="password", spellcheck="false", [formControl]="registerForm.controls['password']", tabindex="0")
                 p#errPasswordRequired.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['password'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.PASSWORD_REQUIRED' | translate }}
                 p#errPasswordMinlength.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['password'].hasError('minlength')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.PASSWORD_MINLENGTH' | translate }}
               .form-group
                 label(for="passwordConfirmInput") Confirm Password
                 input#passwordConfirmInput.form-control(type="password", spellcheck="false", [formControl]="registerForm.controls['passwordConfirm']", tabindex="0")
                 p#errPasswordMismatch.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.hasError('passwordMismatch')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.PASSWORD_MISMATCH' | translate }}
               .form-group
                 label(for="selectUserRole") Role at Institution
@@ -67,7 +73,8 @@
                   option(*ngFor="let role of userRoles", [ngValue]="role.id") {{ role.desc }}
                 p#errRoleRequired.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['role'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.INSTITUTION_ROLE_REQUIRED' | translate }}
               .form-group
                 label(for="selectUserDept") Academic Department
@@ -75,7 +82,8 @@
                   option(*ngFor="let dept of userDepts", [ngValue]="dept.id") {{ dept.desc }}
                 p#errDeptRequired.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['dept'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.ACADEMIC_DEPT_REQUIRED' | translate }}
 
               .form-group
@@ -96,12 +104,13 @@
                     .terms-txt([innerHtml]="'REGISTER.TERMS' | translate ")
                 p#errTermsRequired.has-danger.form-control-feedback(
                   *ngIf="submitted && registerForm.controls['terms'].hasError('required')",
-                  [style.display]="'none'"
+                  [style.display]="'none'",
+                  role="status", aria-live="assertive"
                 ) {{ 'REGISTER.ERRORS.TERMS_REQUIRED' | translate}}
               .form-group
                 button#btnRegister.btn.btn-primary([class.loading]="isLoading", type="submit", name="action", tabindex="0") Register
               .form-group
-                ng-container(*ngIf="submitted")
+                ng-container(*ngIf="submitted", role="status", aria-live="assertive")
                   p#errDuplicateUser.has-danger.form-control-feedback(*ngIf="serviceErrors.duplicate", [innerHtml]="'REGISTER.ERRORS.EMAIL_DUPLICATE' | translate", [style.display]="'none'")
                   p#errJstorUser.has-danger.form-control-feedback(*ngIf="serviceErrors.hasJstor", [innerHtml]="'REGISTER.ERRORS.ALREADY_JSTOR' | translate", [style.display]="'none'")
                   p#errJstorUser.has-danger.form-control-feedback(*ngIf="serviceErrors.hasGoogle", [innerHtml]="'REGISTER.ERRORS.ALREADY_GOOGLE' | translate", [style.display]="'none'")

--- a/src/assets/styleguide/styles/all.css
+++ b/src/assets/styleguide/styles/all.css
@@ -7150,7 +7150,7 @@ ngx-tag-input > form > input {
   color: #0039c6; }
 
 .has-warning {
-  color: #f2be19; }
+  color: #c9510d; }
 
 .search-highlight #inputSearchTerm {
   box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.15);

--- a/src/assets/styleguide/styles/all.css
+++ b/src/assets/styleguide/styles/all.css
@@ -7150,7 +7150,7 @@ ngx-tag-input > form > input {
   color: #0039c6; }
 
 .has-warning {
-  color: #c9510d; }
+  color: #e21c28; }
 
 .search-highlight #inputSearchTerm {
   box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.15);

--- a/src/assets/styleguide/styles/all.css
+++ b/src/assets/styleguide/styles/all.css
@@ -7147,7 +7147,7 @@ ngx-tag-input > form > input {
   color: #e21c28; }
 
 .has-success {
-  color: #afc128; }
+  color: #0039c6; }
 
 .has-warning {
   color: #f2be19; }

--- a/src/sass/modules/_forms.scss
+++ b/src/sass/modules/_forms.scss
@@ -255,7 +255,7 @@ ngx-tag-input > form > input {
 }
 
 .has-warning {
-  color: #f2be19;
+  color: #c9510d;
 }
 
 .search-highlight #inputSearchTerm{

--- a/src/sass/modules/_forms.scss
+++ b/src/sass/modules/_forms.scss
@@ -251,7 +251,7 @@ ngx-tag-input > form > input {
 }
 
 .has-success {
-  color: #afc128;
+  color: #0039c6;
 }
 
 .has-warning {

--- a/src/sass/modules/_forms.scss
+++ b/src/sass/modules/_forms.scss
@@ -255,7 +255,7 @@ ngx-tag-input > form > input {
 }
 
 .has-warning {
-  color: #c9510d;
+  color: #e21c28;
 }
 
 .search-highlight #inputSearchTerm{


### PR DESCRIPTION
Resolves PLATO-609

## Description

Changed the success color to blue for accessibility and added aria live regions for announce the success/error

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [X] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [X] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [X] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
