### PR TITLE
PLATO-955: Add error handling if the file cannot be uploaded

### DIFF
--- a/src/app/uploader/uploader.component.pug
+++ b/src/app/uploader/uploader.component.pug
@@ -23,4 +23,6 @@
             i.icon.icon-loading
       .file-name.error-wrap(*ngIf="invalidFiles && invalidFiles.length > 0" role="alert" aria-atomic="false")
         .error-msg(*ngFor="let file of invalidFiles") "{{ file.name }}" is not a valid JPEG
+      .file-name.error-wrap(*ngIf="uploadErrorFiles && uploadErrorFiles.length > 0" role="alert" aria-atomic="false")
+        .error-msg(*ngFor="let file of uploadErrorFiles") "{{ file.file.name }}" cannot be uploaded at this time. Please contact support if the error persists.
   a.mt-2.link.help-link-text(href="http://support.artstor.org/?article-category=09-using-your-own-images", target="_blank", tabindex="0", (keydown.tab)="helpTabKeyDown($event)") {{ 'UPLOAD_IMAGES_MODAL.HELP' | translate }}

--- a/src/app/uploader/uploader.component.ts
+++ b/src/app/uploader/uploader.component.ts
@@ -23,6 +23,7 @@ export class UploaderComponent implements OnInit {
   public fileOverDropZone: boolean = false
   // keep an array of files which were of invalid type
   public invalidFiles: FileLikeObject[] = []
+  public uploadErrorFiles: FileItem[] = []
 
   constructor(private _auth: AuthService) {
     this.UPLOAD_URL = [this._auth.getUrl(), 'v1', 'pcollection', 'image'].join('/')
@@ -47,6 +48,10 @@ export class UploaderComponent implements OnInit {
         resJson.src = item._file['local-src']
         resJson && this.fileUploaded.emit(resJson)
       }
+    }
+
+    this.uploader.onErrorItem = (item, response, status, headers) => {
+      this.uploadErrorFiles.push(item)
     }
 
     /**


### PR DESCRIPTION
Resolves PLATO-955

## Description

Adds error handling if the file attempts to upload but the service cannot process the request

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [X] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [X] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [X] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
