### PR TITLE
BLUE-205: Allow showFilters to be used in template

### DIFF
--- a/src/app/category-page/category-page.component.ts
+++ b/src/app/category-page/category-page.component.ts
@@ -19,7 +19,8 @@ export class CategoryPage implements OnInit, OnDestroy {
   public catName: string;
   public catDescription: string;
   public catThumbnail: string;
-  public showAccessDeniedModal: boolean = false
+  public showAccessDeniedModal: boolean = false;
+  public showFilters: boolean = false;
 
   private header = new HttpHeaders().set('Content-Type', 'application/json'); // ... Set content type to JSON
   private options = { headers: this.header, withCredentials: true }; // Create a request option
@@ -32,7 +33,6 @@ export class CategoryPage implements OnInit, OnDestroy {
 
   // private searchInResults: boolean = false;
   private unaffiliatedUser: boolean = false;
-  private showFilters: boolean = false;
 
   constructor(
     private _assets: AssetService,

--- a/src/app/collection-page/collection-page.component.ts
+++ b/src/app/collection-page/collection-page.component.ts
@@ -22,6 +22,7 @@ export class CollectionPage implements OnInit, OnDestroy {
   public assetCount: number;
   public descCollapsed: boolean = true;
   public showAccessDeniedModal: boolean = false;
+  public showFilters: boolean = false;
 
   private header = new HttpHeaders().set('Content-Type', 'application/json'); // ... Set content type to JSON
   private options = { headers: this.header, withCredentials: true }; // Create a request option
@@ -31,7 +32,6 @@ export class CollectionPage implements OnInit, OnDestroy {
 
   private subscriptions: Subscription[] = [];
   private userSessionFresh: boolean = false;
-  private showFilters: boolean = false;
 
   constructor(
     private _assets: AssetService,

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -19,7 +19,8 @@ import { AppConfig } from '../app.service'
 
 export class SearchPage implements OnInit, OnDestroy {
 
-  public siteID: string = ''
+  public siteID: string = '';
+  public showFilters: boolean = false;
   // Add user to decide whether to show the banner
   private user: any = this._auth.getUser();
 
@@ -32,8 +33,6 @@ export class SearchPage implements OnInit, OnDestroy {
   private unaffiliatedUser: boolean = false;
 
   private userSessionFresh: boolean = false;
-
-  private showFilters: boolean = false;
 
   constructor(
         public _appConfig: AppConfig,


### PR DESCRIPTION
Resolves BLUE-205

## Description

Need to make showFilters public to allow use in templates.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
