### PR TITLE
Add cookie settings link to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.7.185",
+  "version": "2.8.0",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/white-label-config.ts
+++ b/src/app/white-label-config.ts
@@ -21,6 +21,7 @@ export const WLV_ARTSTOR = {
         "TERMS",
         "PRIVACY",
         "COOKIE_POLICY",
+        "COOKIE_SETTINGS",
         "COPYRIGHT",
         "SUPPORT"
     ],

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -449,6 +449,7 @@
       "TERMS": "<a href=\"https://about.jstor.org/terms/\" class=\"link\" target=\"_blank\">Terms and Conditions</a>",
       "PRIVACY": "<a href=\"https://www.ithaka.org/privacypolicy\" class=\"link\" target=\"_blank\">Privacy Policy</a>",
       "COOKIE_POLICY": "<a href=\"http://www.ithaka.org/cookies\" class=\"link\" target=\"_blank\">Cookie Policy</a>",
+      "COOKIE_SETTINGS": "<a href=\"javascript:void(0)\" onclick=\"OneTrust.ToggleInfoDisplay()\">Cookie settings</a>",
       "COPYRIGHT": "<a href=\"https://about.jstor.org/terms/#jstor-responsibility\" class=\"link\" target=\"_blank\">Copyright Concerns</a>",
       "SUPPORT": "<a href=\"http://support.artstor.org\" class=\"link\" target=\"_blank\">Support</a>",
       "SUPPORT_UNAFFILIATED": "<a href=\"//support.artstor.org/?article-category=05-public-access-to-artstor\" class=\"link\" target=\"_blank\">Support</a>",


### PR DESCRIPTION
## Description

Add a link to the footer that will trigger the consent management modal to come back up so users can change their cookie preferences.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [x] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [x] Not applicable
