### PR TITLE
PLATO-890: Fix Artstor terms and condition link

### DIFF
--- a/src/app/asset-page/asset-page.component.pug
+++ b/src/app/asset-page/asset-page.component.pug
@@ -230,7 +230,7 @@
                 img.license-icon([attr.src]="license.licenseImg", [attr.alt]="license.licenseText", title="License")
                 | &nbsp;
                 span.value.license-text([innerHTML]="cleanFieldValue(license.licenseText) | linkify", title="License")
-            .value([innerHTML]="cleanFieldValue('Use of this image is in accordance with the <a href=`https://www.artstor.org/artstor-terms/` target=`_blank` >Artstor Terms & Conditions</a>') | linkify")
+            .value([innerHTML]="cleanFieldValue('Use of this image is in accordance with the <a href=\"https://www.artstor.org/artstor-terms/\" target=\"_blank\" >Artstor Terms & Conditions</a>') | linkify")
           //- File Properties
           .row-hdr.pt-3(*ngIf="assets[0].filePropertiesArray.length > 0") {{ 'ASSET_PAGE.HEADER_LABELS.FILE_PROPS' | translate}}
           //- File Name


### PR DESCRIPTION
Resolves  PLATO-890

## Description
Fixes terms and conditions link on the asset page

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
