### PR TITLE
BLUE-210: Add global Document to server

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -64,6 +64,7 @@ global['HTMLElement'] = win.HTMLElement
 global['Element'] = win.Element // (PDFjs)
 global['navigator'] = win.navigator
 global['XMLHttpRequest'] = require('xmlhttprequest').XMLHttpRequest
+global['Document'] = win.Document
 /**
  * Angular Universal init
  */


### PR DESCRIPTION
Resolves BLUE-210

## Description

When trying to serve the built SSR build, node would fail with `ReferenceError: Document is not defined at eval (webpack:///./node_modules/lit-element/lib/css-tag.js?:16:62)`. At first I believed this might relate to using ES6 dependencies such as `lit-element` and `lit-html` and needing to exclude them from the server build. Alas, the error was simply a result of the server not having `Document` defined and nothing to do with the dependency referencing it. So I updated the server global to include `Document`.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
