### PR TITLE
Load web component polyfills from index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,9 @@
 <head>
   <!-- Run the app from the root directory -->
   <base href="/">
+  <!-- web component polyfills -->
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.4.3/custom-elements-es5-adapter.js"></script>
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.4.3/webcomponents-loader.js"></script>
   <!--Track initial URL in cases where we need to re-route legacy links-->
   <script type="text/javascript">
     var initPath = window.location.href;

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,10 +2,6 @@
 
 // import 'ie-shim'; // Internet Explorer 9 support
 
-// Web component polyfills for IE11
-import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js';
-import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
-
 // import 'core-js/es6';
 // Added parts of es6 which are necessary for your project or your browser support requirements.
 import 'core-js/es6/symbol';


### PR DESCRIPTION
## Description

Load the web component polyfills from <head> in the index.html file as they may be loading too late from `polyfills.ts`.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
