### PR TITLE
PLATO-605: Allows buttons to grow in height when needed

### DIFF
--- a/src/sass/modules/_buttons.scss
+++ b/src/sass/modules/_buttons.scss
@@ -22,7 +22,7 @@ $iconBtnSize: $btnHeight;
      letter-spacing: 0.5px;
      border-bottom: none;
      cursor: pointer;
-     height: $btnHeight;
+     min-height: $btnHeight;
      line-height: $btnHeight;
 
      &:hover, &:active {


### PR DESCRIPTION
Resolves PLATO-605

## Description
WCAG states that there should be accommodations for tools that change the natural line height, text spacing, etc. When applying these changes, the buttons on the image page were getting cut off.

BEFORE:
![image](https://user-images.githubusercontent.com/3267412/78272982-34760b80-74dc-11ea-80aa-8adeb36aad8b.png)


Setting a `min-height` instead now to not restrict the height, should the button text need to wrap. 

AFTER:
![image](https://user-images.githubusercontent.com/3267412/78272919-21633b80-74dc-11ea-8d5b-8ab2ad8effa8.png)


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
