### PR TITLE
Remove old GDPR banner

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -166,9 +166,6 @@
     </div>
   </app-root>
 
-  <!-- For cookie banner -->
-  <script src="https://static.ithaka.org/gdpr-banner/js/banner.js" type="text/javascript"></script>
-
   <p id="toast-live-region" class="sr-only" role="region" aria-live="polite" aria-atomic="true"></p>
 
 </body>


### PR DESCRIPTION
## Description

Remove the existing GDPR banner so we can go live with OneTrust.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
