### PR TITLE
PALS-2171: remove home promo

### DIFF
--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -30,6 +30,7 @@
             a.blog-post(*ngFor="let post of blogPosts | slice:0:3", [href]="post['link']", target="_blank", tabindex="4", [attr.aria-label]="post['title']['rendered']")
               h3.blog-post__title([innerHtml]="post['title']['rendered']", aria-hidden="true")
               p.blog-post__preview([innerHtml]="post['excerpt']['rendered']", aria-hidden="true")
+      .col-sm-3(*ngIf="!showHomePromo")
       div([ngClass]="showBlog ? 'col-sm-3' : 'row'")
         //- Institution Shared Shelf Collections
         .card(*ngIf="institution && instCollections.length > 0", [class.col-sm-4]="!showBlog")

--- a/src/app/white-label-config.ts
+++ b/src/app/white-label-config.ts
@@ -45,7 +45,7 @@ export const WLV_ARTSTOR = {
     featuredCollection: "HOME.FEATURED",
     showHomeBlog: true,
     showHomeSSC: true,
-    showHomeAd: true,
+    showHomeAd: false,
     showArtstorCurated: true,
     showInstitutionalLogin: true,
     pwResetPortal: "artstor"


### PR DESCRIPTION
PALS-2171: remove home promo

<img width="1176" alt="Screenshot 2024-01-09 at 3 52 13 PM" src="https://github.com/ithaka/aiw-ui/assets/13627169/8a756118-3650-466e-83a4-25ae68e8e164">

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [ ] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
