### PR TITLE
SRCHX-1203: Add URL param to track clicks on JSTOR GA

### DIFF
--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -120,7 +120,7 @@ export class SearchPage implements OnInit, OnDestroy {
         delete logFilters['term']
         this.logFilters = logFilters
         this.searchTerm = params['term']
-        this.jstorLink = `https://www.jstor.org/action/doBasicSearch?Query=${this.searchTerm}`
+        this.jstorLink = `https://www.jstor.org/action/doBasicSearch?Query=${this.searchTerm}&utm_source=aiw`
 
         this._title.setSubtitle( '"' + params['term'] + '"' )
         this._assets.queryAll(params, refreshSearch);


### PR DESCRIPTION
Resolves SRCHX-1203

## Description

In SRCHX-1203 added a link to allow ARTSTOR users run the same search on JSTOR. While viewing GA data realized there's another JSTOR search URL from AIW and adding this will make it easier to track it in GA and distinguish clicks.