### PR TITLE
BLUE-254: Remove breaks from tooltip content

### DIFF
--- a/src/app/asset-grid/thumbnail/thumbnail.component.pug
+++ b/src/app/asset-grid/thumbnail/thumbnail.component.pug
@@ -53,7 +53,7 @@
           (mouseout)="mouseOverDetailIcon=false"
           title="Detail view button icon. Press enter to click this button and go to the asset detail.",
         )
-        div(slot="content") This is a saved <br> detail of the <br> original image
+        div(slot="content") This is a saved detail of the original image
       //- Multi view icon
       pharos-tooltip(*ngIf="multiviewItemCount > 1", placement="right", tabindex="3")
         .multiview-indicator(
@@ -67,4 +67,4 @@
             (mouseout)="mouseOverMultiview=false"
           )
           span.multiview-count {{multiviewItemCount}}
-        div(slot="content") This item has <br> multiple views
+        div(slot="content") This item has multiple views

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.html
@@ -56,7 +56,7 @@
       </pharos-tooltip>
       <pharos-tooltip placement="bottom" *ngIf="isFullscreen && assetCompareCount > 1" class="asset-viewer__buttons__button">
         <button slot="target" class="btn btn--icon" [class.standalone-remove-icon]="state != 1" (click)="removeAsset.emit(asset)" aria-label="Remove from comparison"><i class="icon icon-remove-from-comparison"></i></button>
-        <div slot="content">Remove from<br>comparison</div>
+        <div slot="content">Remove from comparison</div>
       </pharos-tooltip>
     </div>
 


### PR DESCRIPTION
Resolves BLUE-254

## Description

Removes breaks found in tooltip content as these are not desired with the use of Pharos tooltips.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
