### PR TITLE
BLUE-210: Add es5 adapter polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@types/selenium-webdriver": "4.0.0",
     "@types/uglify-js": "^3.0.4",
     "@types/webpack": "^4.4.17",
-    "@webcomponents/webcomponentsjs": "webcomponents/webcomponentsjs",
+    "@webcomponents/webcomponentsjs": "^2.4.3",
     "angular-sortablejs": "^2.6.0",
     "angular2-medium-editor": "1.2.0",
     "angular2-tag-autocomplete": "^1.2.10",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -3,6 +3,7 @@
 // import 'ie-shim'; // Internet Explorer 9 support
 
 // Web component polyfills for IE11
+import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js';
 import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
 
 // import 'core-js/es6';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,9 +1127,10 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/webcomponentsjs@webcomponents/webcomponentsjs":
-  version "2.2.10"
-  resolved "https://codeload.github.com/webcomponents/webcomponentsjs/tar.gz/5988103b9a5d09723196d7627b1ba3064104ae8e"
+"@webcomponents/webcomponentsjs@^2.4.3":
+  version "2.4.3"
+  resolved "https://artifactory.acorn.cirrostratus.org/artifactory/api/npm/npms/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz#384f4f6d54563ba465fb4df21fe89e78a76fc530"
+  integrity sha1-OE9PbVRWO6Rl+03yH+ieeKdvxTA=
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Resolves BLUE-210

## Description

Deployment of BLUE-210 failed. Upon inspecting the codebase I realized the JavaScript is being compiled to es5. As a result, we need to also include the [es5 custom elements adapter](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs#custom-elements-es5-adapterjs) to have things running properly with the web component polyfills.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
