### PR TITLE
BLUE-205: Make links and filters accessible on mobile

### DIFF
--- a/src/app/category-page/category-page.component.pug
+++ b/src/app/category-page/category-page.component.pug
@@ -2,8 +2,9 @@ div
   nav-menu([allowSelectAll]="true")
   .container.main-content
     .row
-      .col-sm-3
-        .mobile--hide
+      .col-sm-3(style="margin-top: 1rem;")
+        button.mobile--show.btn.btn-secondary(id="showFiltersBtn", (click)="showFilters = !showFilters") {{ showFilters ? 'Hide Filters' : 'Show Filters' }}
+        div([ngClass]="[ showFilters ? '' : 'mobile--hide']")
           div(aria-activedescendant="button")
             button.skip-btn#skip-to-search-link((click)="skipToSearchSection()", (keyup.enter)="skipToSearchSection()", tabindex="2", class="sr-only sr-only-focusable") This is the filters section. Skip to the search results section.
           h1 Filtered Search

--- a/src/app/category-page/category-page.component.scss
+++ b/src/app/category-page/category-page.component.scss
@@ -1,5 +1,13 @@
 
 @import '../../../node_modules/bootstrap/scss/mixins/_gradients.scss';
+@import '../../sass/core/variables';
+
+.container.main-content {
+  padding: 25px 25px 0;
+  @media (min-width: $phone) {
+    padding: 0;
+  }
+}
 
 .thumbnail-shelf {
     border-bottom: 1px solid #bebebe;
@@ -16,4 +24,10 @@
 img.collection-thumb {
     max-height: 100px;
     width: auto;
+}
+
+.btn-secondary {
+  @media(max-width: $phone) {
+    margin-bottom: 20px;
+  }
 }

--- a/src/app/category-page/category-page.component.ts
+++ b/src/app/category-page/category-page.component.ts
@@ -31,7 +31,8 @@ export class CategoryPage implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
 
   // private searchInResults: boolean = false;
-  private unaffiliatedUser: boolean = false
+  private unaffiliatedUser: boolean = false;
+  private showFilters: boolean = false;
 
   constructor(
     private _assets: AssetService,

--- a/src/app/collection-page/collection-page.component.pug
+++ b/src/app/collection-page/collection-page.component.pug
@@ -2,8 +2,9 @@ div
   nav-menu([allowSelectAll]="true")
   .container.main-content
     .row
-      .col-sm-3
-        .mobile--hide
+      .col-sm-3(style="margin-top: 1rem;")
+        button.mobile--show.btn.btn-secondary(id="showFiltersBtn", (click)="showFilters = !showFilters") {{ showFilters ? 'Hide Filters' : 'Show Filters' }}
+        div([ngClass]="[ showFilters ? '' : 'mobile--hide']")
           div(aria-activedescendant="button")
             button.skip-btn#skip-to-search-link((click)="skipToSearchSection()", (keyup.enter)="skipToSearchSection()", tabindex="2", class="sr-only sr-only-focusable") This is the filters section. Skip to the search results section.
           h1 Filtered Search

--- a/src/app/collection-page/collection-page.component.scss
+++ b/src/app/collection-page/collection-page.component.scss
@@ -1,5 +1,13 @@
 
 @import '../../../node_modules/bootstrap/scss/mixins/_gradients.scss';
+@import '../../sass/core/variables';
+
+.container.main-content {
+  padding: 25px 25px 0;
+  @media (min-width: $phone) {
+    padding: 0;
+  }
+}
 
 .thumbnail-shelf {
     border-bottom: 1px solid #bebebe;
@@ -37,14 +45,14 @@ img.collection-thumb {
     z-index: 1000;
     line-height: 28px;
     margin-top: -1.3em;
-    
+
     &.collapsed {
         background-image: linear-gradient(to bottom, transparent 0%, white 50%);
     }
 }
 
 // For generate image URL Modal
-#accessDeniedModal{ 
+#accessDeniedModal{
     .modal-body{
         font-family: 'Graphik Web', sans-serif;
 
@@ -56,4 +64,10 @@ img.collection-thumb {
     .close-icon{
         cursor: pointer;
     }
+}
+
+.btn-secondary {
+  @media(max-width: $phone) {
+    margin-bottom: 20px;
+  }
 }

--- a/src/app/collection-page/collection-page.component.ts
+++ b/src/app/collection-page/collection-page.component.ts
@@ -31,6 +31,7 @@ export class CollectionPage implements OnInit, OnDestroy {
 
   private subscriptions: Subscription[] = [];
   private userSessionFresh: boolean = false;
+  private showFilters: boolean = false;
 
   constructor(
     private _assets: AssetService,

--- a/src/app/modals/search-modal/search-modal.component.scss
+++ b/src/app/modals/search-modal/search-modal.component.scss
@@ -1,3 +1,5 @@
+@import './../../../sass/core/variables';
+
 .modal{
     display: block;
 
@@ -139,4 +141,12 @@ h2 {
 h3 {
   color: #444;
   font-size: 12px;
+}
+
+.modal-footer {
+  & .btn-secondary {
+    @media(max-width: $phone) {
+      display: inline-block;
+    }
+  }
 }

--- a/src/app/nav-menu/nav-menu.component.pug
+++ b/src/app/nav-menu/nav-menu.component.pug
@@ -51,6 +51,8 @@
         .nav-item(*ngIf="!mobileCollapsed")
           a.link--accent(tabindex="3", (click)="logout()", *ngIf="user.isLoggedIn") Log Out
           a.link--accent(tabindex="3", [routerLink]="['/login']", *ngIf="!user.isLoggedIn") Log In
+          span &nbsp;or&nbsp;
+          a.link--accent(tabindex="3", [routerLink]="['/register']", *ngIf="!user.isLoggedIn") Register
         .nav-item(*ngIf="!mobileCollapsed && institutionObj")
           | Institution: {{ institutionObj.shortName ? institutionObj.shortName : institutionObj.institutionName }}
 ang-delete-ig-modal(*ngIf="showDeleteIgModal", (closeModal)="showDeleteIgModal = false", [ig]="ig", [igId]="route.snapshot.params.igId", [igName]="route.snapshot.params.name")

--- a/src/app/search-page/search-page.component.pug
+++ b/src/app/search-page/search-page.component.pug
@@ -3,7 +3,8 @@
   .container.main-content
     .row
       .col-sm-3(style="margin-top: 1rem;")
-        .mobile--hide
+        button.mobile--show.btn.btn-secondary(id="showFiltersBtn", (click)="showFilters = !showFilters") {{ showFilters ? 'Hide Filters' : 'Show Filters' }}
+        div([ngClass]="[ showFilters ? '' : 'mobile--hide']")
           button.skip-btn#skip-to-search-link((click)="skipToSearchSec()", (keyup.enter)="skipToSearchSec()", tabindex="2", class="sr-only sr-only-focusable") This is the filters section. Skip to the search results section.
           h3.browse-category {{ 'HOME.HEADINGS.FEATURED' | translate }}
           p.small(*ngIf="siteID!='SAHARA' && _auth.isPublicOnly()", [innerHtml]="'HOME.CONTENT_ACCESS.PUBLIC' | translate")

--- a/src/app/search-page/search-page.component.scss
+++ b/src/app/search-page/search-page.component.scss
@@ -10,3 +10,9 @@
 .no-scroll {
   overflow: hidden;
 }
+
+.btn-secondary {
+  @media(max-width: $phone) {
+    margin-bottom: 20px;
+  }
+}

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -33,6 +33,8 @@ export class SearchPage implements OnInit, OnDestroy {
 
   private userSessionFresh: boolean = false;
 
+  private showFilters: boolean = false;
+
   constructor(
         public _appConfig: AppConfig,
         private _assets: AssetService,

--- a/src/app/shared/search/search.component.scss
+++ b/src/app/shared/search/search.component.scss
@@ -1,7 +1,6 @@
 @import '../../../sass/core/variables';
 
 .open-modal {
-  display: none;
   @media (min-width: 768px) {
       display: block;
   }


### PR DESCRIPTION
Resolves BLUE-205

## Description

Previously links to Register and Advanced Search were not available on mobile, as well as the ability to use filters. These changes allow for that functionality to be available.

<img width="385" alt="Screen Shot 2020-04-10 at 11 30 13 AM" src="https://user-images.githubusercontent.com/2147624/79003527-c73c2900-7b20-11ea-9b27-7c199fb075ee.png">
<img width="377" alt="Screen Shot 2020-04-10 at 11 30 23 AM" src="https://user-images.githubusercontent.com/2147624/79003534-c99e8300-7b20-11ea-9618-944d99ed3434.png">


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [x] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [x] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
