### PR TITLE
SRCHX-577: Adjust styling on date filter when zoomed in

### DIFF
--- a/src/app/asset-filters/asset-filters.component.scss
+++ b/src/app/asset-filters/asset-filters.component.scss
@@ -2,8 +2,6 @@
  * # Filters
  * Search filters, primarilly link styled elements which toggle on click.
  */
-@import '../../sass/core/variables';
-
 
 $activeFilterColor: #000;
 $filterUnfocusOpacity: 0.5;

--- a/src/app/asset-filters/asset-filters.component.scss
+++ b/src/app/asset-filters/asset-filters.component.scss
@@ -2,6 +2,8 @@
  * # Filters
  * Search filters, primarilly link styled elements which toggle on click.
  */
+@import '../../sass/core/variables';
+
 
 $activeFilterColor: #000;
 $filterUnfocusOpacity: 0.5;
@@ -14,7 +16,7 @@ $filterBorderStyle: 1px solid rgba(0, 0, 0, 0.15);
 .col--sliding {
 	transform: translateY(0);
 	transition: transform linear 0.3s, margin linear 0.3s;
-	
+
 	&.slide-up {
 		pointer-events: none;
 		transform: translateY(-100%);
@@ -55,7 +57,7 @@ $filterBorderStyle: 1px solid rgba(0, 0, 0, 0.15);
 				border-bottom: 1px solid #ddd;
 			}
 		}
-	} 
+	}
 }
 
 .filter-group h2{
@@ -83,7 +85,7 @@ $filterBorderStyle: 1px solid rgba(0, 0, 0, 0.15);
 	&.full-spacing {
 		margin-bottom: 12px;
 	}
-	
+
 	& .subtitle-alt {
 		padding: 2px;
 	}
@@ -99,7 +101,7 @@ $filterBorderStyle: 1px solid rgba(0, 0, 0, 0.15);
 
 	&.collapsed {
 		padding: 0;
-		
+
 		&:hover, &:active, &:focus {
 			.filter-group__label {
 				line-height:34px;
@@ -320,10 +322,10 @@ filter:hover .includeIcon, filter:hover .excludeIcon{
     vertical-align: top;
     margin-top: 3px;
 }
-input[type=number]::-webkit-inner-spin-button, 
-input[type=number]::-webkit-outer-spin-button { 
-  -webkit-appearance: none; 
-  margin: 0; 
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 input[type=number] {
   -moz-appearance: textfield;
@@ -332,4 +334,27 @@ input[type=number] {
 .move-up {
 	position: relative;
     top: 8rem;
+}
+
+.date-filter-row {
+
+  input {
+    @media (max-width: 1200px) {
+      width: 100%;
+    }
+  }
+
+  .btn {
+    @media (max-width: 1200px) {
+      width: 100%;
+      border: 1px solid rgba(0, 0, 0, 0.15);;
+    }
+  }
+
+  .side-toggle-btn {
+    @media (max-width: 1200px) {
+      width: 50%;
+      border: 1px solid rgba(0, 0, 0, 0.15);;
+    }
+  }
 }


### PR DESCRIPTION
Resolves SRCHX-577

## Description

When a user has a zoomed in view, the date filter on the asset page was unreadable. Styling has been added to adjust how it appears when the user is zoomed in or on a mobile device. Now the button's text is always readable and appears cleanly to the user. 

Regular:
![Screen Shot 2020-04-29 at 9 44 04 AM](https://user-images.githubusercontent.com/42744307/80603270-2ee9e380-89fe-11ea-8ecd-a8c8aea43d03.png)


Zoomed in:
![Screen Shot 2020-04-29 at 9 44 18 AM](https://user-images.githubusercontent.com/42744307/80603269-2ee9e380-89fe-11ea-8896-4558caa48bd3.png)


## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [x] Mobile
- [x] Safari
  - [x] Mobile
- [x] Firefox
  - [x] Mobile
- [x] Edge
- [ ] IE11
- [ ] Not applicable
