### PR TITLE
BLUE-347: Add Artstor LibGuides to footer

### DIFF
--- a/src/app/white-label-config.ts
+++ b/src/app/white-label-config.ts
@@ -15,6 +15,7 @@ export const WLV_ARTSTOR = {
     footerLinks: [
         "ABOUT",
         "GETTING_STARTED",
+        "LIBGUIDE",
         "TEACHING_IDEAS",
         "STAY_INFORMED",
         "TERMS",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -444,6 +444,7 @@
       "ABOUT": "<a href=\"https://www.artstor.org/about/\" class=\"link\" target=\"_blank\">About Artstor</a>",
       "GETTING_STARTED": "<a href=\"http://support.artstor.org/?page_id=52\" class=\"link\" target=\"_blank\">Getting Started</a>",
       "TEACHING_IDEAS": "<a href=\"https://www.artstor.org/teach/\" class=\"link\" target=\"_blank\">Teach with Artstor</a>",
+      "LIBGUIDE": "<a href=\"https://artstor.libguides.com/\" class=\"link\" target=\"_blank\">Artstor LibGuides</a>",
       "STAY_INFORMED": "<a href=\"https://www.artstor.org/newsletter/\" class=\"link\" target=\"_blank\">Newsletters</a>",
       "TERMS": "<a href=\"https://www.artstor.org/artstor-terms\" class=\"link\" target=\"_blank\">Terms and Conditions</a>",
       "PRIVACY": "<a href=\"https://www.ithaka.org/privacypolicy\" class=\"link\" target=\"_blank\">Privacy Policy</a>",


### PR DESCRIPTION
Resolves BLUE-347

## Description

Adds a link to Artstor LibGuides to the footer

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
