### PR TITLE
PLATO-752: Mitigate performance issues when loading list of image groups on Artstor

### DIFF
--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { BehaviorSubject, Observable, Subject, pipe } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
+import { APP_CONST } from '../app.constants'
 
 // Project Dependencies
 import { environment } from 'environments/environment'
@@ -43,7 +44,7 @@ export class GroupService {
             tags = []
         }
         if (!size) {
-            size = 25
+            size = APP_CONST.IMAGE_GROUP_PAGE_SIZE
         }
         if (!pageNo) {
             pageNo = 1

--- a/src/app/_services/group.service.ts
+++ b/src/app/_services/group.service.ts
@@ -43,7 +43,7 @@ export class GroupService {
             tags = []
         }
         if (!size) {
-            size = 48
+            size = 25
         }
         if (!pageNo) {
             pageNo = 1

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -3,5 +3,6 @@
  */
 
  export const APP_CONST = {
-    MAX_RESULTS:<number> 5000
+    MAX_RESULTS:<number> 5000,
+    IMAGE_GROUP_PAGE_SIZE: <number> 25
  }

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -45,7 +45,7 @@ export class BrowseGroupsComponent implements OnInit {
     page: number
   } = {
     totalPages: 1,
-    size: 48,
+    size: 25,
     page: 1
   }
 

--- a/src/app/browse-page/browse-groups/groups.component.ts
+++ b/src/app/browse-page/browse-groups/groups.component.ts
@@ -3,6 +3,7 @@ import { Router, ActivatedRoute, Params, NavigationEnd } from '@angular/router'
 import { Subscription } from 'rxjs'
 import { map, take, filter } from 'rxjs/operators'
 import { Angulartics2 } from 'angulartics2'
+import { APP_CONST } from '../../app.constants'
 
 // Project Dependencies
 import { AuthService, GroupService, TitleService } from '_services'
@@ -45,7 +46,7 @@ export class BrowseGroupsComponent implements OnInit {
     page: number
   } = {
     totalPages: 1,
-    size: 25,
+    size: APP_CONST.IMAGE_GROUP_PAGE_SIZE,
     page: 1
   }
 

--- a/src/app/pact/group-api.pact.spec.ts
+++ b/src/app/pact/group-api.pact.spec.ts
@@ -2,6 +2,7 @@
 import { HttpClientModule } from '@angular/common/http'
 import { TestBed, getTestBed } from '@angular/core/testing'
 import { PactWeb, Matchers } from '@pact-foundation/pact-web'
+import { APP_CONST } from '../app.constants'
 
 // Project Dependencies
 import { GroupList, ImageGroup } from '../shared'
@@ -182,7 +183,7 @@ describe('Group Calls #pact #group', () => {
           withRequest: {
             method: 'GET',
             path: '/api/v2/group',
-            query: 'size=25&level=private&from=0&sort=alpha&order=asc'
+            query: 'size=' + APP_CONST.IMAGE_GROUP_PAGE_SIZE +'&level=private&from=0&sort=alpha&order=asc'
           },
           willRespondWith: {
             status: 200,
@@ -204,7 +205,7 @@ describe('Group Calls #pact #group', () => {
 
       it('should return a list of private group objects', function(done) {
         // Run the tests
-        _groupService.getAll('private', 25, 0, [], '', '', 'alpha', 'asc')
+        _groupService.getAll('private', APP_CONST.IMAGE_GROUP_PAGE_SIZE, 0, [], '', '', 'alpha', 'asc')
           .subscribe(res => {
             // Test if the response object has all the keys / properties
             let actualResKeys = Object.keys(res).sort();

--- a/src/app/pact/group-api.pact.spec.ts
+++ b/src/app/pact/group-api.pact.spec.ts
@@ -182,7 +182,7 @@ describe('Group Calls #pact #group', () => {
           withRequest: {
             method: 'GET',
             path: '/api/v2/group',
-            query: 'size=48&level=private&from=0&sort=alpha&order=asc'
+            query: 'size=25&level=private&from=0&sort=alpha&order=asc'
           },
           willRespondWith: {
             status: 200,
@@ -204,7 +204,7 @@ describe('Group Calls #pact #group', () => {
 
       it('should return a list of private group objects', function(done) {
         // Run the tests
-        _groupService.getAll('private', 48, 0, [], '', '', 'alpha', 'asc')
+        _groupService.getAll('private', 25, 0, [], '', '', 'alpha', 'asc')
           .subscribe(res => {
             // Test if the response object has all the keys / properties
             let actualResKeys = Object.keys(res).sort();


### PR DESCRIPTION
Resolves PLATO-752

## Description

Show only 25 image groups per page.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
