### PR TITLE
PLATO-1036: change image and URL for Creative Commons: Public Domain Mark

### DIFF
--- a/src/app/asset-page/licenses.ts
+++ b/src/app/asset-page/licenses.ts
@@ -33,7 +33,7 @@ export const licenses = [
     },
     { name: 'Creative Commons: Public Domain Mark',
       link: 'https://creativecommons.org/publicdomain/mark/1.0/',
-      img: 'https://licensebuttons.net/p/mark/1.0/88x31.png ',
+      img: 'https://licensebuttons.net/p/mark/1.0/88x31.png',
       html: '<a href="https://creativecommons.org/publicdomain/mark/1.0/" title="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication">Public Domain</a></div>'
     },
     { name: 'Public Domain',

--- a/src/app/asset-page/licenses.ts
+++ b/src/app/asset-page/licenses.ts
@@ -32,9 +32,9 @@ export const licenses = [
       img: 'https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png'
     },
     { name: 'Creative Commons: Public Domain Mark',
-      link: 'https://creativecommons.org/share-your-work/public-domain/',
-      img: 'https://licensebuttons.net/p/88x31.png',
-      html: '<a href="https://creativecommons.org/publicdomain/zero/1.0/" title="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication">Public Domain</a></div>'
+      link: 'https://creativecommons.org/publicdomain/mark/1.0/',
+      img: 'https://licensebuttons.net/p/mark/1.0/88x31.png ',
+      html: '<a href="https://creativecommons.org/publicdomain/mark/1.0/" title="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication">Public Domain</a></div>'
     },
     { name: 'Public Domain',
       link: 'https://creativecommons.org/share-your-work/public-domain/',


### PR DESCRIPTION
Resolves PLATO-1036

## Description

Changes image and URL for Creative Commons: Public Domain Mark

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
