### PR TITLE
PALS-2335: update artstor dropdown banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.10.66",
+  "version": "2.10.67",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatar",
-  "version": "2.10.67",
+  "version": "2.10.68",
   "description": "Front End for the Artstor Digital Library",
   "author": "Artstor Team Air",
   "license": "MIT",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -62,7 +62,7 @@ export class AppComponent {
   public showAJIInterceptFlag: boolean = false;
   public showPostLoginBanner: boolean = false;
   public showDropDownBanner: boolean = false;
-  public bannerButtonText: string = "Explore Artstor on JSTOR";
+  public bannerButtonText: string = "Learn more about Artstor on JSTOR";
   public skyBannerCopy: string = "";
   public test: any = {};
 
@@ -366,7 +366,7 @@ export class AppComponent {
       this._ga.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "post-login-banner-open-btn"} });
     }
     else{
-      this.bannerButtonText = "Explore Artstor on JSTOR";
+      this.bannerButtonText = "Learn more about Artstor on JSTOR";
       this._ga.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: 'post-login-banner-close-btn'} });
     }
     chevron.classList.toggle("rotate");

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -62,7 +62,7 @@ export class AppComponent {
   public showAJIInterceptFlag: boolean = false;
   public showPostLoginBanner: boolean = false;
   public showDropDownBanner: boolean = false;
-  public bannerButtonText: string = "Learn more about Artstor on JSTOR";
+  public bannerButtonText: string = "Explore Artstor on JSTOR";
   public skyBannerCopy: string = "";
   public test: any = {};
 
@@ -366,7 +366,7 @@ export class AppComponent {
       this._ga.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "post-login-banner-open-btn"} });
     }
     else{
-      this.bannerButtonText = "Learn more about Artstor on JSTOR";
+      this.bannerButtonText = "Explore Artstor on JSTOR";
       this._ga.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: 'post-login-banner-close-btn'} });
     }
     chevron.classList.toggle("rotate");

--- a/src/app/modals/aji-intercept/aji.component.pug
+++ b/src/app/modals/aji-intercept/aji.component.pug
@@ -20,8 +20,8 @@
       .modal-footer.flex-column
         button.primary(
           (click)="tryItNow()", type="button",
-          [attr.aria-label]="'Learn more about Artstor on JSTOR' | translate",
-          [innerHtml]="'Learn more about Artstor on JSTOR' | translate",
+          [attr.aria-label]="'Explore Artstor on JSTOR' | translate",
+          [innerHtml]="'Explore Artstor on JSTOR' | translate",
           id="aji-try-now",
           data-sc="aji-intercept-try-now"
         )

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.pug
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.pug
@@ -13,10 +13,10 @@ div.drop-tray(@trayAnimation)
         span([innerHtml]="'. ' | translate")
         br
         br
-        span([innerHtml]="'Get started with images on JSTOR: ' | translate")
+        span([innerHtml]="'Learn how to work with images on JSTOR: ' | translate")
         a.link(id="webinar-link", (click)="webinarLink()", [innerHtml]="' Register for a training webinar on April 25' | translate")
         span([innerHtml]="'. ' | translate")
       button.try-now((click)="searchNow()",
-      [innerHtml]="'Explore Artstor on JSTOR' | translate",
+      [innerHtml]="'Get started with Artstor on JSTOR' | translate",
       id="drop-down-try-now",
       data-sc="post-login-drop-down")

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.pug
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.pug
@@ -6,7 +6,7 @@ div.drop-tray(@trayAnimation)
             div.banner-separator-top
             div.banner-separator-bottom
       div.mainContent
-        h1([innerHtml]="'The Artstor website will be retired on August 1, 2024' | translate")
+        h1([innerHtml]="'The Artstor website will be retired on August 1, 2024.' | translate")
         div.copy
         span([innerHtml]="'Artstor&apos;s high-quality collections and key functionality are now on JSTOR. If you have image groups on Artstor, they were ' | translate")
         a.link(id="banner-copy-group-link", (click)="bannerCopyGroup()", [innerHtml]="'copied to your JSTOR Workspace in February 2024' | translate")

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.pug
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.pug
@@ -6,12 +6,17 @@ div.drop-tray(@trayAnimation)
             div.banner-separator-top
             div.banner-separator-bottom
       div.mainContent
-        h1([innerHtml]="'The Artstor website will be retired on August 1, 2024.' | translate")
+        h1([innerHtml]="'The Artstor website will be retired on August 1, 2024' | translate")
         div.copy
-        span([innerHtml]="'Artstor&apos;s high-quality collections and key functionality are now on JSTOR. If you have image groups on Artstor, they will be automatically copied over to your ' | translate")
-        a.link(id="banner-copy-group-link", (click)="bannerCopyGroup()", [innerHtml]="'JSTOR Workspace' | translate")
-        span([innerHtml]="' starting February 1, 2024. ' | translate")
+        span([innerHtml]="'Artstor&apos;s high-quality collections and key functionality are now on JSTOR. If you have image groups on Artstor, they were ' | translate")
+        a.link(id="banner-copy-group-link", (click)="bannerCopyGroup()", [innerHtml]="'copied to your JSTOR Workspace in February 2024' | translate")
+        span([innerHtml]="'. ' | translate")
+        br
+        br
+        span([innerHtml]="'Get started with images on JSTOR: ' | translate")
+        a.link(id="webinar-link", (click)="webinarLink()", [innerHtml]="' Register for a training webinar on April 25' | translate")
+        span([innerHtml]="'. ' | translate")
       button.try-now((click)="searchNow()",
-      [innerHtml]="'Learn more about Artstor on JSTOR' | translate",
+      [innerHtml]="'Explore Artstor on JSTOR' | translate",
       id="drop-down-try-now",
       data-sc="post-login-drop-down")

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.ts
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.ts
@@ -37,7 +37,7 @@ export class dropBannerComponent implements OnInit {
     //{ event: 'aji modal banner', category: 'onboarding', label: "post-login-banner-shown"}
     this._angulartics.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "drop-banner-workspace-link"} });
   }
-  public webinarLInk(): void {
+  public webinarLink(): void {
     window.open("https://attendee.gotowebinar.com/register/520699455583316310?source=banner", '_blank')
     this._angulartics.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "register-webinar-link"} });
   }

--- a/src/app/post-login-banner/drop-banner/drop-banner.component.ts
+++ b/src/app/post-login-banner/drop-banner/drop-banner.component.ts
@@ -33,9 +33,13 @@ export class dropBannerComponent implements OnInit {
   ngOnInit() { }
 
   public bannerCopyGroup(): void {
-    window.open("https://support.jstor.org/hc/en-us/articles/360007226454-Workspace-Introduction-to-Workspace", '_blank')
+    window.open("https://support.artstor.org/hc/en-us/articles/18952936497047-Your-Artstor-Image-Groups-on-JSTOR", '_blank')
     //{ event: 'aji modal banner', category: 'onboarding', label: "post-login-banner-shown"}
     this._angulartics.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "drop-banner-workspace-link"} });
+  }
+  public webinarLInk(): void {
+    window.open("https://attendee.gotowebinar.com/register/520699455583316310?source=banner", '_blank')
+    this._angulartics.eventTrack.next({ properties: { event: 'aji modal banner', category: 'onboarding', label: "register-webinar-link"} });
   }
   public readMore(): void {
     window.open("https://www.jstor.org/artstor", '_blank')

--- a/src/app/post-login-banner/static-banner/static-banner.component.pug
+++ b/src/app/post-login-banner/static-banner/static-banner.component.pug
@@ -2,7 +2,7 @@
     div.container
       div.headings
         img.info-icon(src="/assets/img/exclamation-inverse.png", alt="info")
-        div([innerHtml]="'The Artstor website will be retired on August 1, 2024.' | translate")
+        div([innerHtml]="'Artstor is now on JSTOR. The Artstor website will be retired on August 1, 2024.' | translate")
       button.expand((click)="dropBanner.emit()",
       aria-label="Close",
       id="login-banner-expand-collapse",


### PR DESCRIPTION
Resolves PALS-2335

## Description

Copy update to the dropdown banner
<img width="1370" alt="Screenshot 2024-03-27 at 4 38 34 PM" src="https://github.com/ithaka/aiw-ui/assets/13627169/5fc725d2-dab0-468d-a598-dffeca351e2d">

## Checks

**Have you written any necessary unit tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Have you added or updated any necessary integration tests?**

- [ ] Yes
- [ ] Not yet
- [x] Not applicable


**Browsers tested on:**

- [x] Chrome
  - [ ] Mobile
- [ ] Safari
  - [ ] Mobile
- [ ] Firefox
  - [ ] Mobile
- [ ] Edge
- [ ] IE11
- [ ] Not applicable
