### PR TITLE
PLATO-849: limit download size to twice the width/height of image

### DIFF
--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -133,8 +133,8 @@ export class Asset {
                   downloadHeight = parseInt(sizeValues[1]);
                 }
 
-                const maxWidth = this.getDownloadSize(downloadWidth, data.width);
-                const maxHeight = this.getDownloadSize(downloadHeight, data.height);
+                const maxWidth = this.getDownloadSize(downloadWidth, data.width * 2);
+                const maxHeight = this.getDownloadSize(downloadHeight, data.height * 2);
 
                 // Set max values on Asset
                 this.downloadMaxWidth = maxWidth

--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -104,8 +104,8 @@ export class Asset {
     }
 
     private getDownloadSize(downloadSize, imageSize) {
-      return Math.min(downloadSize && downloadSize > 0 ? downloadSize : this.MAXIMUM_DOWNLOAD_SIZE,
-                             imageSize && imageSize > 0 ? imageSize : this.MAXIMUM_DOWNLOAD_SIZE,
+      return Math.min(downloadSize > 0 ? downloadSize : this.MAXIMUM_DOWNLOAD_SIZE,
+                             imageSize > 0 ? imageSize : this.MAXIMUM_DOWNLOAD_SIZE,
                              this.MAXIMUM_DOWNLOAD_SIZE);
     }
 

--- a/src/app/shared/datatypes/asset.interface.ts
+++ b/src/app/shared/datatypes/asset.interface.ts
@@ -103,6 +103,12 @@ export class Asset {
         return formattedData
     }
 
+    private getDownloadSize(downloadSize, imageSize) {
+      return Math.min(downloadSize && downloadSize > 0 ? downloadSize : this.MAXIMUM_DOWNLOAD_SIZE,
+                             imageSize && imageSize > 0 ? imageSize : this.MAXIMUM_DOWNLOAD_SIZE,
+                             this.MAXIMUM_DOWNLOAD_SIZE);
+    }
+
     private buildDownloadLink(data: AssetData, groupId?: string): string {
         let downloadLink: string
         switch (data.object_type_id) {
@@ -117,22 +123,18 @@ export class Asset {
                 break
             default:
                 // Determine allowable size
-                let maxWidth
-                let maxHeight
                 let maxSize
-                if (data.download_size && data.download_size.length > 0) {
-                    let sizeValues = data.download_size.split(',');
+                let downloadWidth = this.MAXIMUM_DOWNLOAD_SIZE;
+                let downloadHeight = this.MAXIMUM_DOWNLOAD_SIZE;
 
-                    maxWidth = Math.min(parseInt(sizeValues[0]), data.width * 2, this.MAXIMUM_DOWNLOAD_SIZE);
-                    maxHeight = Math.min(parseInt(sizeValues[1]), data.height * 2, this.MAXIMUM_DOWNLOAD_SIZE);
-                } else {
-                    maxWidth = data.width && data.width > 0 ?
-                                  Math.min(data.width * 2, this.MAXIMUM_DOWNLOAD_SIZE) :
-                                  this.MAXIMUM_DOWNLOAD_SIZE;
-                    maxHeight = data.height && data.height > 0 ?
-                                  Math.min(data.height * 2, this.MAXIMUM_DOWNLOAD_SIZE) :
-                                  this.MAXIMUM_DOWNLOAD_SIZE;
+                if (data.download_size && data.download_size.length > 0) {
+                  let sizeValues = data.download_size.split(',');
+                  downloadWidth = parseInt(sizeValues[0]);
+                  downloadHeight = parseInt(sizeValues[1]);
                 }
+
+                const maxWidth = this.getDownloadSize(downloadWidth, data.width);
+                const maxHeight = this.getDownloadSize(downloadHeight, data.height);
 
                 // Set max values on Asset
                 this.downloadMaxWidth = maxWidth


### PR DESCRIPTION
PLATO-849

## Description

Images were failing to download at times because we were specifying a download width and/or height that was greater than twice the width/height of the image, which is the maximum download size that IIIF supports. The code now compares the specified download size to twice the width/height of the image and to 3000, the maximum download size that Artstor supports, and uses the smallest of these three sizes.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [X] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [X] Not applicable


**Browsers tested on:**

- [X] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
