### PR TITLE
SRCHX-1286: Increase timeout for search skip section links

### DIFF
--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -144,14 +144,14 @@ export class SearchPage implements OnInit, OnDestroy {
     window.setTimeout(() => {
       let htmlelement = this._dom.byId('skip-to-search-link');
       htmlelement.focus();
-    }, 100);
+    }, 250);
   }
 
   public skipToSearchSec(): void{
     window.setTimeout(() => {
       let htmlelement = this._dom.byId('skip-to-filter-link');
       htmlelement.focus();
-    }, 100);
+    }, 250);
   }
 
   public logNavigateToJstor(): void{


### PR DESCRIPTION
Resolves SRCHX-1286

## Description

Changes in this PR ensure that the section skip links on search page (i.e. Skip to Search Section & Skip to Filter Section) are not buggy and change the active focus to the relevant sections without jumping back and forth.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
