### PR TITLE
SRCHX-574-576: Add alert role to error messages for screen readers

### DIFF
--- a/src/app/asset-grid/asset-grid.component.pug
+++ b/src/app/asset-grid/asset-grid.component.pug
@@ -100,7 +100,7 @@
             ng-container(*ngIf="ig.owner_id == user.baseProfileId.toString()")
               div.mt-4 As the <b>Owner</b> of this group, would you like to remove the deleted images?
               a.mt-2.btn.btn-secondary.btn-sm(tabindex="3", (click)="removeFromGroup(restricted_results)", role="button") Remove deleted images
-          .alert.alert-warning(*ngIf="!isLoading && (totalAssets == 0) && (!results || results.length < 1) && (searchError.length < 1) && !searchLimitError")
+          .alert.alert-warning(*ngIf="!isLoading && (totalAssets == 0) && (!results || results.length < 1) && (searchError.length < 1) && !searchLimitError" role="alert")
             b Unable to find any assets
             br
             | A less specific query might be able to find what you are looking for.

--- a/src/app/modals/search-modal/search-modal.component.pug
+++ b/src/app/modals/search-modal/search-modal.component.pug
@@ -83,7 +83,7 @@
                               label.custom-control-label((click)="toggleFilter(child, filter)")
                                 | {{ child.name }} {{ child.count ? '(' + child.count +')' : '' }}
       .modal-footer
-        .alert.alert-warning(*ngIf="error.empty", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.EMPTY_SEARCH' | translate")
+        .alert.alert-warning(*ngIf="error.empty", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.EMPTY_SEARCH' | translate" role="alert")
         .alert.alert-warning(*ngIf="error.date", [innerHtml]="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE' | translate", role="alert", attr.aria-label="'ADVANCED_SEARCH_MODAL.ERRORS.DUMB_DATE'")
         label.sr-only(for="helpBtn") Help
         button.btn.btn-link.with-pad(id="helpBtn", tabindex="0", (click)="openHelp()") <u> {{ 'ADVANCED_SEARCH_MODAL.BUTTONS.HELP' | translate }} </u>


### PR DESCRIPTION
Resolves SRCHX-574
Resolves SRCHX-576

## Description

Adding accessibility features (screen reader announce) error message when there are no search results and when there is an error using advanced search modal on ARTSTOR

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [x] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
