### PR TITLE
PLATO-2710: Redraw the viewer when tile fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.10.52",
+  "version": "2.10.53",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.10.51",
+  "version": "2.10.52",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.10.50",
+  "version": "2.10.51",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
+++ b/src/app/asset-page/artstor-viewer/artstor-viewer.component.ts
@@ -143,6 +143,8 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
     public pdfZoomValue: number = .5
     public pdfViewerOpts: any = {}
 
+    private triedRedraw: boolean = false
+
     constructor(
         private _http: HttpClient, // TODO: move _http into a service
         private _log: LogService,
@@ -470,12 +472,18 @@ export class ArtstorViewerComponent implements OnInit, OnDestroy {
 
         this.osdViewer.addOnceHandler('tile-load-failed', (e: Event) => {
             console.warn("OSD Loading tiles failed:", e)
-            this.state = viewState.thumbnailFallback
-            this.osdViewer.destroy();
+
+            if (!this.triedRedraw) {
+                this.triedRedraw = true
+                this.osdViewer.forceRedraw()
+            } else {
+                this.state = viewState.thumbnailFallback
+                this.osdViewer.destroy()
+            }  
         })
 
         this.osdViewer.addOnceHandler('ready', () => {
-            console.info("Tiles are ready");
+            console.info("Tiles are ready")
             this.state = viewState.openSeaReady
         })
 


### PR DESCRIPTION
Resolves PLATO-2710

## Description

Redraw the viewer when the tile fail for the first time

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
