### PR TITLE
PALS-1534: Update the Artstor AJI Modal/Banner with copy, and a list of users to roll out to

### DIFF
--- a/src/app/_services/account.service.ts
+++ b/src/app/_services/account.service.ts
@@ -17,8 +17,7 @@ export class AccountService {
       "departmentRole",
       "department",
       "promptedForRole",
-      "showAJIModal",
-      "showBanner",
+      "showAJIModalOrBanner",
       /**
        * the proceeding two fields are used for testing. In order to create a pact that tests
        *  invalid field errors, we allow these two fields to be passed. Their names are not field
@@ -56,8 +55,7 @@ interface User {
   username: string
   baseProfileId: number
   promptedForRole: Date
-  showAJIModal: boolean
-  showBanner: boolean
+  showAJIModalOrBanner: boolean
 }
 
 interface UpdateUserResponse {}

--- a/src/app/_services/account.service.ts
+++ b/src/app/_services/account.service.ts
@@ -17,7 +17,8 @@ export class AccountService {
       "departmentRole",
       "department",
       "promptedForRole",
-      "showAJIModalAndBanner",
+      "showAJIModal",
+      "showBanner",
       /**
        * the proceeding two fields are used for testing. In order to create a pact that tests
        *  invalid field errors, we allow these two fields to be passed. Their names are not field
@@ -55,7 +56,8 @@ interface User {
   username: string
   baseProfileId: number
   promptedForRole: Date
-  showAJIModalAndBanner: boolean
+  showAJIModal: boolean
+  showBanner: boolean
 }
 
 interface UpdateUserResponse {}

--- a/src/app/_services/account.service.ts
+++ b/src/app/_services/account.service.ts
@@ -17,6 +17,7 @@ export class AccountService {
       "departmentRole",
       "department",
       "promptedForRole",
+      "showAJIModalAndBanner",
       /**
        * the proceeding two fields are used for testing. In order to create a pact that tests
        *  invalid field errors, we allow these two fields to be passed. Their names are not field
@@ -54,6 +55,7 @@ interface User {
   username: string
   baseProfileId: number
   promptedForRole: Date
+  showAJIModalAndBanner: boolean
 }
 
 interface UpdateUserResponse {}

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -421,10 +421,11 @@ export class AuthService implements CanActivate {
    public showAJIIntercept(): boolean {
     let user = this.getUser()
     let institution = this.institutionObjSource.value
+    let showIntercept = user.preference.showAJIModalAndBanner ? user.preference.hasOwnProperty('showAJIModalAndBanner') : false
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
-    return user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'
+    return user && user.isLoggedIn && showIntercept && institution.institutionName && institution.institutionName == 'JSTOR'
   }
 
   /**
@@ -433,11 +434,12 @@ export class AuthService implements CanActivate {
    */
   public showPostLoginBanner(): boolean {
     let user = this.getUser()
+    let showBanner = user.preference.showAJIModalAndBanner ? user.preference.hasOwnProperty('showAJIModalAndBanner') : false
     let institution = this.institutionObjSource.value
     let ajiInterceptWasClosed = this.getFromStorage('AJIInterceptClosed')
     let userIsLoggedInJstorUser = user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'
 
-    return ajiInterceptWasClosed && userIsLoggedInJstorUser
+    return ajiInterceptWasClosed && showBanner && userIsLoggedInJstorUser
   }
 
   /**

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -421,7 +421,7 @@ export class AuthService implements CanActivate {
    public showAJIIntercept(): boolean {
     let user = this.getUser()
     let institution = this.institutionObjSource.value
-    let showIntercept = user.preference.showAJIModalAndBanner ? user.preference.hasOwnProperty('showAJIModalAndBanner') : false
+    let showIntercept = user.preferences.showAJIModalAndBanner ? user.preferences.hasOwnProperty('showAJIModalAndBanner') : false
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
@@ -434,7 +434,7 @@ export class AuthService implements CanActivate {
    */
   public showPostLoginBanner(): boolean {
     let user = this.getUser()
-    let showBanner = user.preference.showAJIModalAndBanner ? user.preference.hasOwnProperty('showAJIModalAndBanner') : false
+    let showBanner = user.preferences.showAJIModalAndBanner ? user.preferences.hasOwnProperty('showAJIModalAndBanner') : false
     let institution = this.institutionObjSource.value
     let ajiInterceptWasClosed = this.getFromStorage('AJIInterceptClosed')
     let userIsLoggedInJstorUser = user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -424,7 +424,7 @@ export class AuthService implements CanActivate {
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
-    return user && user.isLoggedIn && user.preference.hasOwnProperty('showAJIModalAndBanner') && user.preference.showAJIModalAndBanner
+    return user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModalAndBanner') && user.preferences.showAJIModalAndBanner
   }
 
   /**

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -420,11 +420,11 @@ export class AuthService implements CanActivate {
    */
    public showAJIIntercept(): boolean {
     let user = this.getUser()
-    let institution = this.institutionObjSource.value
+    // let institution = this.institutionObjSource.value
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
-    return user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModalAndBanner') && user.preferences.showAJIModalAndBanner
+    return user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModal') && user.preferences.showAJIModal
   }
 
   /**
@@ -433,12 +433,11 @@ export class AuthService implements CanActivate {
    */
   public showPostLoginBanner(): boolean {
     let user = this.getUser()
-    let showBanner = user.preferences.showAJIModalAndBanner ? user.preferences.hasOwnProperty('showAJIModalAndBanner') : false
-    let institution = this.institutionObjSource.value
+    // let institution = this.institutionObjSource.value
     let ajiInterceptWasClosed = this.getFromStorage('AJIInterceptClosed')
-    let userIsLoggedInJstorUser = user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'
+    // let userIsLoggedInJstorUser = user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'
 
-    return ajiInterceptWasClosed && showBanner && userIsLoggedInJstorUser
+    return ajiInterceptWasClosed && user && user.isLoggedIn && user.preferences.hasOwnProperty('showBanner') && user.preferences.showBanner
   }
 
   /**

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -421,11 +421,10 @@ export class AuthService implements CanActivate {
    public showAJIIntercept(): boolean {
     let user = this.getUser()
     let institution = this.institutionObjSource.value
-    let showIntercept = user.preferences.showAJIModalAndBanner ? user.preferences.hasOwnProperty('showAJIModalAndBanner') : false
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
-    return user && user.isLoggedIn && showIntercept && institution.institutionName && institution.institutionName == 'JSTOR'
+    return user && user.isLoggedIn && user.preference.hasOwnProperty('showAJIModalAndBanner') && user.preference.showAJIModalAndBanner
   }
 
   /**

--- a/src/app/_services/auth.service.ts
+++ b/src/app/_services/auth.service.ts
@@ -424,7 +424,7 @@ export class AuthService implements CanActivate {
     if (this.getFromStorage('AJIInterceptClosed')) {
       return false
     }
-    return user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModal') && user.preferences.showAJIModal
+    return user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModalOrBanner') && user.preferences.showAJIModalOrBanner
   }
 
   /**
@@ -437,7 +437,7 @@ export class AuthService implements CanActivate {
     let ajiInterceptWasClosed = this.getFromStorage('AJIInterceptClosed')
     // let userIsLoggedInJstorUser = user && user.isLoggedIn && institution.institutionName && institution.institutionName == 'JSTOR'
 
-    return ajiInterceptWasClosed && user && user.isLoggedIn && user.preferences.hasOwnProperty('showBanner') && user.preferences.showBanner
+    return ajiInterceptWasClosed && user && user.isLoggedIn && user.preferences.hasOwnProperty('showAJIModalOrBanner')
   }
 
   /**

--- a/src/app/modals/aji-intercept/aji.component.pug
+++ b/src/app/modals/aji-intercept/aji.component.pug
@@ -14,12 +14,15 @@
           div(class="aji-separator-left")
           div(class="aji-separator-right")
         div([innerHtml]="'Artstor is moving to JSTOR' | translate", tabindex="0", class="main-callout")
-        div.main-text([innerHtml]="'Discover the benefits of researching and teaching with images on JSTOR.' | translate", class="main-text")
+        div.main-text
+          span([innerHtml]="'Teach with images by ' | translate")
+          a.link(href="https://www.jstor.org/copygroups", [innerHtml]="'copying your image groups' | translate")
+          span([innerHtml]="' or start a search on JSTOR.' | translate")
       .modal-footer.flex-column
         button.primary(
           (click)="tryItNow()" type="button",
-          [attr.aria-label]="'Try it now' | translate",
-          [innerHtml]="'Try it now' | translate",
+          [attr.aria-label]="'Try searching now' | translate",
+          [innerHtml]="'Try searching now' | translate",
           id="aji-try-now",
           data-sc="aji-intercept-try-now"
         )
@@ -30,4 +33,3 @@
           id="aji-remind-me-later",
           data-sc="aji-intercept-remind-me-later"
         )
-

--- a/src/app/modals/aji-intercept/aji.component.pug
+++ b/src/app/modals/aji-intercept/aji.component.pug
@@ -6,7 +6,7 @@
         (click)="dismissModal()",
         aria-label="Close",
         id="aji-close",
-        data-sc="aji-intercept")
+        data-sc="aji-intercept-close")
           span(aria-hidden="true") &times;
       .modal-body
         img(src="/assets/img/artstor-jstor-logo.svg", alt="Artstor JSTOR Logo")
@@ -21,13 +21,13 @@
           [attr.aria-label]="'Try it now' | translate",
           [innerHtml]="'Try it now' | translate",
           id="aji-try-now",
-          data-sc="aji-intercept"
+          data-sc="aji-intercept-try-now"
         )
         button.secondary(
           (click)="remindMeLater()" type="button",
           [attr.aria-label]="'Remind me later' | translate",
           [innerHtml]="'Remind me later' | translate",
           id="aji-remind-me-later",
-          data-sc="aji-intercept"
+          data-sc="aji-intercept-remind-me-later"
         )
 

--- a/src/app/modals/aji-intercept/aji.component.pug
+++ b/src/app/modals/aji-intercept/aji.component.pug
@@ -2,7 +2,11 @@
   .modal-dialog(role="document")
     .modal-content(@slideIn)
       .modal-header
-        button.close(type="button", (click)="dismissModal()", aria-label="Close")
+        button.close(type="button",
+        (click)="dismissModal()",
+        aria-label="Close",
+        id="aji-close",
+        data-sc="aji-intercept")
           span(aria-hidden="true") &times;
       .modal-body
         img(src="/assets/img/artstor-jstor-logo.svg", alt="Artstor JSTOR Logo")
@@ -16,10 +20,14 @@
           (click)="tryItNow()" type="button",
           [attr.aria-label]="'Try it now' | translate",
           [innerHtml]="'Try it now' | translate",
+          id="aji-try-now",
+          data-sc="aji-intercept"
         )
         button.secondary(
-          (click)="dismissModal()" type="button",
+          (click)="remindMeLater()" type="button",
           [attr.aria-label]="'Remind me later' | translate",
           [innerHtml]="'Remind me later' | translate",
+          id="aji-remind-me-later",
+          data-sc="aji-intercept"
         )
 

--- a/src/app/modals/aji-intercept/aji.component.scss
+++ b/src/app/modals/aji-intercept/aji.component.scss
@@ -162,3 +162,14 @@ $pharos-font-family-sans-serif: GT America Standard,Helvetica,Helvetica Neue,Ari
   background: #f2f1ed !important;
   cursor: pointer;
 }
+
+.link {
+  cursor: pointer;
+  color: #000000;
+
+  &:hover{
+    color: #990000;
+    text-decoration: underline;
+    text-decoration-color: #990000;
+  }
+}

--- a/src/app/modals/aji-intercept/aji.component.ts
+++ b/src/app/modals/aji-intercept/aji.component.ts
@@ -53,8 +53,8 @@ export class AJIInterceptModal implements OnInit {
     this._auth.store('AJIInterceptClosed', true);
     this.closeModal.emit()
     let updateUser = this._auth.getUser()
-    if(updateUser.preferences.hasOwnProperty("showAJIModal")){
-      updateUser.preferences.showAJIModal = false
+    if(updateUser.preferences.hasOwnProperty("showAJIModalOrBanner")){
+      updateUser.preferences.showAJIModalOrBanner = false
       this.updateUser(updateUser)
     }
   }

--- a/src/app/modals/aji-intercept/aji.component.ts
+++ b/src/app/modals/aji-intercept/aji.component.ts
@@ -66,5 +66,6 @@ export class AJIInterceptModal implements OnInit {
 
   public tryItNow(): void {
     window.location.href = "https://www.jstor.org/artstor"
+    this.dismissModal()
   }
 }

--- a/src/app/modals/aji-intercept/aji.component.ts
+++ b/src/app/modals/aji-intercept/aji.component.ts
@@ -52,16 +52,16 @@ export class AJIInterceptModal implements OnInit {
   public dismissModal(): void {
     this._auth.store('AJIInterceptClosed', true);
     this.closeModal.emit()
-  }
-
-  public remindMeLater(): void {
-    this._auth.store('AJIInterceptClosed', true);
-    this.closeModal.emit()
     let updateUser = this._auth.getUser()
     if(updateUser.preferences.hasOwnProperty("showAJIModalAndBanner")){
       updateUser.preferences.showAJIModalAndBanner = false
       this.updateUser(updateUser)
     }
+  }
+
+  public remindMeLater(): void {
+    this._auth.store('AJIInterceptClosed', true);
+    this.closeModal.emit()
   }
 
   public tryItNow(): void {

--- a/src/app/modals/aji-intercept/aji.component.ts
+++ b/src/app/modals/aji-intercept/aji.component.ts
@@ -53,8 +53,8 @@ export class AJIInterceptModal implements OnInit {
     this._auth.store('AJIInterceptClosed', true);
     this.closeModal.emit()
     let updateUser = this._auth.getUser()
-    if(updateUser.preferences.hasOwnProperty("showAJIModalAndBanner")){
-      updateUser.preferences.showAJIModalAndBanner = false
+    if(updateUser.preferences.hasOwnProperty("showAJIModal")){
+      updateUser.preferences.showAJIModal = false
       this.updateUser(updateUser)
     }
   }

--- a/src/app/modals/aji-intercept/aji.component.ts
+++ b/src/app/modals/aji-intercept/aji.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core'
-import { AuthService } from '_services'
+import { AccountService, AuthService } from '_services'
 import {animate, style, transition, trigger} from "@angular/animations"
+import { map, take } from 'rxjs/operators';
 
 
 @Component({
@@ -31,14 +32,36 @@ export class AJIInterceptModal implements OnInit {
   closeModal: EventEmitter<number> = new EventEmitter();
 
   constructor(
-    private _auth: AuthService,
+    private _auth: AuthService, private _account: AccountService
   ) { }
 
   ngOnInit() { }
 
+  public updateUser(updateUser) {
+    this._account.update(updateUser).pipe(
+      take(1),
+      map(res => {
+        this._auth.saveUser(updateUser)
+      },
+        err => {
+          console.error(err)
+        }
+      )).subscribe()
+  }
+
   public dismissModal(): void {
     this._auth.store('AJIInterceptClosed', true);
     this.closeModal.emit()
+  }
+
+  public remindMeLater(): void {
+    this._auth.store('AJIInterceptClosed', true);
+    this.closeModal.emit()
+    let updateUser = this._auth.getUser()
+    if(updateUser.preferences.hasOwnProperty("showAJIModalAndBanner")){
+      updateUser.preferences.showAJIModalAndBanner = false
+      this.updateUser(updateUser)
+    }
   }
 
   public tryItNow(): void {

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.pug
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.pug
@@ -6,9 +6,13 @@ div.drop-tray(@trayAnimation)
             div.banner-separator-top
             div.banner-separator-bottom
       div.mainContent
-        h1([innerHtml]="'Lorem Ipsum' | translate")
-        p([innerHtml]="'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.' | translate")
-      a( href="https://www.jstor.org/artstor")
-        button.try-now([innerHtml]="'Try now' | translate",
+        h1([innerHtml]="'Artstor is moving to JSTOR' | translate")
+        div.copy
+        span([innerHtml]="'Artstor images and resources are now ready so get started by ' | translate")
+        a.link(href="https://www.jstor.org/copygroups", [innerHtml]="'copying your image groups' | translate")
+        span([innerHtml]="' or you can start a search on JSTOR. ' | translate")
+        a.link(href="https://www.jstor.org/artstor", [innerHtml]="'Read more' | translate")
+      a(href="https://www.jstor.org/images")
+        button.try-now([innerHtml]="'Try searching now' | translate",
         id="drop-down-try-now",
         data-sc="post-login-drop-down")

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.pug
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.pug
@@ -8,5 +8,7 @@ div.drop-tray(@trayAnimation)
       div.mainContent
         h1([innerHtml]="'Lorem Ipsum' | translate")
         p([innerHtml]="'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.' | translate")
-      a( href="https://www.jstor.org")
-        button.try-now([innerHtml]="'Try now' | translate")
+      a( href="https://www.jstor.org/artstor")
+        button.try-now([innerHtml]="'Try now' | translate",
+        id="drop-down-try-now",
+        data-sc="post-login-drop-down")

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.scss
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.scss
@@ -137,3 +137,13 @@ button {
 .container {
   padding: 0 !important;
 }
+
+.link {
+  cursor: pointer;
+
+  &:hover{
+    color: #990000;
+    text-decoration: underline;
+    text-decoration-color: #990000;
+  }
+}

--- a/src/app/post-login-banner/static-banner/static-banner.component.pug
+++ b/src/app/post-login-banner/static-banner/static-banner.component.pug
@@ -3,7 +3,10 @@
       div.headings
         img.info-icon(src="/assets/img/exclamation-inverse.png", alt="info")
         div([innerHtml]="'Artstor is moving to JSTOR.' | translate")
-      button.expand((click)="dropBanner.emit()", aria-label="Close")
+      button.expand((click)="dropBanner.emit()",
+      aria-label="Close",
+      id="login-banner-expand-collapse",
+      data-sc="login-banner")
         div([innerHtml]=" 'Learn more' | translate" )
         img.chevron(id="chevron", src="/assets/img/chevron-down.svg", alt="chevron-down")
 


### PR DESCRIPTION
Resolves PALS-1534

- Update logic for displaying AJI intercept and post login banner to targeted users
- Add data-sc attributes for GA tracking

AJI Intercept
![image](https://user-images.githubusercontent.com/104373697/182904422-92c87032-74b2-47f7-bdef-487fcf17cb94.png)

Post-login drop down banner
![image](https://user-images.githubusercontent.com/104373697/182904632-4b3c5d8c-4044-47d6-83f2-be8b83171daa.png)

Link behavior on hover
![image](https://user-images.githubusercontent.com/104373697/182905246-ff845e39-8db7-4010-8f46-95a141d1eaaa.png)
