### PR TITLE
Inline OneTrust script for improved EZProxy experience

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,13 @@
 
   </script>
 
+  <!-- OneTrust -->
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="8f42873b-4103-438e-9322-64bc4ec1f446" ></script>
+  <script type="text/javascript">
+      function OptanonWrapper() { }
+  </script>
+  <!-- End OneTrust -->
+
   <!-- Google Search Console verification -->
   <meta name="google-site-verification" content="I2cWM2atN4ZtS5JQsMwBOlcC8zUEt5L74_MxJjqKcjg" />
 


### PR DESCRIPTION
## Description

The OneTrust script must be included in the minimal DOM that's initially sent to the browser so that EZProxy has an opportunity to rewrite its domain. Inserting the script dynamically client side does **not** give EZProxy this opportunity.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [x] Not applicable
