### PR TITLE
SRCHX-1142: Filter selection bug fix

### DIFF
--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -150,10 +150,6 @@ export class AssetFilters {
               } catch (err) { // param is not an array
                 parsedParam = routeParams[paramName]
               }
-              // Check if there are multiple selected Geo facets.
-              if(paramName === 'geography') {
-                parsedParam = parsedParam
-              }
               this._filters.apply(paramName, parsedParam);
             }
         }

--- a/src/app/asset-filters/asset-filters.component.ts
+++ b/src/app/asset-filters/asset-filters.component.ts
@@ -152,7 +152,7 @@ export class AssetFilters {
               }
               // Check if there are multiple selected Geo facets.
               if(paramName === 'geography') {
-                parsedParam = parsedParam.split(',')
+                parsedParam = parsedParam
               }
               this._filters.apply(paramName, parsedParam);
             }


### PR DESCRIPTION
Resolves SRCHX-1142

## Description

Changes in this PR are meant to fix a reported prod bug related to filter selection. Apparently the filter selection caused an uncaught error on the UI side where we were trying to split a parsed array by `,`. This prevented the retention of updated search term in the filters component and causing unexpected search behavior on the UI side.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [x] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
