### PR TITLE
SRCHX-573: Wrap text for group-browse Titles for smaller screens

### DIFF
--- a/src/app/browse-page/card-view/card-view.component.pug
+++ b/src/app/browse-page/card-view/card-view.component.pug
@@ -26,7 +26,7 @@
       .row.cardview-text
         .col-sm-8
           div(id="tagItem{{ tag.tagId }}", [ngClass]="[ link ? 'tag-link' : '', 'tag-item', tag.canOpen ? 'clickable' : '', 'tag-item__indent-' + tag.getLevel(), linkRoute.length < 1 ? 'no-link' : '']")
-            a(id="tagItem{{ tag.tagId }}Open", [ngClass]="{ 'no-link' : linkRoute.length < 1 || !tag.canOpen }", [routerLink]="[ linkRoute, tag.tagId ]", tabindex="3", attr.aria-label="{{ tag.title }}, which has {{ group.items.length }} items")
+            a.wrap-on-long-text(id="tagItem{{ tag.tagId }}Open", [ngClass]="{ 'no-link' : linkRoute.length < 1 || !tag.canOpen }", [routerLink]="[ linkRoute, tag.tagId ]", tabindex="3", attr.aria-label="{{ tag.title }}, which has {{ group.items.length }} items")
               span.font-weight-bold.notranslate {{ tag.title }}
           .value.mobile--hide#description([innerHtml]="description")
           .row.mobile--show#information-row

--- a/src/app/browse-page/card-view/card-view.component.scss
+++ b/src/app/browse-page/card-view/card-view.component.scss
@@ -2,6 +2,7 @@
 
 $tagLinkBg: #efefef;
 
+
 .card-view {
     font-family: Verdana;
     box-shadow: 0 0 8px 1px #00000014;
@@ -212,6 +213,10 @@ $tagLinkBg: #efefef;
 .cardview-text {
     padding-left: 1em;
     padding-right: 1em;
+}
+
+.wrap-on-long-text {
+  word-break: break-all;
 }
 
 .group-tag-name {


### PR DESCRIPTION
Resolves SRCHX-573

## Description

Ran into a visual issue when the screen is less wide, the titles that are single word and very long do not wrap causing a very difficult viewing experience for a user. This small styling change should eleviate that.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [x] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
