### PR TITLE
PLATO-2063: can't page through multiple image groups in different tabs

### DIFF
--- a/src/app/_services/assets.service.ts
+++ b/src/app/_services/assets.service.ts
@@ -156,9 +156,10 @@ export class AssetService {
     /**
      * Return most recent results set with at least one asset
      */
-    public getRecentResults(): any {
-        if (this._storage.getLocal('results')) {
-            return this._storage.getLocal('results')
+    public getRecentResults(igId: string): any {
+        const key = igId ? "results-" + igId : "results";
+        if (this._storage.getLocal(key)) {
+            return this._storage.getLocal(key)
         } else {
             return { thumbnails: [] }
         }
@@ -611,8 +612,11 @@ export class AssetService {
         this.allResultsSource.next(resultObj);
 
         // Set Recent Results (used by Compare Mode)
+        const igId = this.currentLoadedParams["igId"];
+        const key = igId ? "results-" + igId : "results";
+
         if (resultObj.thumbnails && resultObj.thumbnails.length > 0) {
-            this._storage.setLocal('results', resultObj)
+            this._storage.setLocal(key, resultObj)
         }
 
         if (this.paginated){

--- a/src/app/asset-page/asset-page.component.ts
+++ b/src/app/asset-page/asset-page.component.ts
@@ -368,7 +368,6 @@ export class AssetPage implements OnInit, OnDestroy {
         }
       }),
       this._assets.allResults.subscribe((allResults) => {
-        // console.log("allResults subscription returned")
         if (allResults.thumbnails) {
           this.prevAssetResults.thumbnails = allResults.thumbnails
           this.restrictedAssetsCount = allResults.restricted_thumbnails.length
@@ -422,7 +421,7 @@ export class AssetPage implements OnInit, OnDestroy {
     );
 
     // Get latest set of results with at least one asset
-    this.prevAssetResults = this._assets.getRecentResults()
+    this.prevAssetResults = this._assets.getRecentResults(this.assetGroupId)
 
     // Subscribe to pagination values
     this.subscriptions.push(


### PR DESCRIPTION
Resolves PLATO-2063

## Description

Users were unable to open multiple groups in different tabs and page through them at the same time. This was because we were storing asset information in local storage under the key `results`. This value would be overwritten when a new group was opened. I have changed this so that we now store the asset information under the key `results-<image group id>` when an ID is available; otherwise it defaults to `results`.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
