### PR TITLE
BLUE-210: Fix z-index usage

### DIFF
--- a/src/app/nav-menu/nav-menu.component.scss
+++ b/src/app/nav-menu/nav-menu.component.scss
@@ -32,9 +32,6 @@ $navBarPad: 0.5rem;
     background-color: $navBarLightBg;
     background-clip: padding-box;
     z-index: 2000;
-    @media (min-width: $phone) {
-        z-index: 100;
-    }
 }
 
 .navbar {
@@ -69,7 +66,6 @@ $navBarPad: 0.5rem;
     z-index: 2000;
     @media (min-width: $phone) {
         position: relative;
-        z-index: 100;
     }
 }
 

--- a/src/app/shared/nav/nav.component.pug
+++ b/src/app/shared/nav/nav.component.pug
@@ -7,7 +7,7 @@ header.navbar.navbar-light(*ngIf="!_fullscreen.isFullscreen")
             img#logo.hidden-xs-down([attr.src]="logoUrl" alt="Artstor logo")
           .mobile--show
             img#logoMobile.hidden-sm-up(src="/assets/img/logo-square.png" alt="Artstor logo")
-        pharos-tooltip(*ngIf="showAppliedFlags", placement="bottom", tabindex="1")
+        pharos-tooltip.mobile--hide.nav-tooltip(*ngIf="showAppliedFlags", placement="bottom", tabindex="1")
           .btn.btn--icon(slot="target")
             .icon.icon-flag
           div(slot="content")

--- a/src/app/shared/nav/nav.component.scss
+++ b/src/app/shared/nav/nav.component.scss
@@ -131,3 +131,8 @@ $loginPanelMobileHeight: 0;
   // width: -webkit-fill-available;
   width: stretch; // fill-available changed in spec to stretch
 }
+
+.nav-tooltip {
+  position: relative;
+  z-index: 3000;
+}


### PR DESCRIPTION
Resolves BLUE-210

## Description

Previously I had tweaked the z-index values of the navbar to allow visibility of Pharos tooltips which resulted in issues for the group view. This simply ups the z-index of the tooltip itself and leaves the current AIW z-index setup alone.

![chrome-2020-04-16-125535-User can create an image group from ADL Collections](https://user-images.githubusercontent.com/2147624/79461930-d4e02b80-7fc4-11ea-9d66-c901ba000f55.png)


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
