### PR TITLE
SRCHX-1186: Remove AppDynamics EUM script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <!-- Run the app from the root directory -->
   <base href="/">
-  
+
   <!--Track initial URL in cases where we need to re-route legacy links-->
   <script type="text/javascript">
     var initPath = window.location.href;
@@ -133,25 +133,6 @@
       display: none !important;
     }
   </style>
-
-  <!-- AppD EUM -->
-  <script charset='UTF-8'>
-    var hostname = window.location.hostname,
-      nonProdHosts = ['stage.artstor.org', 'localhost', '127.0.0.1'],
-      prodKey = 'AD-AAB-AAM-TVS',
-      testKey = 'AD-AAB-AAM-TWZ';
-
-    window['adrum-start-time'] = new Date().getTime();
-    (function(config){
-      config.appKey = nonProdHosts.includes(hostname) ? testKey : prodKey;
-      config.adrumExtUrlHttp = 'http://cdn.appdynamics.com';
-      config.adrumExtUrlHttps = 'https://cdn.appdynamics.com';
-      config.beaconUrlHttp = 'http://col.eum-appdynamics.com';
-      config.beaconUrlHttps = 'https://col.eum-appdynamics.com';
-      config.xd = {enable : false};
-    })(window['adrum-config'] || (window['adrum-config'] = {}));
-  </script>
-  <script src='//cdn.appdynamics.com/adrum/adrum-4.5.9.2098.js'></script>
 </head>
 <body>
   <noscript>


### PR DESCRIPTION
Resolves SRCHX-1186

## Description

Remove the AppDynamics EUM script that is no longer in use, because it sets an ADRUM cookie in the browser that we want to avoid setting for users.

Leaving all the other AppDynamics configuration etc. in place as it looks to be server-side collection that we want to keep.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [x] Not applicable
