### PR TITLE
PALS-744: Update docker image reference to point to Artifactory instead of Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builds a Docker to deliver dist/
-FROM node:11.0
+FROM docker.artifactory.acorn.cirrostratus.org/node:11.0
 # Add environment variables
 ENV PORT=80
 ENV SAGOKU=true


### PR DESCRIPTION
Resolves PALS-744

## Description

In this PR, we made a change to Docker base image to point to Artifactory instead of Docker Hub.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
