### PR TITLE
PLATO-2455: Encode value before setting it as url

### DIFF
--- a/src/app/shared/filter-link.pipe.ts
+++ b/src/app/shared/filter-link.pipe.ts
@@ -19,7 +19,7 @@ export class FilterLinkPipe implements PipeTransform {
         let linkHtml = ''
         values.forEach((value, index) => {
             if (index == (values.length - 1)) restoreChar = ''
-            linkHtml += `<a href="/#/search/${filterKey}:(${value})">${value}</a>${restoreChar}${breakChar}`
+            linkHtml += `<a href="/#/search/${filterKey}:(${encodeURIComponent(value)})">${value}</a>${restoreChar}${breakChar}`
         })
         return linkHtml
     }


### PR DESCRIPTION
Resolves PLATO-2455

## Description

The issue is we allow html tags in Subject and we also set the subject value as search term in url. The `/` in the tags cause the 404

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [ ] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
