### PR TITLE
PLATO-2520: Update Openseadragon version

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "ngx-device-detector": "^1.3.3",
     "ngx-infinite-scroll": "^7.0.1",
     "ngx-tag-autocomplete": "2.0.4",
-    "openseadragon": "2.4.1",
+    "openseadragon": "3.1.0",
     "popper.js": "^1.14.4",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",


### PR DESCRIPTION
Resolves PLATO-2520

## Description

Update Openseadragon to the latest version in order to fix a bug on production.

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
